### PR TITLE
Stop dotgpg from complaining.

### DIFF
--- a/lib/stack_master/parameter_resolvers/secret.rb
+++ b/lib/stack_master/parameter_resolvers/secret.rb
@@ -26,6 +26,7 @@ module StackMaster
       end
 
       def decrypt_with_dotgpg
+        Dotgpg.interactive = true
         dir = Dotgpg::Dir.closest(secret_file_path)
         stream = StringIO.new
         dir.decrypt(secret_path_relative_to_base, stream)


### PR DESCRIPTION
Without this when I tried to use the secret resolver, I got:

```
Andrews-MacBook-Pro:infrastructure andrewjhumphrey$ sm apply production market-docs
Executing apply on market-docs in us-east-1
error: You must set Dotgpg.password or Dotgpg.interactive. Use --trace to view backtrace
```

spewed at me..

my stack_master.yml had the following relevant (I think) fragment:

```
region_defaults:
  us-east-1:
    secret_file: production.yml.gpg
    tags:
      environment: production
```