### PR TITLE
Event streamer should wait until a finish event for the stack

### DIFF
--- a/lib/stack_master/stack_events/streamer.rb
+++ b/lib/stack_master/stack_events/streamer.rb
@@ -23,7 +23,7 @@ module StackMaster
             unseen_events(events).each do |event|
               @block.call(event) if @block
               print_event(event) if @io
-              if @break_on_finish_state && StackStates.finish_state?(event.resource_status)
+              if @break_on_finish_state && finish_state?(event)
                 throw :halt
               end
             end
@@ -56,6 +56,12 @@ module StackMaster
         else
           :yellow
         end
+      end
+
+      def finish_state?(event)
+        StackStates.finish_state?(event.resource_status) &&
+          event.resource_type == 'AWS::CloudFormation::Stack' &&
+          event.logical_id == @stack_name
       end
     end
   end

--- a/spec/stack_master/stack_events/streamer_spec.rb
+++ b/spec/stack_master/stack_events/streamer_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe StackMaster::StackEvents::Streamer do
   ] }
   let(:events_second_call) {
     events_first_call + [
-      OpenStruct.new(event_id: '4', resource_status: 'UPDATE_COMPLETE', timestamp: Time.now)
+      OpenStruct.new(event_id: '4', resource_status: 'UPDATE_COMPLETE', resource_type: 'AWS::CloudFormation::Stack', logical_id: stack_name, timestamp: Time.now)
     ]
   }
   let(:stack_name) { 'stack-name' }


### PR DESCRIPTION
Previously it was exiting on finish states for other resources, which meant that it exited too early.
