### PR TITLE
Handle noecho parameters

### DIFF
--- a/lib/stack_master/commands/status.rb
+++ b/lib/stack_master/commands/status.rb
@@ -17,6 +17,7 @@ module StackMaster
         end
         tp.set :io, StackMaster.stdout
         tp status
+        StackMaster.stdout.puts " * No echo parameters can't be diffed"
       end
 
       private
@@ -43,6 +44,7 @@ module StackMaster
             differ = StackMaster::StackDiffer.new(proposed_stack, stack)
             different = differ.body_different? || differ.params_different?
             stack_status = stack.stack_status
+            noecho = !differ.noecho_keys.empty?
           else
             different = true
             stack_status = nil
@@ -52,7 +54,7 @@ module StackMaster
           different = true
         end
 
-        { region: region, stack_name: stack_name, stack_status: stack_status, different: different ? "Yes" : "No" }
+        { region: region, stack_name: stack_name, stack_status: stack_status, different: different ? "Yes" : (noecho ? "No *" : "No") }
       end
 
     end

--- a/lib/stack_master/security_group_finder.rb
+++ b/lib/stack_master/security_group_finder.rb
@@ -8,7 +8,6 @@ module StackMaster
     end
 
     def find(reference)
-      STDERR.puts "Resolving security group reference '#{reference}'"
       raise ArgumentError, 'Security group references must be non-empty strings' unless reference.is_a?(String) && !reference.empty?
 
       groups = @resource.security_groups({

--- a/lib/stack_master/sns_topic_finder.rb
+++ b/lib/stack_master/sns_topic_finder.rb
@@ -7,7 +7,6 @@ module StackMaster
     end
 
     def find(reference)
-      $stderr.puts "Resolving SNS topic reference '#{reference}'"
       raise ArgumentError, 'SNS topic references must be non-empty strings' unless reference.is_a?(String) && !reference.empty?
 
       topic = @resource.topics.detect { |t| topic_name_from_arn(t.arn) == reference }

--- a/lib/stack_master/stack_differ.rb
+++ b/lib/stack_master/stack_differ.rb
@@ -41,7 +41,7 @@ module StackMaster
         text_diff('Stack', current_template, proposed_template, context: 7, include_diff_info: true)
         text_diff('Parameters', current_parameters, proposed_parameters)
         unless noecho_keys.empty?
-          StackMaster.stdout.puts " * can not tell if NoEcho parameters are different, assuming not."
+          StackMaster.stdout.puts " * can not tell if NoEcho parameters are different."
         end
       else
         text_diff('Stack', '', proposed_template)

--- a/spec/stack_master/commands/status_spec.rb
+++ b/spec/stack_master/commands/status_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe StackMaster::Commands::Status do
       let(:proposed_stack1) { double(:proposed_stack1, template_body: "{}", parameters_with_defaults: {a: 1}) }
       let(:proposed_stack2) { double(:proposed_stack2, template_body: "{}", parameters_with_defaults: {a: 1}) }
       it "returns the status of call stacks" do
-        out = "REGION    | STACK_NAME | STACK_STATUS    | DIFFERENT\n----------|------------|-----------------|----------\nus-east-1 | stack1     | UPDATE_COMPLETE | No       \nus-east-1 | stack2     | CREATE_COMPLETE | Yes      \n"
+        out = "REGION    | STACK_NAME | STACK_STATUS    | DIFFERENT\n----------|------------|-----------------|----------\nus-east-1 | stack1     | UPDATE_COMPLETE | No       \nus-east-1 | stack2     | CREATE_COMPLETE | Yes      \n * No echo parameters can't be diffed\n"
         expect { status.perform }.to output(out).to_stdout
       end
     end
@@ -30,7 +30,7 @@ RSpec.describe StackMaster::Commands::Status do
       let(:proposed_stack1) { double(:proposed_stack1, template_body: "{}", parameters_with_defaults: {a: 1}) }
       let(:proposed_stack2) { double(:proposed_stack2, template_body: "{}", parameters_with_defaults: {a: 1}) }
       it "returns the status of call stacks" do
-        out = "REGION    | STACK_NAME | STACK_STATUS    | DIFFERENT\n----------|------------|-----------------|----------\nus-east-1 | stack1     | UPDATE_COMPLETE | Yes      \nus-east-1 | stack2     | CREATE_COMPLETE | No       \n"
+        out = "REGION    | STACK_NAME | STACK_STATUS    | DIFFERENT\n----------|------------|-----------------|----------\nus-east-1 | stack1     | UPDATE_COMPLETE | Yes      \nus-east-1 | stack2     | CREATE_COMPLETE | No       \n * No echo parameters can't be diffed\n"
         expect { status.perform }.to output(out).to_stdout
       end
     end

--- a/spec/stack_master/stack_differ_spec.rb
+++ b/spec/stack_master/stack_differ_spec.rb
@@ -1,16 +1,26 @@
 RSpec.describe StackMaster::StackDiffer do
   subject(:differ) { described_class.new(proposed_stack, stack) }
+  let(:current_params) { Hash.new }
+  let(:proposed_params) { { 'param1' => 'hello'} }
   let(:stack) { StackMaster::Stack.new(stack_name: stack_name,
                                        region: region,
                                        stack_id: 123,
                                        template_body: '{}',
-                                       parameters: {}) }
+                                       parameters: current_params) }
   let(:proposed_stack) { StackMaster::Stack.new(stack_name: stack_name,
                                                 region: region,
-                                                parameters: { 'param1' => 'hello'},
+                                                parameters: proposed_params,
                                                 template_body: "{\"a\": 1}") }
   let(:stack_name) { 'myapp-vpc' }
   let(:region) { 'us-east-1' }
+
+  describe "#proposed_parameters" do
+    let(:current_params) { { 'param1' => 'hello',
+                             'param2' => '****'} }
+    it "stars out noecho params" do
+      expect(differ.proposed_parameters).to eq "---\nparam1: hello\nparam2: \"****\"\n"
+    end
+  end
 
   describe "#output_diff" do
     context "entirely new stack" do


### PR DESCRIPTION
Will look something like this.

```
⇒ sm status
Fetching stack information: |==============================================================================================================|
REGION    | STACK_NAME          | STACK_STATUS    | DIFFERENT
----------|---------------------|-----------------|----------
us-east-1 | api-gateway         | UPDATE_COMPLETE | No *
us-east-1 | build-envato-com    | UPDATE_COMPLETE | No
us-east-1 | dewey               | CREATE_COMPLETE | No
us-east-1 | ecs-cluster-stack-b | UPDATE_COMPLETE | Yes
us-east-1 | elasticsearch       | UPDATE_COMPLETE | No *
 * No echo parameters can't be diffed
```

Also removes the puts from the param resolves which was screwing with
the progress bar.