### PR TITLE
Fix invalid change set name

### DIFF
--- a/lib/stack_master/change_set.rb
+++ b/lib/stack_master/change_set.rb
@@ -7,7 +7,7 @@ module StackMaster
     ]
 
     def self.generate_change_set_name
-      'StackMaster' + Time.now.strftime('%Y-%m-%e-%H%M-%s')
+      'StackMaster' + Time.now.strftime('%Y-%m-%d-%H%M-%s')
     end
 
     def self.create(create_options)

--- a/spec/stack_master/change_set_spec.rb
+++ b/spec/stack_master/change_set_spec.rb
@@ -4,6 +4,14 @@ RSpec.describe StackMaster::ChangeSet do
   let(:stack_name) { 'myapp-vpc' }
   let(:change_set_name) { 'changeset-123' }
 
+  describe '.generate_change_set_name' do
+    context 'valid name' do
+      it 'creates a valid name' do
+        expect(StackMaster::ChangeSet.generate_change_set_name).to match(/^[a-zA-Z][-a-zA-Z0-9]*$/)
+      end
+    end
+  end
+
   describe '.create' do
     before do
       allow(StackMaster::ChangeSet).to receive(:generate_change_set_name).and_return(change_set_name)


### PR DESCRIPTION
As reported in #93, an invalid ChangeSetName is generated on days of the month <10.  This is due to an incorrect pattern being passed to `strftime`.

Also adds a test.

/cc @stevehodgkiss 
