### PR TITLE
Allow stack master to handle numeric parameters

### DIFF
--- a/lib/stack_master/parameter_resolver.rb
+++ b/lib/stack_master/parameter_resolver.rb
@@ -42,7 +42,7 @@ module StackMaster
     end
 
     def resolve_parameter_value(parameter_value)
-      return parameter_value if String === parameter_value || parameter_value.nil?
+      return parameter_value if Numeric === parameter_value || String === parameter_value || parameter_value.nil?
       raise InvalidParameter, parameter_value unless Hash === parameter_value
       raise InvalidParameter, parameter_value unless parameter_value.keys.size == 1
 

--- a/lib/stack_master/utils.rb
+++ b/lib/stack_master/utils.rb
@@ -4,7 +4,7 @@ module StackMaster
 
     def hash_to_aws_parameters(params)
       params.inject([]) do |params, (key, value)|
-        params << { parameter_key: key, parameter_value: value }
+        params << { parameter_key: key, parameter_value: value.to_s }
         params
       end
     end

--- a/spec/stack_master/parameter_resolver_spec.rb
+++ b/spec/stack_master/parameter_resolver_spec.rb
@@ -30,6 +30,10 @@ RSpec.describe StackMaster::ParameterResolver do
     expect(resolve(param1: 'value1')).to eq(param1: 'value1')
   end
 
+  it 'returns the same value for numerics' do
+    expect(resolve(param1: 1)).to eq(param1: 1)
+  end
+
   it 'it throws an error when the hash contains more than one key' do
     expect {
       resolve(param: { nested1: 'value1', nested2: 'value2' })

--- a/spec/stack_master/utils_spec.rb
+++ b/spec/stack_master/utils_spec.rb
@@ -17,13 +17,14 @@ RSpec.describe StackMaster::Utils do
   end
 
   describe ".hash_to_aws_parameters" do
-    let(:params) { { 'param1' => 'value1', 'param2' => 'value2' } }
+    let(:params) { { 'param1' => 'value1', 'param2' => 'value2', 'param3' => 3 } }
     subject(:aws_params) { StackMaster::Utils.hash_to_aws_parameters(params) }
 
-    it "converts to aws parameters" do
+    it "converts to aws parameters (numerics convert to strings)" do
       expect(aws_params).to eq([
         { parameter_key: 'param1', parameter_value: 'value1' },
-        { parameter_key: 'param2', parameter_value: 'value2' }
+        { parameter_key: 'param2', parameter_value: 'value2' },
+        { parameter_key: 'param3', parameter_value: '3' }
       ])
     end
   end


### PR DESCRIPTION
Fixes: https://github.com/envato/stack_master/issues/66

Although you can specify numeric parameters in stacks AWS when you pass those parameters they need to be strings. Passing numeric parameters to SM causes a confusing error. This PR fixes this problem by letting you pass numeric params then converting them to strings for AWS.

/cc @stevehodgkiss 