### PR TITLE
Add the capability to use templates from S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,28 @@ stacks:
       template: myapp_vpc.rb
 ```
 
+## S3
+
+StackMaster can optionally use S3 to store the templates before creating a stack.
+This requires to configure an S3 bucket in stack_master.yml:
+
+```yaml
+stack_defaults:
+  s3:
+    bucket: my_bucket_name
+    prefix: cfn_templates/my-awesome-app
+    region: us-west-2
+```
+
+Additional files can be configured to be uploaded to S3 alongside the templates:
+```yaml
+stacks:
+  production:
+    myapp-vpc:
+      template: myapp_vpc.rb
+      files:
+        - userdata.sh
+```
 ## Directories
 
 - `templates` - CloudFormation or SparkleFormation templates.

--- a/lib/stack_master.rb
+++ b/lib/stack_master.rb
@@ -17,6 +17,7 @@ require "stack_master/version"
 require "stack_master/stack"
 require "stack_master/prompter"
 require "stack_master/aws_driver/cloud_formation"
+require "stack_master/aws_driver/s3"
 require "stack_master/test_driver/cloud_formation"
 require "stack_master/stack_events/fetcher"
 require "stack_master/stack_events/presenter"
@@ -60,6 +61,10 @@ module StackMaster
     @cloud_formation_driver ||= AwsDriver::CloudFormation.new
   end
 
+  def s3_driver
+    @s3_driver ||= AwsDriver::S3.new
+  end
+
   def cloud_formation_driver=(value)
     @cloud_formation_driver = value
   end
@@ -80,4 +85,3 @@ module StackMaster
     @stderr = io
   end
 end
-

--- a/lib/stack_master/aws_driver/s3.rb
+++ b/lib/stack_master/aws_driver/s3.rb
@@ -1,0 +1,56 @@
+module StackMaster
+  module AwsDriver
+    class S3ConfigurationError < StandardError; end
+
+    class S3
+      def set_region(region)
+        @region = region
+        @s3 = nil
+      end
+
+      def upload_files(options)
+        bucket = options.fetch(:bucket) { raise StackMaster::AwsDriver::S3ConfigurationError, 'A bucket must be specified in order to use S3' }
+        prefix = options[:prefix]
+        bucket_region = options.fetch(:region, @region)
+        files = options.fetch(:files, [])
+
+        return if files.empty?
+
+        set_region(bucket_region) if bucket_region
+
+        files.each do |file|
+          body = File.read(file)
+          key = File.basename(file)
+          key.prepend("#{prefix}/") if prefix
+
+          put_object(
+            bucket: bucket,
+            key: key,
+            body: body
+          )
+        end
+      end
+
+      def put_object(options)
+        puts "Uploading #{options[:key]} to bucket #{options[:bucket]}..."
+        s3.put_object(options)
+      end
+
+      def url(options)
+        puts "Generating url for #{options.inspect}"
+        s3_url(@region, options['bucket'], options['prefix'], options['template'])
+      end
+
+      def s3_url(region, bucket, prefix, file)
+        "https://s3-#{region}.amazonaws.com/#{bucket}/#{prefix}/#{file}"
+      end
+
+      private
+
+      def s3
+        puts "Creating S3 client in #{@region}"
+        @s3 ||= Aws::S3::Client.new(region: @region)
+      end
+    end
+  end
+end

--- a/lib/stack_master/aws_driver/s3.rb
+++ b/lib/stack_master/aws_driver/s3.rb
@@ -37,7 +37,6 @@ module StackMaster
       end
 
       def url(options)
-        puts "Generating url for #{options.inspect}"
         s3_url(@region, options['bucket'], options['prefix'], options['template'])
       end
 
@@ -48,7 +47,6 @@ module StackMaster
       private
 
       def s3
-        puts "Creating S3 client in #{@region}"
         @s3 ||= Aws::S3::Client.new(region: @region)
       end
     end

--- a/lib/stack_master/aws_driver/s3.rb
+++ b/lib/stack_master/aws_driver/s3.rb
@@ -23,6 +23,8 @@ module StackMaster
           key = File.basename(file)
           key.prepend("#{prefix}/") if prefix
 
+          StackMaster.stdout.puts "Uploading #{file} to bucket #{options[:bucket]}/#{key}..."
+
           put_object(
             bucket: bucket,
             key: key,
@@ -32,7 +34,6 @@ module StackMaster
       end
 
       def put_object(options)
-        puts "Uploading #{options[:key]} to bucket #{options[:bucket]}..."
         s3.put_object(options)
       end
 

--- a/lib/stack_master/commands/apply.rb
+++ b/lib/stack_master/commands/apply.rb
@@ -78,7 +78,7 @@ module StackMaster
       end
 
       def stack_too_big
-        if proposed_stack.too_big?
+        if proposed_stack.too_big?(use_s3?)
           StackMaster.stdout.puts 'The (space compressed) stack is larger than the limit set by AWS. See http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-limits.html'
           true
         else

--- a/lib/stack_master/commands/apply.rb
+++ b/lib/stack_master/commands/apply.rb
@@ -7,7 +7,7 @@ module StackMaster
 
       def initialize(config, stack_definition, options = {})
         @config = config
-        @s3_config = stack_definition['s3']
+        @s3_config = stack_definition.s3
         @stack_definition = stack_definition
         @from_time = Time.now
         @updating = false
@@ -52,7 +52,7 @@ module StackMaster
       end
 
       def use_s3?
-        @s3_config
+        !@s3_config.empty?
       end
 
       def diff_stacks
@@ -110,6 +110,7 @@ module StackMaster
       end
 
       def files_to_upload
+        return [] unless use_s3?
         [@stack_definition.files_to_upload, @stack_definition.template_file_path].flatten
       end
 
@@ -125,6 +126,7 @@ module StackMaster
       end
 
       def s3_options
+        return {} unless use_s3?
         {
           bucket: @s3_config['bucket'],
           prefix: @s3_config['prefix'],

--- a/lib/stack_master/commands/apply.rb
+++ b/lib/stack_master/commands/apply.rb
@@ -7,7 +7,7 @@ module StackMaster
 
       def initialize(config, stack_definition, options = {})
         @config = config
-        @s3_config = config.stack_defaults['s3']
+        @s3_config = stack_definition['s3']
         @stack_definition = stack_definition
         @from_time = Time.now
         @updating = false

--- a/lib/stack_master/config.rb
+++ b/lib/stack_master/config.rb
@@ -74,7 +74,7 @@ module StackMaster
         region = Utils.underscore_to_hyphen(region)
         stacks_for_region.each do |stack_name, attributes|
           stack_name = Utils.underscore_to_hyphen(stack_name)
-          stack_attributes = attributes.deeper_merge(build_stack_defaults(region)).merge(
+          stack_attributes = build_stack_defaults(region).deeper_merge(attributes).merge(
             'region' => region,
             'stack_name' => stack_name,
             'base_dir' => @base_dir,

--- a/lib/stack_master/config.rb
+++ b/lib/stack_master/config.rb
@@ -74,7 +74,7 @@ module StackMaster
         region = Utils.underscore_to_hyphen(region)
         stacks_for_region.each do |stack_name, attributes|
           stack_name = Utils.underscore_to_hyphen(stack_name)
-          stack_attributes = build_stack_defaults(region).deeper_merge(attributes).merge(
+          stack_attributes = build_stack_defaults(region).deeper_merge!(attributes).merge(
             'region' => region,
             'stack_name' => stack_name,
             'base_dir' => @base_dir,

--- a/lib/stack_master/config.rb
+++ b/lib/stack_master/config.rb
@@ -74,7 +74,7 @@ module StackMaster
         region = Utils.underscore_to_hyphen(region)
         stacks_for_region.each do |stack_name, attributes|
           stack_name = Utils.underscore_to_hyphen(stack_name)
-          stack_attributes = build_stack_defaults(region).deeper_merge(attributes).merge(
+          stack_attributes = attributes.deeper_merge(build_stack_defaults(region)).merge(
             'region' => region,
             'stack_name' => stack_name,
             'base_dir' => @base_dir,

--- a/lib/stack_master/stack.rb
+++ b/lib/stack_master/stack.rb
@@ -1,6 +1,7 @@
 module StackMaster
   class Stack
     MAX_TEMPLATE_SIZE = 51200
+    MAX_S3_TEMPLATE_SIZE = 460800
 
     include Virtus.model
 
@@ -82,8 +83,13 @@ module StackMaster
           stack_policy_body: stack_policy_body)
     end
 
-    def too_big?
-      maybe_compressed_template_body.size > MAX_TEMPLATE_SIZE
+    def max_template_size(use_s3)
+      return MAX_S3_TEMPLATE_SIZE if use_s3
+      MAX_TEMPLATE_SIZE
+    end
+
+    def too_big?(use_s3 = false)
+      maybe_compressed_template_body.size > max_template_size(use_s3)
     end
 
     def aws_parameters

--- a/lib/stack_master/stack.rb
+++ b/lib/stack_master/stack.rb
@@ -14,6 +14,7 @@ module StackMaster
     attribute :outputs, Array
     attribute :stack_policy_body, String
     attribute :tags, Hash
+    attribute :files, Array[String]
 
     def template_hash
       if template_body

--- a/lib/stack_master/stack_definition.rb
+++ b/lib/stack_master/stack_definition.rb
@@ -38,6 +38,10 @@ module StackMaster
       File.join(base_dir, 'policies', stack_policy_file) if stack_policy_file
     end
 
+    def s3_configured?
+      !s3.nil?
+    end
+
     private
 
     def additional_parameter_lookup_file_paths

--- a/lib/stack_master/stack_definition.rb
+++ b/lib/stack_master/stack_definition.rb
@@ -7,6 +7,7 @@ module StackMaster
       attribute :stack_name, String
       attribute :template, String
       attribute :tags, Hash
+      attribute :s3, Hash
       attribute :notification_arns, Array[String]
       attribute :base_dir, String
       attribute :secret_file, String

--- a/lib/stack_master/stack_definition.rb
+++ b/lib/stack_master/stack_definition.rb
@@ -10,12 +10,23 @@ module StackMaster
       attribute :notification_arns, Array[String]
       attribute :base_dir, String
       attribute :secret_file, String
+      attribute :files, Array[String]
       attribute :stack_policy_file, String
       attribute :additional_parameter_lookup_dirs, Array[String]
     end
 
+    def template_dir
+      File.join(base_dir, 'templates')
+    end
+
     def template_file_path
-      File.join(base_dir, 'templates', template)
+      File.join(template_dir, template)
+    end
+
+    def files_to_upload
+      files.map do |file|
+        "#{template_dir}/#{file}"
+      end
     end
 
     def parameter_files

--- a/spec/stack_master/aws_driver/s3_spec.rb
+++ b/spec/stack_master/aws_driver/s3_spec.rb
@@ -1,0 +1,78 @@
+RSpec.describe StackMaster::AwsDriver::S3 do
+  subject(:s3_driver) { StackMaster::AwsDriver::S3.new }
+
+  describe '#upload_files' do
+    before do
+      allow(File).to receive(:read).and_return('file content')
+    end
+
+    context 'when called with a prefix' do
+      let(:options) do
+        {
+          bucket: 'bucket',
+          prefix: 'prefix',
+          files: ['file']
+        }
+      end
+
+      it 'uploads files under a prefix' do
+        expect(s3_driver).to receive(:put_object).with(bucket: 'bucket',
+                                                       key: 'prefix/file',
+                                                       body: 'file content')
+        s3_driver.upload_files(options)
+      end
+    end
+
+    context 'when called without a prefix' do
+      let(:options) do
+        {
+          bucket: 'bucket',
+          files: ['file']
+        }
+      end
+
+      it 'uploads files under the bucket root' do
+        expect(s3_driver).to receive(:put_object).with(bucket: 'bucket',
+                                                       key: 'file',
+                                                       body: 'file content')
+        s3_driver.upload_files(options)
+      end
+    end
+
+    context 'when called with files in a subfolder' do
+      let(:options) do
+        {
+          bucket: 'bucket',
+          prefix: 'prefix',
+          files: ['folder/file']
+        }
+      end
+
+      it 'uploads files under the prefix' do
+        expect(s3_driver).to receive(:put_object).with(bucket: 'bucket',
+                                                       key: 'prefix/file',
+                                                       body: 'file content')
+        s3_driver.upload_files(options)
+      end
+    end
+
+    context 'when called with several files' do
+      let(:options) do
+        {
+          bucket: 'bucket',
+          files: ['file1', 'file2']
+        }
+      end
+
+      it 'uploads all the files' do
+        expect(s3_driver).to receive(:put_object).with(bucket: 'bucket',
+                                                       key: 'file1',
+                                                       body: 'file content')
+        expect(s3_driver).to receive(:put_object).with(bucket: 'bucket',
+                                                       key: 'file2',
+                                                       body: 'file content')
+        s3_driver.upload_files(options)
+      end
+    end
+  end
+end

--- a/spec/stack_master/commands/apply_spec.rb
+++ b/spec/stack_master/commands/apply_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe StackMaster::Commands::Apply do
   before do
     allow(StackMaster::Stack).to receive(:find).with(region, stack_name).and_return(stack)
     allow(StackMaster::Stack).to receive(:generate).with(stack_definition, config).and_return(proposed_stack)
+    allow(config).to receive(:stack_defaults).and_return({})
     allow(Aws::CloudFormation::Client).to receive(:new).and_return(cf)
     allow(cf).to receive(:update_stack)
     allow(cf).to receive(:create_stack)

--- a/spec/stack_master/stack_spec.rb
+++ b/spec/stack_master/stack_spec.rb
@@ -144,14 +144,32 @@ RSpec.describe StackMaster::Stack do
   end
 
   describe '#too_big?' do
-    let(:big_stack) { described_class.new(template_body: "{\"a\":\"#{'x' * 60000}\"}") }
+    let(:big_stack) { described_class.new(template_body: "{\"a\":\"#{'x' * 500000}\"}") }
+    let(:medium_stack) { described_class.new(template_body: "{\"a\":\"#{'x' * 60000}\"}") }
     let(:little_stack) { described_class.new(template_body: "{\"a\":\"#{'x' * 1000}\"}") }
 
-    it 'returns true for big stacks' do
-      expect(big_stack.too_big?).to be_truthy
+    context 'when not using S3' do
+      it 'returns true for big stacks' do
+        expect(big_stack.too_big?).to be_truthy
+      end
+      it 'returns true for medium stacks' do
+        expect(medium_stack.too_big?).to be_truthy
+      end
+      it 'returns false for small stacks' do
+        expect(little_stack.too_big?).to be_falsey
+      end
     end
-    it 'returns false for small stacks' do
-      expect(little_stack.too_big?).to be_falsey
+
+    context 'when using S3' do
+      it 'returns true for big stacks' do
+        expect(big_stack.too_big?(true)).to be_truthy
+      end
+      it 'returns false for medium stacks' do
+        expect(medium_stack.too_big?(true)).to be_falsey
+      end
+      it 'returns false for small stacks' do
+        expect(little_stack.too_big?(true)).to be_falsey
+      end
     end
   end
 end


### PR DESCRIPTION
This covers the first part of #60, which is the upload to S3 of templates and associated files, and triggering the stack creation from an S3 URL.

 *This works for manually created nested templates, I haven't tested the SparkleFormation nested stacks functions. As @luckymike mentioned the s3 bucket/prefix would have to be passed on to sfn.
 * Stack diff and events tail only apply to the toplevel stack for now (when using nested stacks).
 * If no bucket is configured the old behaviour applies