### PR TITLE
Parameter values must be strings

### DIFF
--- a/lib/stack_master/parameter_resolver.rb
+++ b/lib/stack_master/parameter_resolver.rb
@@ -43,6 +43,7 @@ module StackMaster
 
     def resolve_parameter_value(key, parameter_value)
       return parameter_value.to_s if Numeric === parameter_value
+      return parameter_value.join(',') if Array === parameter_value
       return parameter_value unless Hash === parameter_value
       validate_parameter_value!(key, parameter_value)
 

--- a/lib/stack_master/resolver_array.rb
+++ b/lib/stack_master/resolver_array.rb
@@ -7,9 +7,9 @@ module StackMaster
       end
 
       def resolve(values)
-        value_list = Array(values).map do |value|
+        Array(values).map do |value|
           resolver_class.new(@config, @stack_definition).resolve(value)
-        end
+        end.join(',')
       end
 
       def resolver_class

--- a/spec/stack_master/parameter_resolver_spec.rb
+++ b/spec/stack_master/parameter_resolver_spec.rb
@@ -34,6 +34,10 @@ RSpec.describe StackMaster::ParameterResolver do
     expect(resolve(param1: 2)).to eq(param1: '2')
   end
 
+  it 'joins arrays into comma separated strings' do
+    expect(resolve(param1: [1, 2])).to eq(param1: '1,2')
+  end
+
   it 'it throws an error when the hash contains more than one key' do
     expect {
       resolve(param: { nested1: 'value1', nested2: 'value2' })

--- a/spec/stack_master/parameter_resolvers/security_groups_spec.rb
+++ b/spec/stack_master/parameter_resolvers/security_groups_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe StackMaster::ParameterResolvers::SecurityGroups do
 
     context 'when given a single SG name' do
       it "resolves the security group" do
-        expect(resolver.resolve(sg_name)).to eq [sg_id]
+        expect(resolver.resolve(sg_name)).to eq sg_id
       end
     end
 
@@ -25,7 +25,7 @@ RSpec.describe StackMaster::ParameterResolvers::SecurityGroups do
       end
 
       it "resolves the security groups" do
-        expect(resolver.resolve([sg_name, sg_name2])).to eq [sg_id, sg_id2]
+        expect(resolver.resolve([sg_name, sg_name2])).to eq "#{sg_id},#{sg_id2}"
       end
     end
   end


### PR DESCRIPTION
Converts arrays into strings whether supplied through the resolver array or as a list in YAML.

Ref: https://github.com/aws/aws-sdk-ruby/blob/master/aws-sdk-core/apis/cloudformation/2010-05-15/api-2.json#L579