### PR TITLE
Output time in localtime.

### DIFF
--- a/lib/stack_master/stack_events/presenter.rb
+++ b/lib/stack_master/stack_events/presenter.rb
@@ -10,7 +10,7 @@ module StackMaster
       end
 
       def print_event(event)
-        @io.puts "#{event.timestamp} #{event.logical_resource_id} #{event.resource_type} #{event.resource_status} #{event.resource_status_reason}".colorize(event_colour(event))
+        @io.puts "#{event.timestamp.localtime} #{event.logical_resource_id} #{event.resource_type} #{event.resource_status} #{event.resource_status_reason}".colorize(event_colour(event))
       end
 
       def event_colour(event)

--- a/spec/stack_master/stack_events/presenter_spec.rb
+++ b/spec/stack_master/stack_events/presenter_spec.rb
@@ -1,0 +1,18 @@
+RSpec.describe StackMaster::StackEvents::Presenter do
+  describe "#print_event" do
+    let(:time) { Time.new(2001,1,1,2,2,2) }
+    let(:event) do
+      double(:event,
+             timestamp:              time,
+             logical_resource_id:    'MyAwesomeQueue',
+             resource_type:          'AWS::SQS::Queue',
+             resource_status:        'CREATE_IN_PROGRESS',
+             resource_status_reason: 'Resource creation Initiated')
+    end
+    subject(:print_event) { described_class.print_event($stdout, event) }
+
+    it "nicely presents event data" do
+      expect { print_event }.to output("\e[0;33;49m2001-01-01 02:02:02 +1100 MyAwesomeQueue AWS::SQS::Queue CREATE_IN_PROGRESS Resource creation Initiated\e[0m\n").to_stdout
+    end
+  end
+end


### PR DESCRIPTION
```
2015-11-04 09:35:23 +1100 teststack AWS::CloudFormation::Stack CREATE_IN_PROGRESS User Initiated
2015-11-04 09:35:41 +1100 MyAwesomeQueue AWS::SQS::Queue CREATE_IN_PROGRESS
2015-11-04 09:35:41 +1100 MyAwesomeQueue AWS::SQS::Queue CREATE_IN_PROGRESS Resource creation Initiated
2015-11-04 09:35:42 +1100 MyAwesomeQueue AWS::SQS::Queue CREATE_COMPLETE
2015-11-04 09:35:44 +1100 teststack AWS::CloudFormation::Stack CREATE_COMPLETE
```
