### PR TITLE
handle throttling errors from AWS with a simple capped backoff strategy

### DIFF
--- a/lib/stack_master/aws_driver/cloud_formation.rb
+++ b/lib/stack_master/aws_driver/cloud_formation.rb
@@ -11,7 +11,9 @@ module StackMaster
       end
 
       def describe_stacks(options)
-        cf.describe_stacks(options)
+        retry_with_backoff do
+          cf.describe_stacks(options)
+        end
       end
 
       def cancel_update_stack(options)
@@ -50,6 +52,23 @@ module StackMaster
 
       def cf
         @cf ||= Aws::CloudFormation::Client.new(region: @region)
+      end
+
+      def retry_with_backoff
+        delay       = 1
+        max_delay   = 30
+        begin
+          yield
+        rescue Aws::CloudFormation::Errors::Throttling => e
+          if e.message =~ /Rate exceeded/
+            sleep delay
+            delay *= 2
+            if delay > max_delay
+              delay = max_delay
+            end
+            retry
+          end
+        end
       end
     end
   end

--- a/spec/stack_master/commands/status_spec.rb
+++ b/spec/stack_master/commands/status_spec.rb
@@ -8,11 +8,14 @@ RSpec.describe StackMaster::Commands::Status do
 
   before do
     allow(Aws::CloudFormation::Client).to receive(:new).with(region: 'us-east-1').and_return cf
-    allow(StackMaster::Stack).to receive(:find).and_return stack1, stack2
-    allow(StackMaster::Stack).to receive(:generate).and_return proposed_stack1, proposed_stack2
   end
 
   context "#perform" do
+    before do
+      allow(StackMaster::Stack).to receive(:find).and_return stack1, stack2
+      allow(StackMaster::Stack).to receive(:generate).and_return proposed_stack1, proposed_stack2
+    end
+
     context "some parameters are different" do
       let(:stack1) { double(:stack1, template_hash: {}, parameters_with_defaults: {a: 1}, stack_status: 'UPDATE_COMPLETE') }
       let(:stack2) { double(:stack2, template_hash: {}, parameters_with_defaults: {a: 2}, stack_status: 'CREATE_COMPLETE') }
@@ -33,6 +36,26 @@ RSpec.describe StackMaster::Commands::Status do
         out = "REGION    | STACK_NAME | STACK_STATUS    | DIFFERENT\n----------|------------|-----------------|----------\nus-east-1 | stack1     | UPDATE_COMPLETE | Yes      \nus-east-1 | stack2     | CREATE_COMPLETE | No       \n * No echo parameters can't be diffed\n"
         expect { status.perform }.to output(out).to_stdout
       end
+    end
+  end
+
+  context "handles AWS throttling" do
+    let(:throttle_exception)  { Aws::CloudFormation::Errors::Throttling.new(double(), "Rate exceeded.") }
+    let(:stack1) { double(:stack1, template_hash: {}, parameters_with_defaults: {a: 1}, stack_status: 'UPDATE_COMPLETE') }
+    let(:stack2) { double(:stack2, template_hash: {}, parameters_with_defaults: {a: 2}, stack_status: 'CREATE_COMPLETE') }
+    let(:proposed_stack1) { double(:proposed_stack1, template_body: "{}", parameters_with_defaults: {a: 1}) }
+    let(:proposed_stack2) { double(:proposed_stack2, template_body: "{}", parameters_with_defaults: {a: 1}) }
+
+    it "doubles the sleep time across calls" do
+      call_count = 0
+      expect(cf).to receive(:describe_stacks).at_least(1).times do 
+        call_count += 1
+        call_count <= 3 ? raise(throttle_exception) : double(stacks: double(first: nil))
+      end
+      expect(StackMaster.cloud_formation_driver).to receive(:sleep).with(1).ordered
+      expect(StackMaster.cloud_formation_driver).to receive(:sleep).with(2).ordered
+      expect(StackMaster.cloud_formation_driver).to receive(:sleep).with(4).ordered
+      expect { status.perform }.to_not raise_exception
     end
   end
 end


### PR DESCRIPTION
I have a CF setup with a large number of stacks, and sometimes AWS throws errors b/c the request rate on the `status` command is too high.  This fixes that by adding a very simple capped-delay retry strategy and related tests.