### PR TITLE
Fix SparklePath so that dynamics etc work

### DIFF
--- a/lib/stack_master/template_compiler.rb
+++ b/lib/stack_master/template_compiler.rb
@@ -2,6 +2,7 @@ module StackMaster
   class TemplateCompiler
     def self.compile(template_file_path)
       if template_file_path.ends_with?('.rb')
+        SparkleFormation.sparkle_path = File.dirname(template_file_path)
         JSON.pretty_generate(SparkleFormation.compile(template_file_path))
       else
         File.read(template_file_path)

--- a/spec/stack_master/template_compiler_spec.rb
+++ b/spec/stack_master/template_compiler_spec.rb
@@ -26,6 +26,11 @@ RSpec.describe StackMaster::TemplateCompiler do
       it 'compiles with sparkleformation' do
         expect(compile).to eq("{\n}")
       end
+
+      it 'sets the appropriate sparkle_path' do
+        compile
+        expect(SparkleFormation.sparkle_path).to eq File.dirname(template_file_path)
+      end
     end
   end
 end


### PR DESCRIPTION
Overrides the default of `Dir.pwd` with the correct path to the base sparkle dir.
