### PR TITLE
Implement region_aliases config option

### DIFF
--- a/features/region_aliases.feature
+++ b/features/region_aliases.feature
@@ -1,0 +1,60 @@
+Feature: Region aliases
+
+  Background:
+    Given a file named "stack_master.yml" with:
+      """
+      region_aliases:
+        staging: ap-southeast-2
+        production: us_east_1
+      stacks:
+        staging:
+          myapp_vpc:
+            template: myapp_vpc.rb
+        production:
+          myapp_vpc:
+            template: myapp_vpc.rb
+      """
+    And a directory named "templates"
+    And a file named "templates/myapp_vpc.rb" with:
+      """
+      SparkleFormation.new(:myapp_vpc) do
+        description "Test template"
+        set!('AWSTemplateFormatVersion', '2010-09-09')
+
+        parameters.key_name do
+          description 'Key name'
+          type 'String'
+          default 'blah'
+        end
+
+        resources.vpc do
+          type 'AWS::EC2::VPC'
+          properties do
+            cidr_block '10.200.0.0/16'
+          end
+        end
+
+        outputs do
+          vpc_id do
+            description 'A VPC ID'
+            value ref!(:vpc)
+          end
+        end
+      end
+      """
+    And I stub the following stack events:
+      | stack_id | event_id | stack_name | logical_resource_id | resource_status | resource_type              | timestamp           |
+      | 1        | 1        | myapp-vpc  | TestSg              | CREATE_COMPLETE | AWS::EC2::SecurityGroup    | 2020-10-29 00:00:00 |
+      | 1        | 1        | myapp-vpc  | myapp-vpc           | CREATE_COMPLETE | AWS::CloudFormation::Stack | 2020-10-29 00:00:00 |
+    And I set the environment variables to:
+      | variable | value |
+      | STUB_AWS | true  |
+      | ANSWER   | y     |
+
+  Scenario: Create a stack using region aliases
+    When I run `stack_master apply ap-southeast-2 myapp-vpc --trace` interactively
+    And the output should contain all of these lines:
+      | Stack diff:                                                                    |
+      | +    "Vpc": {                                                                  |
+      | 2020-10-29 00:00:00 +1100 myapp-vpc AWS::CloudFormation::Stack CREATE_COMPLETE |
+    Then the exit status should be 0

--- a/lib/stack_master/cli.rb
+++ b/lib/stack_master/cli.rb
@@ -87,15 +87,13 @@ module StackMaster
       exit 1
     end
 
-    def normalize_region_and_stack_name(args)
-      args.map { |a| a.gsub('_', '-') }
-    end
-
     def execute_stack_command(command, args, options)
-      region, stack_name = normalize_region_and_stack_name(args)
-      StackMaster.cloud_formation_driver.set_region(region)
       say "Invalid arguments. stack_master #{command.name.split('::').last.downcase} [region] [stack_name]" and return unless args.size == 2
       config = load_config(options.config)
+      aliased_region, stack_name = args
+      region = Utils.underscore_to_hyphen(config.unalias_region(aliased_region))
+      stack_name = Utils.underscore_to_hyphen(stack_name)
+      StackMaster.cloud_formation_driver.set_region(region)
       command.perform(config, region, stack_name)
     end
   end

--- a/lib/stack_master/config.rb
+++ b/lib/stack_master/config.rb
@@ -9,29 +9,36 @@ module StackMaster
     attr_accessor :stack_definitions,
                   :base_dir,
                   :stack_defaults,
-                  :region_defaults
+                  :region_defaults,
+                  :region_aliases
 
     def initialize(config, base_dir)
       @config = config
       @base_dir = base_dir
-      @stack_defaults = underscore_keys_to_hyphen(config.fetch('stack_defaults', {}))
-      @region_defaults = underscore_keys_to_hyphen(config.fetch('region_defaults', {}))
+      @stack_defaults = Utils.underscore_keys_to_hyphen(config.fetch('stack_defaults', {}))
+      @region_defaults = Utils.underscore_keys_to_hyphen(config.fetch('region_defaults', {}))
+      @region_aliases = Utils.underscore_keys_to_hyphen(config.fetch('region_aliases', {}))
       load_config
     end
 
     extend Forwardable
     def_delegator :@stack_definitions, :find_stack, :find_stack
 
+    def unalias_region(region)
+      @region_aliases.fetch(region) { region }
+    end
+
     private
 
     def load_config
       @stack_definitions = Config::StackDefinitions.new(@base_dir, @stack_defaults, @region_defaults)
-      @stack_definitions.load(@config.fetch('stacks'))
+      unaliased_stacks = resolve_region_aliases(@config.fetch('stacks'))
+      @stack_definitions.load(unaliased_stacks)
     end
 
-    def underscore_keys_to_hyphen(hash)
-      hash.inject({}) do |hash, (key, value)|
-        hash[key.gsub('_', '-')] = value
+    def resolve_region_aliases(stacks)
+      stacks.inject({}) do |hash, (region, attributes)|
+        hash[unalias_region(region)] = attributes
         hash
       end
     end

--- a/lib/stack_master/config/stack_definitions.rb
+++ b/lib/stack_master/config/stack_definitions.rb
@@ -15,9 +15,9 @@ module StackMaster
 
       def load(stacks)
         stacks.each do |region, stacks_for_region|
-          region = underscore_to_hyphen(region)
+          region = Utils.underscore_to_hyphen(region)
           stacks_for_region.each do |stack_name, attributes|
-            stack_name = underscore_to_hyphen(stack_name)
+            stack_name = Utils.underscore_to_hyphen(stack_name)
             stack_attributes = stack_defaults(region).deeper_merge(attributes).merge(
               'region' => region,
               'stack_name' => stack_name,
@@ -35,10 +35,6 @@ module StackMaster
       end
 
       private
-
-      def underscore_to_hyphen(string)
-        string.gsub('_', '-')
-      end
 
       def stack_defaults(region)
         region_defaults = @region_defaults.fetch(region, {}).deep_dup

--- a/lib/stack_master/utils.rb
+++ b/lib/stack_master/utils.rb
@@ -16,5 +16,16 @@ module StackMaster
         aws_tags
       end
     end
+
+    def underscore_to_hyphen(string)
+      string.gsub('_', '-')
+    end
+
+    def underscore_keys_to_hyphen(hash)
+      hash.inject({}) do |hash, (key, value)|
+        hash[underscore_to_hyphen(key)] = value
+        hash
+      end
+    end
   end
 end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -50,6 +50,13 @@ RSpec.describe StackMaster::Config do
     })
   end
 
+  it 'loads region_aliases' do
+    expect(loaded_config.region_aliases).to eq(
+      'production' => 'us-east-1',
+      'staging' => 'ap-southeast-2'
+    )
+  end
+
   it 'deep merges stack attributes' do
     expect(loaded_config.find_stack('ap-southeast-2', 'myapp-vpc')).to eq(StackMaster::Config::StackDefinition.new(
       stack_name: 'myapp-vpc',

--- a/spec/fixtures/stack_master.yml
+++ b/spec/fixtures/stack_master.yml
@@ -1,3 +1,6 @@
+region_aliases:
+  production: us-east-1
+  staging: ap-southeast-2
 stack_defaults:
   tags:
     application: my-awesome-blog


### PR DESCRIPTION
This makes it easier when environments are split by region.
