### PR TITLE
Increase the maximum allowed width of output

### DIFF
--- a/lib/stack_master/commands/outputs.rb
+++ b/lib/stack_master/commands/outputs.rb
@@ -11,6 +11,7 @@ module StackMaster
 
       def perform
         if stack
+          tp.set :max_width, 80
           tp stack.outputs, :output_key, :output_value, :description
         else
           StackMaster.stdout.puts "Stack doesn't exist"


### PR DESCRIPTION
Output variables tend to get cut off with the default.

/cc @stevehodgkiss 