### PR TITLE
Complain when parameters have nil values

### DIFF
--- a/features/apply.feature
+++ b/features/apply.feature
@@ -15,6 +15,10 @@ Feature: Apply command
       """
       KeyName: my-key
       """
+    And a file named "parameters/myapp_web.yml" with:
+      """
+      VpcId: vpc-blah
+      """
     And a directory named "templates"
     And a file named "templates/myapp_vpc.rb" with:
       """

--- a/lib/stack_master/commands/apply.rb
+++ b/lib/stack_master/commands/apply.rb
@@ -14,6 +14,13 @@ module StackMaster
 
       def perform
         diff_stacks
+        if @proposed_stack.empty_parameters?
+          StackMaster.stderr.puts "Empty/blank parameters detected, ensure values exist for those parameters. Parameters will be read from the following locations:"
+          @stack_definition.parameter_files.each do |parameter_file|
+            StackMaster.stderr.puts " - #{parameter_file}"
+          end
+          return
+        end
         unless ask?("Continue and apply the stack (y/n)? ")
           StackMaster.stdout.puts "Stack update aborted"
           return

--- a/lib/stack_master/commands/apply.rb
+++ b/lib/stack_master/commands/apply.rb
@@ -14,7 +14,7 @@ module StackMaster
 
       def perform
         diff_stacks
-        if @proposed_stack.empty_parameters?
+        if @proposed_stack.missing_parameters?
           StackMaster.stderr.puts "Empty/blank parameters detected, ensure values exist for those parameters. Parameters will be read from the following locations:"
           @stack_definition.parameter_files.each do |parameter_file|
             StackMaster.stderr.puts " - #{parameter_file}"

--- a/lib/stack_master/stack.rb
+++ b/lib/stack_master/stack.rb
@@ -40,7 +40,7 @@ module StackMaster
       template_default_parameters.merge(parameters)
     end
 
-    def empty_parameters?
+    def missing_parameters?
       parameters_with_defaults.any? do |key, value|
         value == nil
       end

--- a/lib/stack_master/stack.rb
+++ b/lib/stack_master/stack.rb
@@ -40,6 +40,12 @@ module StackMaster
       template_default_parameters.merge(parameters)
     end
 
+    def empty_parameters?
+      parameters_with_defaults.any? do |key, value|
+        value == nil
+      end
+    end
+
     def self.find(region, stack_name)
       cf = StackMaster.cloud_formation_driver
       cf_stack = cf.describe_stacks(stack_name: stack_name).stacks.first

--- a/spec/stack_master/commands/apply_spec.rb
+++ b/spec/stack_master/commands/apply_spec.rb
@@ -99,4 +99,23 @@ RSpec.describe StackMaster::Commands::Apply do
       end
     end
   end
+
+  context 'one or more parameters are empty' do
+    let(:stack) { StackMaster::Stack.new(stack_id: '1', parameters: parameters) }
+    let(:parameters) { { 'param_1' => nil } }
+
+    it "doesn't allow apply" do
+      expect { apply }.to_not output(/Continue and apply the stack/).to_stderr
+    end
+
+    it 'outputs a description of the problem' do
+      expect { apply }.to output(/Empty\/blank parameters detected/).to_stderr
+    end
+
+    it 'outputs where param files are loaded from' do
+      stack_definition.parameter_files.each do |parameter_file|
+        expect { apply }.to output(/#{parameter_file}/).to_stderr
+      end
+    end
+  end
 end

--- a/spec/stack_master/commands/apply_spec.rb
+++ b/spec/stack_master/commands/apply_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe StackMaster::Commands::Apply do
   let(:notification_arn) { 'test_arn' }
   let(:stack_definition) { StackMaster::StackDefinition.new(base_dir: '/base_dir', region: region, stack_name: stack_name) }
   let(:template_body) { '{}' }
-  let(:proposed_stack) { StackMaster::Stack.new(template_body: template_body, tags: { 'environment' => 'production' } , parameters: { 'param_1' => 'hello' }, notification_arns: [notification_arn], stack_policy_body: stack_policy_body ) }
+  let(:parameters) { { 'param_1' => 'hello' } }
+  let(:proposed_stack) { StackMaster::Stack.new(template_body: template_body, tags: { 'environment' => 'production' } , parameters: parameters, notification_arns: [notification_arn], stack_policy_body: stack_policy_body ) }
   let(:stack_policy_body) { '{}' }
 
   before do
@@ -105,7 +106,7 @@ RSpec.describe StackMaster::Commands::Apply do
     let(:parameters) { { 'param_1' => nil } }
 
     it "doesn't allow apply" do
-      expect { apply }.to_not output(/Continue and apply the stack/).to_stderr
+      expect { apply }.to_not output(/Continue and apply the stack/).to_stdout
     end
 
     it 'outputs a description of the problem' do

--- a/spec/stack_master/stack_spec.rb
+++ b/spec/stack_master/stack_spec.rb
@@ -154,4 +154,21 @@ RSpec.describe StackMaster::Stack do
       expect(little_stack.too_big?).to be_falsey
     end
   end
+
+  describe '#empty_parameters?' do
+    subject { stack.empty_parameters? }
+    let(:stack) { StackMaster::Stack.new(parameters: parameters, template_body: '{}') }
+
+    context 'when a parameter has a nil value' do
+      let(:parameters) { { 'my_param' => nil } }
+
+      it { should eq true }
+    end
+
+    context 'when no parameers have a nil value' do
+      let(:parameters) { { 'my_param' => '1' } }
+
+      it { should eq false }
+    end
+  end
 end

--- a/spec/stack_master/stack_spec.rb
+++ b/spec/stack_master/stack_spec.rb
@@ -155,8 +155,9 @@ RSpec.describe StackMaster::Stack do
     end
   end
 
-  describe '#empty_parameters?' do
-    subject { stack.empty_parameters? }
+  describe '#missing_parameters?' do
+    subject { stack.missing_parameters? }
+
     let(:stack) { StackMaster::Stack.new(parameters: parameters, template_body: '{}') }
 
     context 'when a parameter has a nil value' do


### PR DESCRIPTION
This will cause the update to fail, so this outputs a message indicating where to check for parameter files.