### PR TITLE
Improve error messages when parameters are broken

### DIFF
--- a/lib/stack_master/parameter_resolver.rb
+++ b/lib/stack_master/parameter_resolver.rb
@@ -19,8 +19,8 @@ module StackMaster
         begin
           parameters[key] = resolve_parameter_value(value)
         rescue InvalidParameter
-          say "Unable to resolve parameter #{key.inspect} value causing error: #{$!.message}"
-          exit 1
+          StackMaster.stderr.puts  "Unable to resolve parameter #{key.inspect} value causing error: #{$!.message}"
+          raise
         end
         parameters
       end

--- a/lib/stack_master/parameter_resolver.rb
+++ b/lib/stack_master/parameter_resolver.rb
@@ -16,7 +16,12 @@ module StackMaster
 
     def resolve
       @parameters.reduce({}) do |parameters, (key, value)|
-        parameters[key] = resolve_parameter_value(value)
+        begin
+          parameters[key] = resolve_parameter_value(value)
+        rescue InvalidParameter
+          say "Unable to resolve parameter #{key.inspect} value causing error: #{$!.message}"
+          exit 1
+        end
         parameters
       end
     end

--- a/lib/stack_master/parameter_resolver.rb
+++ b/lib/stack_master/parameter_resolver.rb
@@ -19,8 +19,7 @@ module StackMaster
         begin
           parameters[key] = resolve_parameter_value(value)
         rescue InvalidParameter
-          StackMaster.stderr.puts  "Unable to resolve parameter #{key.inspect} value causing error: #{$!.message}"
-          raise
+          raise InvalidParameter, "Unable to resolve parameter #{key.inspect} value causing error: #{$!.message}"
         end
         parameters
       end


### PR DESCRIPTION
Before:
``` MacBook-Pro:stackmaster andrewhumphrey$ sm apply staging 
market-db-replicas error: 5. Use --trace to view backtrace
```

After:
``` MacBook-Pro:stackmaster andrewhumphrey$ sm apply staging 
market-db-replicas Unable to resolve parameter "DbAllocatedStorage" value causing error: 5
```