### PR TITLE
Remove Hard Dependencies on Template Compilation Related Gems

### DIFF
--- a/lib/stack_master/template_compilers/cfndsl.rb
+++ b/lib/stack_master/template_compilers/cfndsl.rb
@@ -2,9 +2,19 @@ module StackMaster::TemplateCompilers
   class Cfndsl
 
     def self.compile(template_file_path)
-      require 'cfndsl'
+      load_cfndsl
       CfnDsl.eval_file_with_extras(template_file_path).to_json
     end
+
+    def self.load_cfndsl
+      require 'cfndsl'
+    rescue LoadError => e
+      StackMaster.stderr.puts(CFNDSL_LOAD_ERROR_MSG)
+      raise e
+    end
+    private_class_method :load_cfndsl
+
+    CFNDSL_LOAD_ERROR_MSG='Couldn\'t load cfndsl. Make sure you have the cfndsl gem installed, if you want to use cfndsl templates with SM.'
 
     StackMaster::TemplateCompiler.register(:cfndsl, self)
   end

--- a/stack_master.gemspec
+++ b/stack_master.gemspec
@@ -36,5 +36,4 @@ Gem::Specification.new do |spec|
   spec.add_dependency "table_print"
   spec.add_dependency "dotgpg"
   spec.add_dependency "deep_merge"
-  spec.add_dependency "cfndsl"
 end


### PR DESCRIPTION
## Context

> Currently we have hard dependencies on sparkleformation and cfndsl, although some users of SM will never use them or the associated functionality. I wonder if we could not have a hard dependency on them, check for them if the user attempt to use them, then complain and fail if they don't have them (+ask them to install them first if they want to use whatever template they attempted to). 

Refer the conversation at: https://github.com/envato/stack_master/pull/99