### PR TITLE
Allow arrays in parameter files and support numeric types

### DIFF
--- a/lib/stack_master/parameter_resolver.rb
+++ b/lib/stack_master/parameter_resolver.rb
@@ -42,6 +42,7 @@ module StackMaster
     end
 
     def resolve_parameter_value(key, parameter_value)
+      return parameter_value.to_s if Numeric === parameter_value
       return parameter_value unless Hash === parameter_value
       validate_parameter_value!(key, parameter_value)
 

--- a/spec/stack_master/parameter_resolver_spec.rb
+++ b/spec/stack_master/parameter_resolver_spec.rb
@@ -36,10 +36,10 @@ RSpec.describe StackMaster::ParameterResolver do
     }.to raise_error(StackMaster::ParameterResolver::InvalidParameter)
   end
 
-  it 'throws an error when given an array' do
+  it "doesn't throw an error when given an array" do
     expect {
       resolve(param: [1, 2])
-    }.to raise_error(StackMaster::ParameterResolver::InvalidParameter)
+    }.to_not raise_error
   end
 
   context 'when given a proper resolve hash' do

--- a/spec/stack_master/parameter_resolver_spec.rb
+++ b/spec/stack_master/parameter_resolver_spec.rb
@@ -30,6 +30,10 @@ RSpec.describe StackMaster::ParameterResolver do
     expect(resolve(param1: 'value1')).to eq(param1: 'value1')
   end
 
+  it 'returns integers as strings' do
+    expect(resolve(param1: 2)).to eq(param1: '2')
+  end
+
   it 'it throws an error when the hash contains more than one key' do
     expect {
       resolve(param: { nested1: 'value1', nested2: 'value2' })


### PR DESCRIPTION
Arrays can be supplied to the AWS SDK for the List<> types, so StackMaster should support that.

Also allows numeric types to be passed in and converted to strings before being passed to the AWS SDK . Ref: https://github.com/envato/stack_master/pull/67 and https://github.com/envato/stack_master/issues/66