### PR TITLE
Allow delete to use a region_alias as well

### DIFF
--- a/features/apply.feature
+++ b/features/apply.feature
@@ -80,7 +80,7 @@ Feature: Apply command
       | +    "Vpc": {                                                                  |
       | Parameters diff:                                                               |
       | KeyName: my-key                                                                |
-      | 2020-10-29 00:00:00 +1100 myapp-vpc AWS::CloudFormation::Stack CREATE_COMPLETE |
+    And the output should match /2020-10-29 00:00:00 \+[0-9]{4} myapp-vpc AWS::CloudFormation::Stack CREATE_COMPLETE/
     Then the exit status should be 0
 
   Scenario: Run apply and don't create the stack
@@ -94,8 +94,7 @@ Feature: Apply command
       | Parameters diff: |
       | KeyName: my-key  |
       | aborted          |
-    And the output should not contain all of these lines:
-      | 2020-10-29 00:00:00 +1100 myapp-vpc AWS::CloudFormation::Stack CREATE_COMPLETE |
+    And the output should not match /2020-10-29 00:00:00 \+[0-9]{4} myapp-vpc AWS::CloudFormation::Stack CREATE_COMPLETE/ 
     Then the exit status should be 0
 
   Scenario: Run apply on an existing stack
@@ -171,7 +170,7 @@ Feature: Apply command
       | +    "TestSg": {                                                               |
       | Parameters diff:                                                               |
       | VpcId: vpc-xxxxxx                                                              |
-      | 2020-10-29 00:00:00 +1100 myapp-web AWS::CloudFormation::Stack CREATE_COMPLETE |
+    And the output should match /2020-10-29 00:00:00 \+[0-9]{4} myapp-web AWS::CloudFormation::Stack CREATE_COMPLETE/
     Then the exit status should be 0
 
   Scenario: Create a stack with a notification ARN and a stack update policy

--- a/features/delete.feature
+++ b/features/delete.feature
@@ -16,8 +16,7 @@ Feature: Delete command
       | stack_id | event_id | stack_name | logical_resource_id | resource_status | resource_type              | timestamp           |
       |        1 |        1 | myapp-vpc  | myapp-vpc           | DELETE_COMPLETE | AWS::CloudFormation::Stack | 2020-10-29 00:00:00 |
     When I run `stack_master delete us-east-1 myapp-vpc --trace` interactively
-    And the output should contain all of these lines:
-    | 2020-10-29 00:00:00 +1100 myapp-vpc AWS::CloudFormation::Stack DELETE_COMPLETE |
+    And the output should match /2020-10-29 00:00:00 \+[0-9]{4} myapp-vpc AWS::CloudFormation::Stack DELETE_COMPLETE/
     Then the exit status should be 0
 
   Scenario: Run a delete command on a stack that does not exists

--- a/features/events.feature
+++ b/features/events.feature
@@ -34,5 +34,4 @@ Feature: Events command
       | 1        | 1        | myapp-vpc  | TestSg              | CREATE_COMPLETE | AWS::EC2::SecurityGroup    | 2020-10-29 00:00:00 |
       | 1        | 1        | myapp-vpc  | myapp-vpc           | CREATE_COMPLETE | AWS::CloudFormation::Stack | 2020-10-29 00:00:00 |
     When I run `stack_master events us-east-1 myapp-vpc --trace`
-    And the output should contain all of these lines:
-      | 2020-10-29 00:00:00 +1100 myapp-vpc AWS::CloudFormation::Stack CREATE_COMPLETE |
+    And the output should match /2020-10-29 00:00:00 \+[0-9]{4} myapp-vpc AWS::CloudFormation::Stack CREATE_COMPLETE/

--- a/features/region_aliases.feature
+++ b/features/region_aliases.feature
@@ -62,5 +62,5 @@ Feature: Region aliases
       | +    "Vpc": {                                                                  |
       | Parameters diff:                                                               |
       | KeyName: my-key                                                                |
-      | 2020-10-29 00:00:00 +1100 myapp-vpc AWS::CloudFormation::Stack CREATE_COMPLETE |
+    And the output should match /2020-10-29 00:00:00 \+[0-9]{4} myapp-vpc AWS::CloudFormation::Stack CREATE_COMPLETE/
     Then the exit status should be 0

--- a/lib/stack_master/cli.rb
+++ b/lib/stack_master/cli.rb
@@ -127,8 +127,13 @@ module StackMaster
             say "Invalid arguments. stack_master delete [region] [stack_name]"
             return
           end
-          config = load_config(options.config)
-          region = Utils.underscore_to_hyphen(config.unalias_region(args[0]))
+	  # Because delete can work without a stack_master.yml
+	  if options.config and File.file?(options.config)
+            config = load_config(options.config)
+            region = Utils.underscore_to_hyphen(config.unalias_region(args[0]))
+	  else
+	    region = args[0]
+	  end
           StackMaster.cloud_formation_driver.set_region(region)
           StackMaster::Commands::Delete.perform(region, args[1])
         end

--- a/lib/stack_master/cli.rb
+++ b/lib/stack_master/cli.rb
@@ -127,8 +127,10 @@ module StackMaster
             say "Invalid arguments. stack_master delete [region] [stack_name]"
             return
           end
-          StackMaster.cloud_formation_driver.set_region(args[0])
-          StackMaster::Commands::Delete.perform(*args)
+          config = load_config(options.config)
+          region = Utils.underscore_to_hyphen(config.unalias_region(args[0]))
+          StackMaster.cloud_formation_driver.set_region(region)
+          StackMaster::Commands::Delete.perform(region, args[1])
         end
       end
 

--- a/spec/stack_master/stack_events/presenter_spec.rb
+++ b/spec/stack_master/stack_events/presenter_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe StackMaster::StackEvents::Presenter do
     subject(:print_event) { described_class.print_event($stdout, event) }
 
     it "nicely presents event data" do
-      expect { print_event }.to output("\e[0;33;49m2001-01-01 02:02:02 +1100 MyAwesomeQueue AWS::SQS::Queue CREATE_IN_PROGRESS Resource creation Initiated\e[0m\n").to_stdout
+      expect { print_event }.to output("\e[0;33;49m2001-01-01 02:02:02 #{Time.now.strftime('%z')} MyAwesomeQueue AWS::SQS::Queue CREATE_IN_PROGRESS Resource creation Initiated\e[0m\n").to_stdout
     end
   end
 end


### PR DESCRIPTION
region_aliases are super handy things, I hate remembering  which environment is in which region, so this lets me use them when I delete stacks as well as create them.