### PR TITLE
Allow commands to run on a single stack, multiple or all stacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,13 +251,16 @@ my_parameter:
 stack_master help # Display up to date docs on the commands available
 stack_master init # Initialises a directory structure and stack_master.yml file
 stack_master list # Lists stack definitions
-stack_master apply <region-or-alias> <stack-name> # Create or update a stack
-stack_master --yes apply <region-or-alias> <stack-name> # Create or update a stack non-interactively (forcing yes)
-stack_master diff <region-or-alias> <stack-name> # Display a stack tempalte and parameter diff
-stack_master delete <region-or-alias> <stack-name> # Delete a stack
-stack_master events <region-or-alias> <stack-name> # Display events for a stack
-stack_master outputs <region-or-alias> <stack-name> # Display outputs for a stack
-stack_master resources <region-or-alias> <stack-name> # Display outputs for a stack
+stack_master apply [region-or-alias] [stack-name] # Create or update a stack
+stack_master apply [region-or-alias] [stack-name] [region-or-alias] [stack-name] # Create or update multiple stacks
+stack_master apply [region-or-alias] # Create or update stacks in the given region
+stack_master apply # Create or update all stacks
+stack_master --yes apply [region-or-alias] [stack-name] # Create or update a stack non-interactively (forcing yes)
+stack_master diff [region-or-alias] [stack-name] # Display a stack tempalte and parameter diff
+stack_master delete [region-or-alias] [stack-name] # Delete a stack
+stack_master events [region-or-alias] [stack-name] # Display events for a stack
+stack_master outputs [region-or-alias] [stack-name] # Display outputs for a stack
+stack_master resources [region-or-alias] [stack-name] # Display outputs for a stack
 stack_master status # Displays the status of each stack
 ```
 

--- a/features/apply.feature
+++ b/features/apply.feature
@@ -91,6 +91,23 @@ Feature: Apply command
     And the output should not match /2020-10-29 00:00:00 \+[0-9]{4} myapp-vpc AWS::CloudFormation::Stack CREATE_COMPLETE/ 
     Then the exit status should be 0
 
+  Scenario: Run apply with region only and create 2 stacks
+    Given I stub the following stack events:
+      | stack_id | event_id | stack_name | logical_resource_id | resource_status | resource_type              | timestamp           |
+      | 1        | 1        | myapp-vpc  | TestSg              | CREATE_COMPLETE | AWS::EC2::SecurityGroup    | 2020-10-29 00:00:00 |
+      | 1        | 1        | myapp-vpc  | myapp-vpc           | CREATE_COMPLETE | AWS::CloudFormation::Stack | 2020-10-29 00:00:00 |
+      | 1        | 1        | myapp-web  | TestSg              | CREATE_COMPLETE | AWS::EC2::SecurityGroup    | 2020-10-29 00:00:00 |
+      | 1        | 1        | myapp-web  | myapp-web           | CREATE_COMPLETE | AWS::CloudFormation::Stack | 2020-10-29 00:00:00 |
+    When I run `stack_master apply us-east-1 --trace`
+    And the output should contain all of these lines:
+      | Stack diff:                                                                    |
+      | +    "Vpc": {                                                                  |
+      | Parameters diff:                                                               |
+      | KeyName: my-key                                                                |
+    And the output should match /2020-10-29 00:00:00 \+[0-9]{4} myapp-vpc AWS::CloudFormation::Stack CREATE_COMPLETE/
+    And the output should match /2020-10-29 00:00:00 \+[0-9]{4} myapp-web AWS::CloudFormation::Stack CREATE_COMPLETE/
+    Then the exit status should be 0
+
   Scenario: Run apply on an existing stack
     Given I stub the following stack events:
       | stack_id | event_id | stack_name | logical_resource_id | resource_status | resource_type              | timestamp           |

--- a/features/apply.feature
+++ b/features/apply.feature
@@ -104,6 +104,43 @@ Feature: Apply command
       | +    "Vpc": {                                                                  |
       | Parameters diff:                                                               |
       | KeyName: my-key                                                                |
+
+  Scenario: Run apply nothing and create 2 stacks
+    Given I stub the following stack events:
+      | stack_id | event_id | stack_name | logical_resource_id | resource_status | resource_type              | timestamp           |
+      | 1        | 1        | myapp-vpc  | TestSg              | CREATE_COMPLETE | AWS::EC2::SecurityGroup    | 2020-10-29 00:00:00 |
+      | 1        | 1        | myapp-vpc  | myapp-vpc           | CREATE_COMPLETE | AWS::CloudFormation::Stack | 2020-10-29 00:00:00 |
+      | 1        | 1        | myapp-web  | TestSg              | CREATE_COMPLETE | AWS::EC2::SecurityGroup    | 2020-10-29 00:00:00 |
+      | 1        | 1        | myapp-web  | myapp-web           | CREATE_COMPLETE | AWS::CloudFormation::Stack | 2020-10-29 00:00:00 |
+    When I run `stack_master apply --trace`
+    And the output should contain all of these lines:
+      | Stack diff:                                                                    |
+      | +    "Vpc": {                                                                  |
+      | Parameters diff:                                                               |
+      | KeyName: my-key                                                                |
+    And the output should match /2020-10-29 00:00:00 \+[0-9]{4} myapp-vpc AWS::CloudFormation::Stack CREATE_COMPLETE/
+    And the output should match /2020-10-29 00:00:00 \+[0-9]{4} myapp-web AWS::CloudFormation::Stack CREATE_COMPLETE/
+    Then the exit status should be 0
+    And the output should match /2020-10-29 00:00:00 \+[0-9]{4} myapp-vpc AWS::CloudFormation::Stack CREATE_COMPLETE/
+    And the output should match /2020-10-29 00:00:00 \+[0-9]{4} myapp-web AWS::CloudFormation::Stack CREATE_COMPLETE/
+    Then the exit status should be 0
+
+  Scenario: Run apply with 2 specific stacks and create 2 stacks
+    Given I stub the following stack events:
+      | stack_id | event_id | stack_name | logical_resource_id | resource_status | resource_type              | timestamp           |
+      | 1        | 1        | myapp-vpc  | TestSg              | CREATE_COMPLETE | AWS::EC2::SecurityGroup    | 2020-10-29 00:00:00 |
+      | 1        | 1        | myapp-vpc  | myapp-vpc           | CREATE_COMPLETE | AWS::CloudFormation::Stack | 2020-10-29 00:00:00 |
+      | 1        | 1        | myapp-web  | TestSg              | CREATE_COMPLETE | AWS::EC2::SecurityGroup    | 2020-10-29 00:00:00 |
+      | 1        | 1        | myapp-web  | myapp-web           | CREATE_COMPLETE | AWS::CloudFormation::Stack | 2020-10-29 00:00:00 |
+    When I run `stack_master apply us-east-1 myapp-vpc us-east-1 myapp-web --trace`
+    And the output should contain all of these lines:
+      | Stack diff:                                                                    |
+      | +    "Vpc": {                                                                  |
+      | Parameters diff:                                                               |
+      | KeyName: my-key                                                                |
+    And the output should match /2020-10-29 00:00:00 \+[0-9]{4} myapp-vpc AWS::CloudFormation::Stack CREATE_COMPLETE/
+    And the output should match /2020-10-29 00:00:00 \+[0-9]{4} myapp-web AWS::CloudFormation::Stack CREATE_COMPLETE/
+    Then the exit status should be 0
     And the output should match /2020-10-29 00:00:00 \+[0-9]{4} myapp-vpc AWS::CloudFormation::Stack CREATE_COMPLETE/
     And the output should match /2020-10-29 00:00:00 \+[0-9]{4} myapp-web AWS::CloudFormation::Stack CREATE_COMPLETE/
     Then the exit status should be 0

--- a/lib/stack_master/cli.rb
+++ b/lib/stack_master/cli.rb
@@ -33,7 +33,7 @@ module StackMaster
         c.example 'update a stack named myapp-vpc in us-east-1', 'stack_master apply us-east-1 myapp-vpc'
         c.action do |args, options|
           options.defaults config: default_config_file
-          execute_stack_command(StackMaster::Commands::Apply, args, options)
+          execute_stacks_command(StackMaster::Commands::Apply, args, options)
         end
       end
 
@@ -43,7 +43,7 @@ module StackMaster
         c.description = "Displays outputs for a stack"
         c.action do |args, options|
           options.defaults config: default_config_file
-          execute_stack_command(StackMaster::Commands::Outputs, args, options)
+          execute_stacks_command(StackMaster::Commands::Outputs, args, options)
         end
       end
 
@@ -69,7 +69,7 @@ module StackMaster
         c.example 'diff a stack named myapp-vpc in us-east-1', 'stack_master diff us-east-1 myapp-vpc'
         c.action do |args, options|
           options.defaults config: default_config_file
-          execute_stack_command(StackMaster::Commands::Diff, args, options)
+          execute_stacks_command(StackMaster::Commands::Diff, args, options)
         end
       end
 
@@ -83,7 +83,7 @@ module StackMaster
         c.option '--tail', 'Tail events'
         c.action do |args, options|
           options.defaults config: default_config_file
-          execute_stack_command(StackMaster::Commands::Events, args, options)
+          execute_stacks_command(StackMaster::Commands::Events, args, options)
         end
       end
 
@@ -93,7 +93,7 @@ module StackMaster
         c.description = "Shows stack resources"
         c.action do |args, options|
           options.defaults config: default_config_file
-          execute_stack_command(StackMaster::Commands::Resources, args, options)
+          execute_stacks_command(StackMaster::Commands::Resources, args, options)
         end
       end
 
@@ -116,7 +116,7 @@ module StackMaster
         c.example 'validate a stack named myapp-vpc in us-east-1', 'stack_master validate us-east-1 myapp-vpc'
         c.action do |args, options|
           options.defaults config: default_config_file
-          execute_stack_command(StackMaster::Commands::Validate, args, options)
+          execute_stacks_command(StackMaster::Commands::Validate, args, options)
         end
       end
 
@@ -169,22 +169,20 @@ module StackMaster
       exit 1
     end
 
-    def execute_stack_command(command, args, options)
-      unless args.size == 2
-        say "Invalid arguments. stack_master #{command.name.split('::').last.downcase} [region] [stack_name]"
-        return
-      end
+    def execute_stacks_command(command, args, options)
       config = load_config(options.config)
-      aliased_region, stack_name = args
-      region = Utils.underscore_to_hyphen(config.unalias_region(aliased_region))
-      stack_name = Utils.underscore_to_hyphen(stack_name)
-      StackMaster.cloud_formation_driver.set_region(region)
-      stack_definition ||= config.find_stack(region, stack_name)
-      if stack_definition.nil?
-        say "Could not find stack definition #{stack_name} in region #{region}"
-        return
+      args.each_slice(2) do |aliased_region, stack_name|
+        region = Utils.underscore_to_hyphen(config.unalias_region(aliased_region))
+        stack_name = Utils.underscore_to_hyphen(stack_name)
+        stack_definitions = config.filter(region, stack_name)
+        if stack_definitions.empty?
+          say "Could not find stack definition #{stack_name} in region #{region}"
+        end
+        stack_definitions.each do |stack_definition|
+          StackMaster.cloud_formation_driver.set_region(stack_definition.region)
+          command.perform(config, stack_definition, options)
+        end
       end
-      command.perform(config, stack_definition, options)
     end
   end
 end

--- a/lib/stack_master/cli.rb
+++ b/lib/stack_master/cli.rb
@@ -171,6 +171,7 @@ module StackMaster
 
     def execute_stacks_command(command, args, options)
       config = load_config(options.config)
+      args = [nil, nil] if args.size == 0
       args.each_slice(2) do |aliased_region, stack_name|
         region = Utils.underscore_to_hyphen(config.unalias_region(aliased_region))
         stack_name = Utils.underscore_to_hyphen(stack_name)

--- a/lib/stack_master/config.rb
+++ b/lib/stack_master/config.rb
@@ -46,8 +46,8 @@ module StackMaster
 
     def filter(region = nil, stack_name = nil)
       @stacks.select do |s|
-        (s.region == region || region.nil? || s.region == region.gsub('_', '-')) &&
-          (s.stack_name == stack_name || stack_name.blank? || s.stack_name == stack_name.gsub('_', '-'))
+        (region.blank? || s.region == region || s.region == region.gsub('_', '-')) &&
+          (stack_name.blank? || s.stack_name == stack_name || s.stack_name == stack_name.gsub('_', '-'))
       end
     end
 

--- a/lib/stack_master/config.rb
+++ b/lib/stack_master/config.rb
@@ -44,11 +44,15 @@ module StackMaster
       load_config
     end
 
-    def find_stack(region, stack_name)
-      @stacks.find do |s|
-        (s.region == region || s.region == region.gsub('_', '-')) &&
-          (s.stack_name == stack_name || s.stack_name == stack_name.gsub('_', '-'))
+    def filter(region = nil, stack_name = nil)
+      @stacks.select do |s|
+        (s.region == region || region.nil? || s.region == region.gsub('_', '-')) &&
+          (s.stack_name == stack_name || stack_name.blank? || s.stack_name == stack_name.gsub('_', '-'))
       end
+    end
+
+    def find_stack(region, stack_name)
+      filter(region, stack_name).first
     end
 
     def unalias_region(region)

--- a/spec/stack_master/config_spec.rb
+++ b/spec/stack_master/config_spec.rb
@@ -31,14 +31,33 @@ RSpec.describe StackMaster::Config do
     end
   end
 
-  it 'returns an object that can find stack definitions' do
-    stack = loaded_config.find_stack('us-east-1', 'myapp-vpc')
-    expect(stack).to eq(myapp_vpc_definition)
+  describe '#find_stack' do
+    it 'returns an object that can find stack definitions' do
+      stack = loaded_config.find_stack('us-east-1', 'myapp-vpc')
+      expect(stack).to eq(myapp_vpc_definition)
+    end
+
+    it 'can find things with underscores instead of hyphens' do
+      stack = loaded_config.find_stack('us_east_1', 'myapp_vpc')
+      expect(stack).to eq(myapp_vpc_definition)
+    end
   end
 
-  it 'can find things with underscores instead of hyphens' do
-    stack = loaded_config.find_stack('us_east_1', 'myapp_vpc')
-    expect(stack).to eq(myapp_vpc_definition)
+  describe '#filter' do
+    it 'returns a list of stack definitions' do
+      stack = loaded_config.filter('us-east-1', 'myapp-vpc')
+      expect(stack).to eq([myapp_vpc_definition])
+    end
+
+    it 'can filter by region only' do
+      stacks = loaded_config.filter('us-east-1')
+      expect(stacks.size).to eq 2
+    end
+
+    it 'can return all stack definitions with no filters' do
+      stacks = loaded_config.filter
+      expect(stacks.size).to eq 4
+    end
   end
 
   it 'exposes the base_dir' do


### PR DESCRIPTION
Allows running commands on multiple or all stacks. Examples:

```
stack_master diff # diffs all stacks
stack_master apply # applies all stacks
stack_master apply us-east-1 # applies all stacks in us-east-1
stack_master apply us-east-1 my-stack us-east-1 my-other stack # applies the two stacks. I need to add a cucumber scenario for this.
```

Next up will be adding a `--changed` option to only execute commands on changed stacks. This will be useful to run on CI to post stack diffs to PRs. `stack_master diff --changed`.