### PR TITLE
commands get passed an options array

### DIFF
--- a/lib/stack_master/commands/validate.rb
+++ b/lib/stack_master/commands/validate.rb
@@ -4,7 +4,7 @@ module StackMaster
       include Command
       include Commander::UI
 
-      def initialize(config, stack_definition)
+      def initialize(config, stack_definition, options = {})
         @config = config
         @stack_definition = stack_definition
       end

--- a/spec/stack_master/commands/validate_spec.rb
+++ b/spec/stack_master/commands/validate_spec.rb
@@ -1,9 +1,10 @@
 RSpec.describe StackMaster::Commands::Validate do
 
-  subject(:validate) { described_class.new(config, stack_definition) }
+  subject(:validate) { described_class.new(config, stack_definition, options) }
   let(:config) { instance_double(StackMaster::Config) }
   let(:region) { "us-east-1" }
   let(:stack_name) { "mystack" }
+  let(:options) { }
   let(:stack_definition) do
     StackMaster::StackDefinition.new(
       region: region,


### PR DESCRIPTION
also update spec to reflect this for validate, which was failing when called
``` MacBook-Pro:stackmaster andrewhumphrey$ sm validate staging 
marketdbreplicas --trace Received the following args: 3 0:StackMaster::Config 
1:StackMaster::StackDefinition 2:
/Users/andrewhumphrey/src/envato-cloud-management/.bundle/ruby/2.1.0/gems/stack_master-0.0.2/lib/stack_master/commands/validate.rb:7:in
`initialize': wrong number of arguments (3 for 2) (ArgumentError)
```