### PR TITLE
Dynamically require parameter resolvers

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,41 @@ web_ami:
   latest_ami_by_tags: role=web,application=myapp
 ```
 
+### Custom parameter resolvers
+
+New parameter resolvers can be created in a separate gem.
+
+To create a resolver named my_resolver:
+  * Create a new gem using your favorite tool
+  * The gem structure must contain the following path:
+```
+lib/stack_master/parameter_resolvers/my_resolver.rb
+```
+  * That file need to contain a class named `StackMaster::ParameterResolvers::MyResolver`
+    that implements a `resolve` method and an initializer taking 2 parameters :
+```ruby
+module StackMaster
+  module ParameterResolvers
+    class MyResolver
+      def initialize(config, stack_definition)
+        @config = config
+        @stack_definition = stack_definition
+      end
+
+      def resolve(value)
+        value
+      end
+    end
+  end
+end
+```
+  * Note that the filename and classname are both derived from the resolver name
+    passed in the parameter file. In our case, the parameters YAML would look like:
+```yaml
+vpc_id:
+  my_resolver: dummy_value
+```
+
 ## Commands
 
 ```bash

--- a/lib/stack_master/parameter_resolver.rb
+++ b/lib/stack_master/parameter_resolver.rb
@@ -27,19 +27,53 @@ module StackMaster
 
     private
 
+    def require_parameter_resolver(file_name)
+      begin
+        require "stack_master/parameter_resolvers/#{file_name}"
+      rescue LoadError
+        raise ResolverNotFound.new(file_name)
+      end
+    end
+
+    def load_parameter_resolver(class_name)
+      begin
+        # Check if the class name already exists
+        return if resolver_class_const(class_name)
+      rescue NameError
+        # If it doesn't, try to load it
+        require_parameter_resolver(class_name.underscore)
+      end
+    end
+
     def resolve_parameter_value(parameter_value)
       return parameter_value if String === parameter_value || parameter_value.nil?
       raise InvalidParameter, parameter_value unless Hash === parameter_value
       raise InvalidParameter, parameter_value unless parameter_value.keys.size == 1
-      resolver_class_name = parameter_value.keys.first.to_s.camelize
+
+      resolver_name = parameter_value.keys.first.to_s
+      load_parameter_resolver(resolver_name)
+
       value = parameter_value.values.first
-      resolver_class(resolver_class_name).resolve(value)
+      resolver_class_name = resolver_name.camelize
+      call_resolver(resolver_class_name, value)
+    end
+
+    def call_resolver(class_name, value)
+      resolver_class(class_name).resolve(value)
+    end
+
+    def resolver_class_name(class_name)
+      "StackMaster::ParameterResolvers::#{class_name.camelize}"
+    end
+
+    def resolver_class_const(class_name)
+      Kernel.const_get(resolver_class_name(class_name))
     end
 
     def resolver_class(class_name)
       @resolvers.fetch(class_name) do
         begin
-          @resolvers[class_name] = Kernel.const_get("StackMaster::ParameterResolvers::#{class_name}").new(@config, @stack_definition)
+          @resolvers[class_name] = resolver_class_const(class_name).new(@config, @stack_definition)
         rescue NameError
           raise ResolverNotFound, "Could not find parameter resolver called #{class_name}, please double check your configuration"
         end

--- a/lib/stack_master/parameter_resolver.rb
+++ b/lib/stack_master/parameter_resolver.rb
@@ -35,7 +35,7 @@ module StackMaster
 
     def load_parameter_resolver(class_name)
       # Check if the class name already exists
-      return if resolver_class_const(class_name)
+      resolver_class_const(class_name)
     rescue NameError
       # If it doesn't, try to load it
       require_parameter_resolver(class_name.underscore)

--- a/lib/stack_master/parameter_resolver.rb
+++ b/lib/stack_master/parameter_resolver.rb
@@ -28,21 +28,17 @@ module StackMaster
     private
 
     def require_parameter_resolver(file_name)
-      begin
-        require "stack_master/parameter_resolvers/#{file_name}"
-      rescue LoadError
-        raise ResolverNotFound.new(file_name)
-      end
+      require "stack_master/parameter_resolvers/#{file_name}"
+    rescue LoadError
+      raise ResolverNotFound.new(file_name)
     end
 
     def load_parameter_resolver(class_name)
-      begin
-        # Check if the class name already exists
-        return if resolver_class_const(class_name)
-      rescue NameError
-        # If it doesn't, try to load it
-        require_parameter_resolver(class_name.underscore)
-      end
+      # Check if the class name already exists
+      return if resolver_class_const(class_name)
+    rescue NameError
+      # If it doesn't, try to load it
+      require_parameter_resolver(class_name.underscore)
     end
 
     def resolve_parameter_value(parameter_value)

--- a/spec/stack_master/parameter_resolver_spec.rb
+++ b/spec/stack_master/parameter_resolver_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe StackMaster::ParameterResolver do
-  subject { StackMaster::ParameterResolver.new(config, region, params) }
+  subject(:parameter_resolver) { StackMaster::ParameterResolver.new(config, region, params) }
   let(:params) do
     {
       param: { my_resolver: 2 }
@@ -21,7 +21,6 @@ RSpec.describe StackMaster::ParameterResolver do
   before do
     stub_const('StackMaster::ParameterResolvers::MyResolver', my_resolver)
   end
-
 
   def resolve(params)
     StackMaster::ParameterResolver.resolve(config, 'us-east-1', params)
@@ -66,10 +65,10 @@ RSpec.describe StackMaster::ParameterResolver do
 
   context 'when the resolver class already exist' do
     it 'does not try to load it' do
-      expect(subject).to receive(:load_parameter_resolver).once.and_call_original
-      expect(subject).not_to receive(:require_parameter_resolver)
+      expect(parameter_resolver).to receive(:load_parameter_resolver).once.and_call_original
+      expect(parameter_resolver).not_to receive(:require_parameter_resolver)
 
-      subject.resolve
+      parameter_resolver.resolve
     end
   end
 
@@ -81,11 +80,11 @@ RSpec.describe StackMaster::ParameterResolver do
     end
 
     it 'tries to load it' do
-      expect(subject).to receive(:load_parameter_resolver).once.and_call_original
-      expect(subject).to receive(:require_parameter_resolver).and_return nil
-      expect(subject).to receive(:call_resolver).and_return nil
+      expect(parameter_resolver).to receive(:load_parameter_resolver).once.and_call_original
+      expect(parameter_resolver).to receive(:require_parameter_resolver).and_return nil
+      expect(parameter_resolver).to receive(:call_resolver).and_return nil
 
-      subject.resolve
+      parameter_resolver.resolve
     end
   end
 end


### PR DESCRIPTION
This allows the creation of new resolvers in a separate gem (See the README for more details).

My use case is that we have an internal company-specific service to lookup Vpc and subnet Ids