### PR TITLE
Ensure that aws-sdk must be newer than 2.2.31

### DIFF
--- a/stack_master.gemspec
+++ b/stack_master.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "ruby-progressbar"
   spec.add_dependency "commander"
   spec.add_dependency "virtus"
-  spec.add_dependency "aws-sdk", ">= 2.2.31"
+  spec.add_dependency "aws-sdk", "~> 2.2.31"
   spec.add_dependency "diffy"
   spec.add_dependency "colorize"
   spec.add_dependency "activesupport"

--- a/stack_master.gemspec
+++ b/stack_master.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "ruby-progressbar"
   spec.add_dependency "commander"
   spec.add_dependency "virtus"
-  spec.add_dependency "aws-sdk", "~> 2.1"
+  spec.add_dependency "aws-sdk", ">= 2.2.31"
   spec.add_dependency "diffy"
   spec.add_dependency "colorize"
   spec.add_dependency "activesupport"


### PR DESCRIPTION
according to CHANGELOG of aws-sdk, the CreateChangeSet function was introduced since 2.2.31