### PR TITLE
Fix SNS topic name doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Looks up an SNS topic by name and returns the ARN.
 
 ```yaml
 notification_topic:
-  sns_topic: PagerDuty
+  sns_topic_name: PagerDuty
 ```
 
 ### Latest AMI by Tag


### PR DESCRIPTION
The correct parameter resolver should be sns_topic_name rather than
sns_topic

/cc @stevehodgkiss