### PR TITLE
Add an easier to understand error message...

### DIFF
--- a/lib/stack_master/parameter_resolver.rb
+++ b/lib/stack_master/parameter_resolver.rb
@@ -37,7 +37,7 @@ module StackMaster
         begin
           @resolvers[class_name] = Kernel.const_get("StackMaster::ParameterResolvers::#{class_name}").new(@config, @stack_definition)
         rescue NameError
-          raise ResolverNotFound, "Could not find parameter resolver for #{class_name}, please double check your configuration"
+          raise ResolverNotFound, "Could not find parameter resolver called #{class_name}, please double check your configuration"
         end
       end
     end


### PR DESCRIPTION
...when the parameter resolver can not be found.
