### PR TITLE
Handle Template Compilation Errors

### DIFF
--- a/lib/stack_master/command.rb
+++ b/lib/stack_master/command.rb
@@ -35,7 +35,7 @@ module StackMaster
 
     def error_message(e)
       msg = "#{e.class} #{e.message}"
-      msg = "\n Caused by: #{e.cause.class} #{e.cause.message}" if e.cause
+      msg << "\n Caused by: #{e.cause.class} #{e.cause.message}" if e.cause
       msg
     end
 

--- a/lib/stack_master/command.rb
+++ b/lib/stack_master/command.rb
@@ -22,7 +22,7 @@ module StackMaster
         catch(:halt) do
           super
         end
-      rescue Aws::CloudFormation::Errors::ServiceError => e
+      rescue Aws::CloudFormation::Errors::ServiceError, TemplateCompiler::TemplateCompilationFailed => e
         failed "#{e.class} #{e.message}"
       end
     end

--- a/lib/stack_master/command.rb
+++ b/lib/stack_master/command.rb
@@ -23,7 +23,7 @@ module StackMaster
           super
         end
       rescue Aws::CloudFormation::Errors::ServiceError, TemplateCompiler::TemplateCompilationFailed => e
-        failed "#{e.class} #{e.message}"
+        failed error_message(e)
       end
     end
 
@@ -32,6 +32,12 @@ module StackMaster
     end
 
     private
+
+    def error_message(e)
+      msg = "#{e.class} #{e.message}"
+      msg = "\n Caused by: #{e.cause.class} #{e.cause.message}" if e.cause
+      msg
+    end
 
     def failed(message = nil)
       StackMaster.stderr.puts(message) if message

--- a/lib/stack_master/template_compiler.rb
+++ b/lib/stack_master/template_compiler.rb
@@ -4,7 +4,7 @@ module StackMaster
 
     def self.compile(config, template_file_path)
       template_compiler_for_file(template_file_path, config).compile(template_file_path)
-    rescue Exception
+    rescue StandardError
       raise TemplateCompilationFailed.new("Failed to compile #{template_file_path}.")
     end
 

--- a/lib/stack_master/template_compiler.rb
+++ b/lib/stack_master/template_compiler.rb
@@ -1,8 +1,11 @@
 module StackMaster
   class TemplateCompiler
+    class TemplateCompilationFailed < RuntimeError; end
 
     def self.compile(config, template_file_path)
       template_compiler_for_file(template_file_path, config).compile(template_file_path)
+    rescue Exception
+      raise TemplateCompilationFailed.new("Failed to compile #{template_file_path}.")
     end
 
     def self.register(name, klass)

--- a/lib/stack_master/template_compiler.rb
+++ b/lib/stack_master/template_compiler.rb
@@ -4,7 +4,7 @@ module StackMaster
 
     def self.compile(config, template_file_path)
       template_compiler_for_file(template_file_path, config).compile(template_file_path)
-    rescue StandardError
+    rescue
       raise TemplateCompilationFailed.new("Failed to compile #{template_file_path}.")
     end
 

--- a/lib/stack_master/template_compiler.rb
+++ b/lib/stack_master/template_compiler.rb
@@ -1,6 +1,6 @@
 module StackMaster
   class TemplateCompiler
-    class TemplateCompilationFailed < RuntimeError; end
+    TemplateCompilationFailed = Class.new(RuntimeError)
 
     def self.compile(config, template_file_path)
       template_compiler_for_file(template_file_path, config).compile(template_file_path)

--- a/spec/stack_master/command_spec.rb
+++ b/spec/stack_master/command_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe StackMaster::Command do
     end
   end
 
-  context 'when a CF error occurs' do
+  context 'when a template compilation error occurs' do
     it 'outputs the message' do
       error_proc = proc {
         raise Aws::CloudFormation::Errors::ServiceError.new('a', 'the message')

--- a/spec/stack_master/command_spec.rb
+++ b/spec/stack_master/command_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe StackMaster::Command do
     end
   end
 
-  context 'when a template compilation error occurs' do
+  context 'when a CF error occurs' do
     it 'outputs the message' do
       error_proc = proc {
         raise Aws::CloudFormation::Errors::ServiceError.new('a', 'the message')
@@ -46,7 +46,7 @@ RSpec.describe StackMaster::Command do
     end
   end
 
-  context 'when a CF error occurs' do
+  context 'when a template compilation error occurs' do
     it 'outputs the message' do
       error_proc = proc {
         raise StackMaster::TemplateCompiler::TemplateCompilationFailed.new('the message')

--- a/spec/stack_master/command_spec.rb
+++ b/spec/stack_master/command_spec.rb
@@ -45,4 +45,13 @@ RSpec.describe StackMaster::Command do
       expect { command_class.perform(error_proc) }.to output(/the message/).to_stderr
     end
   end
+
+  context 'when a CF error occurs' do
+    it 'outputs the message' do
+      error_proc = proc {
+        raise StackMaster::TemplateCompiler::TemplateCompilationFailed.new('the message')
+      }
+      expect { command_class.perform(error_proc) }.to output(/the message/).to_stderr
+    end
+  end
 end

--- a/spec/stack_master/command_spec.rb
+++ b/spec/stack_master/command_spec.rb
@@ -53,5 +53,14 @@ RSpec.describe StackMaster::Command do
       }
       expect { command_class.perform(error_proc) }.to output(/the message/).to_stderr
     end
+
+    it 'outputs the exception\'s cause' do
+      exception_with_cause = StackMaster::TemplateCompiler::TemplateCompilationFailed.new('the message')
+      allow(exception_with_cause).to receive(:cause).and_return(RuntimeError.new('the cause message'))
+      error_proc = proc {
+        raise exception_with_cause
+      }
+      expect { command_class.perform(error_proc) }.to output(/Caused by: RuntimeError the cause message/).to_stderr
+    end
   end
 end

--- a/spec/stack_master/template_compiler_spec.rb
+++ b/spec/stack_master/template_compiler_spec.rb
@@ -16,6 +16,16 @@ RSpec.describe StackMaster::TemplateCompiler do
         expect(TestTemplateCompiler).to receive(:compile).with(template_file_path)
         StackMaster::TemplateCompiler.compile(config, template_file_path)
       end
+
+      context 'when template compilation fails' do
+        before { allow(TestTemplateCompiler).to receive(:compile).and_raise(RuntimeError) }
+
+        it 'raise TemplateCompilationFailed exception' do
+          expect{ StackMaster::TemplateCompiler.compile(config, template_file_path)
+          }.to raise_error(
+                 StackMaster::TemplateCompiler::TemplateCompilationFailed,"Failed to compile #{template_file_path}.")
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Right now the application would just crash if there is an template compilation error. This PR adds some error handling that deals with template compilation errors, so the application will output an error and shutdown gracefully if a template compilation error was to happen.