### PR TITLE
Ensure StackMaster uses the new ruby AWS SDK

### DIFF
--- a/stack_master.gemspec
+++ b/stack_master.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "ruby-progressbar"
   spec.add_dependency "commander"
   spec.add_dependency "virtus"
-  spec.add_dependency "aws-sdk"
+  spec.add_dependency "aws-sdk", "~> 2.1"
   spec.add_dependency "diffy"
   spec.add_dependency "colorize"
   spec.add_dependency "activesupport"


### PR DESCRIPTION
@andrewjhumphrey reported an issue where an error is thrown about a missing `Aws` constant. It's most likely because we're not specifying the aws-sdk version and it's using an old ruby sdk.