### PR TITLE
Allow list to output in a parsable format

### DIFF
--- a/features/list.feature
+++ b/features/list.feature
@@ -1,0 +1,34 @@
+Feature: List command
+
+  Background:
+    Given a file named "stack_master.yml" with:
+      """
+      stacks:
+        us_east_1:
+          stack1:
+            template: stack1.json
+          stack2:
+            template: stack2.json
+          stack3:
+            template: stack3.json
+      """
+
+  Scenario: Run list command and get a list of stacks
+    When I run `stack_master list` interactively
+    Then the output should contain all of these lines:
+      | REGION    | STACK_NAME|
+      | ----------|---------- |
+      | us-east-1 | stack1    |
+      | us-east-1 | stack2    |
+      | us-east-1 | stack3    |
+
+    And the exit status should be 0
+
+  Scenario: Run list command and get machine-readable list of stacks
+    When I run `stack_master list --machine-readable` interactively
+    Then the output should contain all of these lines:
+      |us-east-1 stack1|
+      |us-east-1 stack2|
+      |us-east-1 stack3|
+
+    And the exit status should be 0

--- a/lib/stack_master/cli.rb
+++ b/lib/stack_master/cli.rb
@@ -98,11 +98,12 @@ module StackMaster
         c.syntax = 'stack_master list'
         c.summary = 'List stack definitions'
         c.description = 'List stack definitions'
+        c.option '--machine-readable', 'Output region and stack space delimited without headers'
         c.action do |args, options|
           options.defaults config: default_config_file
           say "Invalid arguments." if args.size > 0
           config = load_config(options.config)
-          StackMaster::Commands::ListStacks.perform(config)
+          StackMaster::Commands::ListStacks.perform(config, options)
         end
       end
 

--- a/lib/stack_master/commands/list_stacks.rb
+++ b/lib/stack_master/commands/list_stacks.rb
@@ -5,13 +5,20 @@ module StackMaster
       include Commander::UI
       include StackMaster::Commands::TerminalHelper
 
-      def initialize(config)
+      def initialize(config, options = {})
         @config = config
+        @options = options
       end
 
       def perform
-        tp.set :max_width, self.window_size
-        tp @config.stacks, :region, :stack_name
+        if @options.machine_readable
+          @config.stacks.each do |stack|
+            StackMaster.stdout.puts "#{stack.region} #{stack.stack_name}"
+          end
+        else
+          tp.set :max_width, self.window_size
+          tp @config.stacks, :region, :stack_name
+        end
       end
     end
   end


### PR DESCRIPTION
So that a script can output a list of stacks and operate on each one