### PR TITLE
Add `-y` and `-n` global options to run without user interaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ stack_master help # Display up to date docs on the commands available
 stack_master init # Initialises a directory structure and stack_master.yml file
 stack_master list # Lists stack definitions
 stack_master apply <region-or-alias> <stack-name> # Create or update a stack
-stack_master -f apply <region-or-alias> <stack-name> # Create or update a stack non-interactively (forcing yes)
+stack_master --yes apply <region-or-alias> <stack-name> # Create or update a stack non-interactively (forcing yes)
 stack_master diff <region-or-alias> <stack-name> # Display a stack tempalte and parameter diff
 stack_master delete <region-or-alias> <stack-name> # Delete a stack
 stack_master events <region-or-alias> <stack-name> # Display events for a stack

--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ stack_master help # Display up to date docs on the commands available
 stack_master init # Initialises a directory structure and stack_master.yml file
 stack_master list # Lists stack definitions
 stack_master apply <region-or-alias> <stack-name> # Create or update a stack
+stack_master -f apply <region-or-alias> <stack-name> # Create or update a stack non-interactively (forcing yes)
 stack_master diff <region-or-alias> <stack-name> # Display a stack tempalte and parameter diff
 stack_master delete <region-or-alias> <stack-name> # Delete a stack
 stack_master events <region-or-alias> <stack-name> # Display events for a stack

--- a/features/apply.feature
+++ b/features/apply.feature
@@ -64,14 +64,11 @@ Feature: Apply command
       """
 
   Scenario: Run apply and create a new stack
-    Given I set the environment variables to:
-      | variable | value |
-      | ANSWER   | y     |
-    And I stub the following stack events:
+    Given I stub the following stack events:
       | stack_id | event_id | stack_name | logical_resource_id | resource_status | resource_type              | timestamp           |
       | 1        | 1        | myapp-vpc  | TestSg              | CREATE_COMPLETE | AWS::EC2::SecurityGroup    | 2020-10-29 00:00:00 |
       | 1        | 1        | myapp-vpc  | myapp-vpc           | CREATE_COMPLETE | AWS::CloudFormation::Stack | 2020-10-29 00:00:00 |
-    When I run `stack_master apply us-east-1 myapp-vpc --trace` interactively
+    When I run `stack_master apply us-east-1 myapp-vpc --trace`
     And the output should contain all of these lines:
       | Stack diff:                                                                    |
       | +    "Vpc": {                                                                  |
@@ -84,7 +81,7 @@ Feature: Apply command
     Given I set the environment variables to:
       | variable | value |
       | ANSWER   | n     |
-    When I run `stack_master apply us-east-1 myapp-vpc --trace` interactively
+    When I run `stack_master apply us-east-1 myapp-vpc --trace`
     And the output should contain all of these lines:
       | Stack diff:      |
       | +    "Vpc": {    |
@@ -95,10 +92,7 @@ Feature: Apply command
     Then the exit status should be 0
 
   Scenario: Run apply on an existing stack
-    Given I set the environment variables to:
-      | variable | value |
-      | ANSWER   | y     |
-    And I stub the following stack events:
+    Given I stub the following stack events:
       | stack_id | event_id | stack_name | logical_resource_id | resource_status | resource_type              | timestamp           |
       | 1        | 1        | myapp-vpc  | TestSg              | CREATE_COMPLETE | AWS::EC2::SecurityGroup    | 2020-10-29 00:00:00 |
       | 1        | 1        | myapp-vpc  | myapp-vpc           | CREATE_COMPLETE | AWS::CloudFormation::Stack | 2020-10-29 00:00:00 |
@@ -146,10 +140,7 @@ Feature: Apply command
     Then the exit status should be 0
 
   Scenario: Create a stack using a stack output resolver
-    Given I set the environment variables to:
-      | variable | value |
-      | ANSWER   | y     |
-    And a file named "parameters/myapp_web.yml" with:
+    Given a file named "parameters/myapp_web.yml" with:
       """
       VpcId:
         stack_output: myapp-vpc/VpcId
@@ -185,9 +176,6 @@ Feature: Apply command
       """
       {}
       """
-    And I set the environment variables to:
-      | variable | value |
-      | ANSWER   | y     |
     And I stub the following stack events:
       | stack_id | event_id | stack_name | logical_resource_id | resource_status | resource_type              | timestamp           |
       | 1        | 1        | myapp-vpc  | TestSg              | CREATE_COMPLETE | AWS::EC2::SecurityGroup    | 2020-10-29 00:00:00 |

--- a/features/apply.feature
+++ b/features/apply.feature
@@ -132,7 +132,7 @@ Feature: Apply command
         }
       }
       """
-    When I run `stack_master apply us-east-1 myapp-vpc --trace` interactively
+    When I run `stack_master apply us-east-1 myapp-vpc --trace`
     And the output should contain all of these lines:
       | Stack diff:                                                                    |
       | -    "TestSg2": {                                                              |
@@ -152,7 +152,7 @@ Feature: Apply command
     And I stub the following stacks:
       | stack_id | stack_name | region    | outputs          |
       | 1        | myapp-vpc  | us-east-1 | VpcId=vpc-xxxxxx |
-    When I run `stack_master apply us-east-1 myapp-web --trace` interactively
+    When I run `stack_master apply us-east-1 myapp-web --trace`
     And the output should contain all of these lines:
       | Stack diff:                                                                    |
       | +    "TestSg": {                                                               |
@@ -216,7 +216,7 @@ Feature: Apply command
         }
       }
       """
-    When I run `stack_master apply us-east-1 myapp-vpc --trace` interactively
+    When I run `stack_master apply us-east-1 myapp-vpc --trace`
     Then the stack "myapp-vpc" should have a policy with the following:
       """
       {}

--- a/features/apply.feature
+++ b/features/apply.feature
@@ -62,9 +62,6 @@ Feature: Apply command
         end
       end
       """
-    And I set the environment variables to:
-      | variable | value |
-      | STUB_AWS | true  |
 
   Scenario: Run apply and create a new stack
     Given I set the environment variables to:

--- a/features/apply.feature
+++ b/features/apply.feature
@@ -78,9 +78,7 @@ Feature: Apply command
     Then the exit status should be 0
 
   Scenario: Run apply and don't create the stack
-    Given I set the environment variables to:
-      | variable | value |
-      | ANSWER   | n     |
+    Given I will answer prompts with "n"
     When I run `stack_master apply us-east-1 myapp-vpc --trace`
     And the output should contain all of these lines:
       | Stack diff:      |

--- a/features/delete.feature
+++ b/features/delete.feature
@@ -12,18 +12,13 @@ Feature: Delete command
     Then the exit status should be 0
 
   Scenario: Run a delete command on a stack that does not exists
-    Given I set the environment variables to:
-      | variable | value |
-      | ANSWER   | y     |
     When I run `stack_master delete us-east-1 myapp-vpc --trace`
     And the output should contain all of these lines:
       | Stack does not exist |
     Then the exit status should be 0
 
   Scenario: Answer no when asked to delete stack
-    Given I set the environment variables to:
-      | variable | value |
-      | ANSWER   | n     |
+    Given I will answer prompts with "n"
     And I stub the following stacks:
       | stack_id | stack_name | parameters       | region    |
       | 1        | myapp-vpc  | KeyName=my-key   | us-east-1 | 

--- a/features/delete.feature
+++ b/features/delete.feature
@@ -1,10 +1,5 @@
 Feature: Delete command
 
-  Background:
-    Given I set the environment variables to:
-      | variable | value |
-      | STUB_AWS | true  |
-
   Scenario: Run a delete command on a stack that exists
     Given I set the environment variables to:
       | variable | value |

--- a/features/delete.feature
+++ b/features/delete.feature
@@ -1,10 +1,7 @@
 Feature: Delete command
 
   Scenario: Run a delete command on a stack that exists
-    Given I set the environment variables to:
-      | variable | value |
-      | ANSWER   | y     |
-     And I stub the following stacks:
+    Given I stub the following stacks:
       | stack_id | stack_name | parameters       | region    |
       | 1        | myapp-vpc  | KeyName=my-key   | us-east-1 |
     And I stub the following stack events:

--- a/features/delete.feature
+++ b/features/delete.feature
@@ -7,7 +7,7 @@ Feature: Delete command
     And I stub the following stack events:
       | stack_id | event_id | stack_name | logical_resource_id | resource_status | resource_type              | timestamp           |
       |        1 |        1 | myapp-vpc  | myapp-vpc           | DELETE_COMPLETE | AWS::CloudFormation::Stack | 2020-10-29 00:00:00 |
-    When I run `stack_master delete us-east-1 myapp-vpc --trace` interactively
+    When I run `stack_master delete us-east-1 myapp-vpc --trace`
     And the output should match /2020-10-29 00:00:00 \+[0-9]{4} myapp-vpc AWS::CloudFormation::Stack DELETE_COMPLETE/
     Then the exit status should be 0
 
@@ -15,7 +15,7 @@ Feature: Delete command
     Given I set the environment variables to:
       | variable | value |
       | ANSWER   | y     |
-    When I run `stack_master delete us-east-1 myapp-vpc --trace` interactively
+    When I run `stack_master delete us-east-1 myapp-vpc --trace`
     And the output should contain all of these lines:
       | Stack does not exist |
     Then the exit status should be 0
@@ -27,7 +27,7 @@ Feature: Delete command
     And I stub the following stacks:
       | stack_id | stack_name | parameters       | region    |
       | 1        | myapp-vpc  | KeyName=my-key   | us-east-1 | 
-    When I run `stack_master delete us-east-1 myapp-vpc --trace` interactively
+    When I run `stack_master delete us-east-1 myapp-vpc --trace`
     And the output should contain all of these lines:
       | Stack update aborted |
     Then the exit status should be 0

--- a/features/diff.feature
+++ b/features/diff.feature
@@ -47,9 +47,6 @@ Feature: Diff command
         }
       }
       """
-    And I set the environment variables to:
-      | variable | value |
-      | STUB_AWS | true  |
 
   Scenario: Run diff on a stack with no changes
     Given I set the environment variables to:

--- a/features/diff.feature
+++ b/features/diff.feature
@@ -49,10 +49,7 @@ Feature: Diff command
       """
 
   Scenario: Run diff on a stack with no changes
-    Given I set the environment variables to:
-      | variable | value |
-      | ANSWER   | y     |
-    And I stub the following stacks:
+    Given I stub the following stacks:
       | stack_id | stack_name | parameters          | region    |
       |        1 | myapp-vpc  | KeyName=changed-key | us-east-1 |
     And I stub a template for the stack "myapp-vpc":
@@ -95,10 +92,7 @@ Feature: Diff command
     Then the exit status should be 0
 
   Scenario: Run diff on a stack with parameter changes
-    Given I set the environment variables to:
-      | variable | value |
-      | ANSWER   | y     |
-    And I stub the following stacks:
+    Given I stub the following stacks:
       | stack_id | stack_name | parameters       | region    |
       | 1        | myapp-vpc  | KeyName=my-key   | us-east-1 |
     And I stub a template for the stack "myapp-vpc":
@@ -141,10 +135,7 @@ Feature: Diff command
     Then the exit status should be 0
 
   Scenario: Run diff on a stack with template changes
-    Given I set the environment variables to:
-      | variable | value |
-      | ANSWER   | y     |
-    And I stub the following stacks:
+    Given I stub the following stacks:
       | stack_id | stack_name | parameters       | region    |
       | 1        | myapp-vpc  | KeyName=my-key   | us-east-1 |
     And I stub a template for the stack "myapp-vpc":

--- a/features/diff.feature
+++ b/features/diff.feature
@@ -85,7 +85,7 @@ Feature: Diff command
         }
       }
       """
-    When I run `stack_master diff us-east-1 myapp-vpc --trace` interactively
+    When I run `stack_master diff us-east-1 myapp-vpc --trace`
     And the output should contain all of these lines:
       | -KeyName: changed |
       | +KeyName: my-key  |
@@ -128,7 +128,7 @@ Feature: Diff command
         }
       }
       """
-    When I run `stack_master diff us-east-1 myapp-vpc --trace` interactively
+    When I run `stack_master diff us-east-1 myapp-vpc --trace`
     And the output should contain all of these lines:
       | Stack diff: No changes      |
       | Parameters diff: No changes |
@@ -171,7 +171,7 @@ Feature: Diff command
         }
       }
       """
-    When I run `stack_master diff us-east-1 myapp-vpc --trace` interactively
+    When I run `stack_master diff us-east-1 myapp-vpc --trace`
     And the output should contain all of these lines:
     | -        "GroupDescription": "Changed description" |
     | +        "GroupDescription": "Test SG 2",          |

--- a/features/events.feature
+++ b/features/events.feature
@@ -25,7 +25,7 @@ Feature: Events command
       """
 
   Scenario: View events
-    And I stub the following stack events:
+    Given I stub the following stack events:
       | stack_id | event_id | stack_name | logical_resource_id | resource_status | resource_type              | timestamp           |
       | 1        | 1        | myapp-vpc  | TestSg              | CREATE_COMPLETE | AWS::EC2::SecurityGroup    | 2020-10-29 00:00:00 |
       | 1        | 1        | myapp-vpc  | myapp-vpc           | CREATE_COMPLETE | AWS::CloudFormation::Stack | 2020-10-29 00:00:00 |

--- a/features/events.feature
+++ b/features/events.feature
@@ -23,10 +23,6 @@ Feature: Events command
         end
       end
       """
-    And I set the environment variables to:
-      | variable | value |
-      | STUB_AWS | true  |
-      | ANSWER   | y     |
 
   Scenario: View events
     And I stub the following stack events:

--- a/features/outputs.feature
+++ b/features/outputs.feature
@@ -24,7 +24,7 @@ Feature: Outputs command
       """
 
   Scenario: Output stack resources
-    And I stub the following stacks:
+    Given I stub the following stacks:
       | stack_id | stack_name | parameters       | region    | outputs          |
       | 1        | myapp-vpc  | KeyName=my-key   | us-east-1 | VpcId=vpc-123456 |
     And I stub a template for the stack "myapp-vpc":

--- a/features/outputs.feature
+++ b/features/outputs.feature
@@ -22,10 +22,6 @@ Feature: Outputs command
         end
       end
       """
-    And I set the environment variables to:
-      | variable | value |
-      | STUB_AWS | true  |
-      | ANSWER   | y     |
 
   Scenario: Output stack resources
     And I stub the following stacks:

--- a/features/region_aliases.feature
+++ b/features/region_aliases.feature
@@ -50,10 +50,6 @@ Feature: Region aliases
       | stack_id | event_id | stack_name | logical_resource_id | resource_status | resource_type              | timestamp           |
       | 1        | 1        | myapp-vpc  | TestSg              | CREATE_COMPLETE | AWS::EC2::SecurityGroup    | 2020-10-29 00:00:00 |
       | 1        | 1        | myapp-vpc  | myapp-vpc           | CREATE_COMPLETE | AWS::CloudFormation::Stack | 2020-10-29 00:00:00 |
-    And I set the environment variables to:
-      | variable | value |
-      | STUB_AWS | true  |
-      | ANSWER   | y     |
 
   Scenario: Create a stack using region aliases
     When I run `stack_master apply staging myapp-vpc --trace`

--- a/features/resources.feature
+++ b/features/resources.feature
@@ -22,9 +22,6 @@ Feature: Resources command
         end
       end
       """
-    And I set the environment variables to:
-      | variable | value |
-      | STUB_AWS | true  |
 
   Scenario: Show resources
     And I stub the following stacks:

--- a/features/resources.feature
+++ b/features/resources.feature
@@ -24,7 +24,7 @@ Feature: Resources command
       """
 
   Scenario: Show resources
-    And I stub the following stacks:
+    Given I stub the following stacks:
       | stack_id | stack_name | parameters       | region    |
       | 1        | myapp-vpc  | KeyName=my-key   | us-east-1 |
     And I stub the following stack resources:

--- a/features/stack_defaults.feature
+++ b/features/stack_defaults.feature
@@ -73,7 +73,7 @@ Feature: Stack defaults
       | 1        | 1        | myapp-vpc  | myapp-vpc           | CREATE_COMPLETE | AWS::CloudFormation::Stack | 2020-10-29 00:00:00 |
 
   Scenario: Create a stack with inherited attributes
-    When I run `stack_master apply ap-southeast-2 myapp-vpc --trace` interactively
+    When I run `stack_master apply ap-southeast-2 myapp-vpc --trace`
     Then the stack "myapp-vpc" should contain this notification ARN "test_arn_1"
     Then the stack "myapp-vpc" should contain this notification ARN "test_arn_3"
     And the stack "myapp-vpc" should have a policy with the following:

--- a/features/stack_defaults.feature
+++ b/features/stack_defaults.feature
@@ -71,12 +71,6 @@ Feature: Stack defaults
       | stack_id | event_id | stack_name | logical_resource_id | resource_status | resource_type              | timestamp           |
       | 1        | 1        | myapp-vpc  | TestSg              | CREATE_COMPLETE | AWS::EC2::SecurityGroup    | 2020-10-29 00:00:00 |
       | 1        | 1        | myapp-vpc  | myapp-vpc           | CREATE_COMPLETE | AWS::CloudFormation::Stack | 2020-10-29 00:00:00 |
-    And I set the environment variables to:
-      | variable | value |
-      | STUB_AWS | true  |
-    Given I set the environment variables to:
-      | variable | value |
-      | ANSWER   | y     |
 
   Scenario: Create a stack with inherited attributes
     When I run `stack_master apply ap-southeast-2 myapp-vpc --trace` interactively

--- a/features/status.feature
+++ b/features/status.feature
@@ -63,10 +63,7 @@ Feature: Status command
       """
 
   Scenario: Run status command and get a list of stack statuii
-    Given I set the environment variables to:
-      | variable | value |
-      | ANSWER   | y     |
-    And I stub the following stacks:
+    Given I stub the following stacks:
       | stack_id | stack_name | parameters     | region    | stack_status    |
       |        1 | stack1     | KeyName=my-key | us-east-1 | CREATE_COMPLETE |
       |        2 | stack2     |                | us-east-1 | UPDATE_COMPLETE |

--- a/features/status.feature
+++ b/features/status.feature
@@ -106,7 +106,7 @@ Feature: Status command
 }
       """
 
-    When I run `stack_master status --trace` interactively
+    When I run `stack_master status --trace`
     And the output should contain all of these lines:
       | REGION    \| STACK_NAME \| STACK_STATUS    \| DIFFERENT |
       | ----------\|------------\|-----------------\|---------- |

--- a/features/status.feature
+++ b/features/status.feature
@@ -61,9 +61,6 @@ Feature: Status command
 {
 }
       """
-    And I set the environment variables to:
-      | variable | value |
-      | STUB_AWS | true  |
 
   Scenario: Run status command and get a list of stack statuii
     Given I set the environment variables to:

--- a/features/step_definitions/stack_steps.rb
+++ b/features/step_definitions/stack_steps.rb
@@ -1,3 +1,11 @@
+Before do
+  StackMaster.non_interactive_answer = 'y'
+end
+
+Given(/^I will answer prompts with "([^"]*)"$/) do |answer|
+  StackMaster.non_interactive_answer = answer
+end
+
 Given(/^I stub the following stack events:$/) do |table|
   table.hashes.each do |row|
     row.symbolize_keys!

--- a/lib/stack_master.rb
+++ b/lib/stack_master.rb
@@ -66,6 +66,9 @@ module StackMaster
     @non_interactive = true
   end
 
+  attr_accessor :non_interactive_answer
+  @non_interactive_answer = 'y'
+
   def base_dir
     File.expand_path(File.join(File.dirname(__FILE__), ".."))
   end

--- a/lib/stack_master.rb
+++ b/lib/stack_master.rb
@@ -86,6 +86,10 @@ module StackMaster
     @stdout = io
   end
 
+  def stdin
+    $stdin
+  end
+
   def stderr
     @stderr || $stderr
   end

--- a/lib/stack_master.rb
+++ b/lib/stack_master.rb
@@ -54,6 +54,18 @@ require "stack_master/cli"
 module StackMaster
   extend self
 
+  def interactive?
+    !non_interactive?
+  end
+
+  def non_interactive?
+    @non_interactive || false
+  end
+
+  def non_interactive!
+    @non_interactive = true
+  end
+
   def base_dir
     File.expand_path(File.join(File.dirname(__FILE__), ".."))
   end

--- a/lib/stack_master/cli.rb
+++ b/lib/stack_master/cli.rb
@@ -22,6 +22,9 @@ module StackMaster
       program :description, 'AWS Stack Management'
 
       global_option '-c', '--config FILE', 'Config file to use'
+      global_option '-f', '--force', 'Run in non-interactive mode, all prompts will be answered positively by default or according to the ANSWER environment variable' do
+        StackMaster.non_interactive!
+      end
 
       command :apply do |c|
         c.syntax = 'stack_master apply [region_or_alias] [stack_name]'

--- a/lib/stack_master/cli.rb
+++ b/lib/stack_master/cli.rb
@@ -22,8 +22,13 @@ module StackMaster
       program :description, 'AWS Stack Management'
 
       global_option '-c', '--config FILE', 'Config file to use'
-      global_option '-f', '--force', 'Run in non-interactive mode, all prompts will be answered negatively by default' do
+      global_option '-y', '--yes', 'Run in non-interactive mode answering yes to any prompts' do
         StackMaster.non_interactive!
+        StackMaster.non_interactive_answer = 'y'
+      end
+      global_option '-n', '--no', 'Run in non-interactive mode answering no to any prompts' do
+        StackMaster.non_interactive!
+        StackMaster.non_interactive_answer = 'n'
       end
 
       command :apply do |c|

--- a/lib/stack_master/cli.rb
+++ b/lib/stack_master/cli.rb
@@ -22,7 +22,7 @@ module StackMaster
       program :description, 'AWS Stack Management'
 
       global_option '-c', '--config FILE', 'Config file to use'
-      global_option '-f', '--force', 'Run in non-interactive mode, all prompts will be answered positively by default or according to the ANSWER environment variable' do
+      global_option '-f', '--force', 'Run in non-interactive mode, all prompts will be answered negatively by default' do
         StackMaster.non_interactive!
       end
 

--- a/lib/stack_master/prompter.rb
+++ b/lib/stack_master/prompter.rb
@@ -3,7 +3,12 @@ module StackMaster
     def ask?(question)
       StackMaster.stdout.print question
       answer = if StackMaster.interactive?
-        STDIN.getch.chomp
+        if StackMaster.stdin.tty?
+          StackMaster.stdin.getch.chomp
+        else
+          StackMaster.stdout.puts "STDOUT was not a TTY. Defaulting to no. To force yes use -f"
+          'n'
+        end
       else
         ENV.fetch('ANSWER') { 'y' }
       end

--- a/lib/stack_master/prompter.rb
+++ b/lib/stack_master/prompter.rb
@@ -2,10 +2,10 @@ module StackMaster
   module Prompter
     def ask?(question)
       StackMaster.stdout.print question
-      answer = if ENV['STUB_AWS']
-        ENV['ANSWER']
-      else
+      answer = if StackMaster.interactive?
         STDIN.getch.chomp
+      else
+        ENV.fetch('ANSWER') { 'y' }
       end
       StackMaster.stdout.puts
       answer == 'y'

--- a/lib/stack_master/prompter.rb
+++ b/lib/stack_master/prompter.rb
@@ -7,7 +7,7 @@ module StackMaster
           StackMaster.stdin.getch.chomp
         else
           StackMaster.stdout.puts
-          StackMaster.stdout.puts "STDOUT or STDIN was not a TTY. Defaulting to no. To force yes use -f"
+          StackMaster.stdout.puts "STDOUT or STDIN was not a TTY. Defaulting to no. To force yes use -y"
           'n'
         end
       else

--- a/lib/stack_master/prompter.rb
+++ b/lib/stack_master/prompter.rb
@@ -6,6 +6,7 @@ module StackMaster
         if StackMaster.stdin.tty? && StackMaster.stdout.tty?
           StackMaster.stdin.getch.chomp
         else
+          StackMaster.stdout.puts
           StackMaster.stdout.puts "STDOUT or STDIN was not a TTY. Defaulting to no. To force yes use -f"
           'n'
         end

--- a/lib/stack_master/prompter.rb
+++ b/lib/stack_master/prompter.rb
@@ -3,10 +3,10 @@ module StackMaster
     def ask?(question)
       StackMaster.stdout.print question
       answer = if StackMaster.interactive?
-        if StackMaster.stdin.tty?
+        if StackMaster.stdin.tty? && StackMaster.stdout.tty?
           StackMaster.stdin.getch.chomp
         else
-          StackMaster.stdout.puts "STDOUT was not a TTY. Defaulting to no. To force yes use -f"
+          StackMaster.stdout.puts "STDOUT or STDIN was not a TTY. Defaulting to no. To force yes use -f"
           'n'
         end
       else

--- a/lib/stack_master/prompter.rb
+++ b/lib/stack_master/prompter.rb
@@ -1,8 +1,8 @@
 module StackMaster
   module Prompter
     def ask?(question)
-      StackMaster.stdout.print question
       answer = if StackMaster.interactive?
+        StackMaster.stdout.print question
         if StackMaster.stdin.tty? && StackMaster.stdout.tty?
           StackMaster.stdin.getch.chomp
         else

--- a/lib/stack_master/prompter.rb
+++ b/lib/stack_master/prompter.rb
@@ -11,7 +11,7 @@ module StackMaster
           'n'
         end
       else
-        ENV.fetch('ANSWER') { 'y' }
+        StackMaster.non_interactive_answer
       end
       StackMaster.stdout.puts
       answer == 'y'

--- a/lib/stack_master/testing.rb
+++ b/lib/stack_master/testing.rb
@@ -5,3 +5,4 @@ Aws.config[:stub_responses] = true
 require 'stack_master/test_driver/cloud_formation'
 
 StackMaster.cloud_formation_driver = StackMaster::TestDriver::CloudFormation.new
+StackMaster.non_interactive!

--- a/spec/stack_master/commands/apply_spec.rb
+++ b/spec/stack_master/commands/apply_spec.rb
@@ -16,9 +16,8 @@ RSpec.describe StackMaster::Commands::Apply do
     allow(cf).to receive(:update_stack)
     allow(cf).to receive(:create_stack)
     allow(StackMaster::StackDiffer).to receive(:new).with(proposed_stack, stack).and_return double.as_null_object
-    allow(STDOUT).to receive(:print)
-    allow(STDIN).to receive(:getch).and_return('y')
     allow(StackMaster::StackEvents::Streamer).to receive(:stream)
+    allow(StackMaster).to receive(:interactive?).and_return(false)
   end
 
   def apply
@@ -77,6 +76,7 @@ RSpec.describe StackMaster::Commands::Apply do
       let(:template_body) do
         "{\"a\":\"#{big_string}\"}"
       end
+
       it 'exits with a message' do
         expect { apply }.to output(/The \(space compressed\) stack is larger than the limit set by AWS/).to_stdout
       end

--- a/spec/stack_master/prompter_spec.rb
+++ b/spec/stack_master/prompter_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe StackMaster::Prompter do
+  include StackMaster::Prompter
+
+  context 'when STDIN is not a TTY' do
+    before do
+      allow(StackMaster.stdin).to receive(:tty?).and_return(false)
+    end
+
+    it 'defaults to no and outputs info about -f' do
+      expect { ask?('blah') }.to output(/To force yes use -f/).to_stdout
+    end
+  end
+
+  context 'when STDOUT is not a TTY' do
+    before do
+      allow(StackMaster.stdout).to receive(:tty?).and_return(false)
+    end
+
+    it 'defaults to no and outputs info about -f' do
+      expect { ask?('blah') }.to output(/To force yes use -f/).to_stdout
+    end
+  end
+end

--- a/spec/stack_master/prompter_spec.rb
+++ b/spec/stack_master/prompter_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe StackMaster::Prompter do
       allow(StackMaster.stdin).to receive(:tty?).and_return(false)
     end
 
-    it 'defaults to no and outputs info about -f' do
-      expect { ask?('blah') }.to output(/To force yes use -f/).to_stdout
+    it 'defaults to no and outputs info about -y' do
+      expect { ask?('blah') }.to output(/To force yes use -y/).to_stdout
     end
   end
 
@@ -16,8 +16,8 @@ RSpec.describe StackMaster::Prompter do
       allow(StackMaster.stdout).to receive(:tty?).and_return(false)
     end
 
-    it 'defaults to no and outputs info about -f' do
-      expect { ask?('blah') }.to output(/To force yes use -f/).to_stdout
+    it 'defaults to no and outputs info about -y' do
+      expect { ask?('blah') }.to output(/To force yes use -y/).to_stdout
     end
   end
 end


### PR DESCRIPTION
Accepts `-y` to force a 'y' response to any prompt in StackMaster and cleans up features.

Fixes https://github.com/envato/stack_master/pull/64

Took inspiration from @lethalpaga's work on this here https://github.com/envato/stack_master/compare/master...lethalpaga:fix/interactive

cc @redterror