### PR TITLE
Make template compilers configurable by user

### DIFF
--- a/lib/stack_master/config.rb
+++ b/lib/stack_master/config.rb
@@ -42,7 +42,7 @@ module StackMaster
       end
       @region_defaults = normalise_region_defaults(config.fetch('region_defaults', {}))
       @stacks = []
-      @template_compilers = default_template_compilers
+      load_template_compilers(config)
       load_config
     end
 
@@ -62,6 +62,21 @@ module StackMaster
     end
 
     private
+    def load_template_compilers config
+      @template_compilers = {}
+      populate_template_compilers(config.fetch('template_compilers', {}))
+      merge_defaults_to_user_defined_compilers
+    end
+
+    def merge_defaults_to_user_defined_compilers
+      @template_compilers = default_template_compilers.merge(@template_compilers)
+    end
+
+    def populate_template_compilers user_defined_compilers
+      user_defined_compilers.each do |key, val|
+        @template_compilers[key.to_sym] = val.to_sym
+      end
+    end
 
     def default_template_compilers
       {

--- a/lib/stack_master/config.rb
+++ b/lib/stack_master/config.rb
@@ -62,7 +62,7 @@ module StackMaster
     end
 
     private
-    def load_template_compilers config
+    def load_template_compilers(config)
       @template_compilers = {}
       populate_template_compilers(config.fetch('template_compilers', {}))
       merge_defaults_to_user_defined_compilers

--- a/spec/fixtures/stack_master.yml
+++ b/spec/fixtures/stack_master.yml
@@ -4,6 +4,8 @@ region_aliases:
 stack_defaults:
   tags:
     application: my-awesome-blog
+template_compilers:
+  rb: ruby_dsl
 region_defaults:
   us_east_1:
     tags:

--- a/spec/stack_master/config_spec.rb
+++ b/spec/stack_master/config_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe StackMaster::Config do
     )
   }
 
-  context ".load!" do
+  describe ".load!" do
     it "fails to load the config if no stack_master.yml in parent directories" do
       expect { StackMaster::Config.load!('stack_master.yml') }.to raise_error Errno::ENOENT
     end

--- a/spec/stack_master/config_spec.rb
+++ b/spec/stack_master/config_spec.rb
@@ -70,6 +70,16 @@ RSpec.describe StackMaster::Config do
     })
   end
 
+  it 'loads template compiler mappings' do
+    expect(loaded_config.template_compilers).to eq({
+                                                     rb: :ruby_dsl,
+                                                     json: :json,
+                                                     yml: :yaml,
+                                                     yaml: :yaml,
+
+                                                   })
+  end
+
   it 'loads region defaults' do
     expect(loaded_config.region_defaults).to eq({
       'us-east-1' => {


### PR DESCRIPTION
## Context
We are going to add support for [Cfndsl](https://github.com/stevenjack/cfndsl) in a future PR. And this means that there is going to be two possible template compilers for the .rb files. Hence we need template compiler to file type mapping, to be configurable.

## Change
Let users configure what template compiler is used for a given file extension.

Related documentation will be added in the PR that introduce Cfndsl.