### PR TITLE
Add support for user data files in sparkleformation templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,23 @@ my_parameter:
     - value2
 ```
 
+## User Data Files in SparkleFormation templates
+
+An extension to SparkleFormation is the `user_data_file!` method, which evaluates templates in `templates/user_data/[file_name]`. Most of the usual SparkleFormation methods are available in user data templates. Example:
+
+```
+# templates/user_data/app.erb
+REGION=<%= region! %>
+ROLE=<%= role %>
+```
+
+And used like this in SparkleFormation templates:
+
+```
+# templates/app.rb
+  user_data user_data_file!('app.erb', role: :worker)
+```
+
 ## Commands
 
 ```bash

--- a/lib/stack_master.rb
+++ b/lib/stack_master.rb
@@ -12,6 +12,7 @@ require 'dotgpg'
 require 'ruby-progressbar'
 
 require "stack_master/ctrl_c"
+require "stack_master/sparkle_formation/user_data_file"
 require "stack_master/command"
 require "stack_master/version"
 require "stack_master/stack"

--- a/lib/stack_master/sparkle_formation/user_data_file.rb
+++ b/lib/stack_master/sparkle_formation/user_data_file.rb
@@ -22,7 +22,22 @@ class SparkleFormation
       def _user_data_file(file_name)
         file_path = File.join(::SparkleFormation.sparkle_path, 'user_data', file_name)
         template = File.read(file_path)
-        base64!(join!(SfEruby.new(template).evaluate(self)))
+
+        compiled_template = SfEruby.new(template).evaluate(self)
+        formatted_cf_template = compiled_template.flat_map do |lines|
+          if String === lines
+            newlines = []
+            lines.count("\n").times do
+              newlines << "\n"
+            end
+            lines.split("\n").map do |line|
+              "#{line}#{newlines.pop}"
+            end
+          else
+            lines
+          end
+        end
+        base64!(join!(formatted_cf_template))
       rescue Errno::ENOENT => e
         Kernel.raise UserDataFileNotFound, "Could not find user data file at path: #{file_path}"
       end

--- a/lib/stack_master/sparkle_formation/user_data_file.rb
+++ b/lib/stack_master/sparkle_formation/user_data_file.rb
@@ -80,11 +80,11 @@ module StackMaster
       def _user_data_file(file_name, vars = {})
         file_path = File.join(::SparkleFormation.sparkle_path, 'user_data', file_name)
         template = File.read(file_path)
-        template_context = StackMaster::SparkleFormation::TemplateContext.build(vars)
-        compiled_template = StackMaster::SparkleFormation::SfEruby.new(template).evaluate(template_context)
-        base64!(join!(StackMaster::SparkleFormation::CloudFormationLineFormatter.format(compiled_template)))
+        template_context = TemplateContext.build(vars)
+        compiled_template = SfEruby.new(template).evaluate(template_context)
+        base64!(join!(CloudFormationLineFormatter.format(compiled_template)))
       rescue Errno::ENOENT => e
-        Kernel.raise StackMaster::SparkleFormation::UserDataFileNotFound, "Could not find user data file at path: #{file_path}"
+        Kernel.raise UserDataFileNotFound, "Could not find user data file at path: #{file_path}"
       end
       alias_method :user_data_file!, :_user_data_file
     end

--- a/lib/stack_master/sparkle_formation/user_data_file.rb
+++ b/lib/stack_master/sparkle_formation/user_data_file.rb
@@ -1,92 +1,94 @@
 require 'sparkle_formation'
 require 'erubis'
 
-class SparkleFormation
-  module SparkleAttribute
-    module Aws
-      class SfEruby < Erubis::Eruby
-        include Erubis::ArrayEnhancer
+module StackMaster
+  module SparkleFormation
+    UserDataFileNotFound = ::Class.new(StandardError)
 
-        def add_expr(src, code, indicator)
-          case indicator
-            when '='
-              src << " #{@bufvar} << (" << code << ');'
-            else
-              super
+    class SfEruby < Erubis::Eruby
+      include Erubis::ArrayEnhancer
+
+      def add_expr(src, code, indicator)
+        case indicator
+          when '='
+            src << " #{@bufvar} << (" << code << ');'
+          else
+            super
+        end
+      end
+    end
+
+    class TemplateContext < AttributeStruct
+      include ::SparkleFormation::SparkleAttribute
+      include ::SparkleFormation::SparkleAttribute::Aws
+      include ::SparkleFormation::Utils::TypeCheckers
+
+      def self.build(vars)
+        ::Class.new(self).tap do |klass|
+          vars.each do |key, value|
+            klass.send(:define_method, key) do
+              value
+            end
+          end
+        end.new(vars)
+      end
+
+      def initialize(vars)
+        self._camel_keys = true
+        @vars = vars
+      end
+
+      def has_var?(var_key)
+        @vars.include?(var_key)
+      end
+    end
+
+    # Splits up long strings with multiple lines in them to multiple strings
+    # in the CF array. Makes the compiled template and diffs more readable.
+    class CloudFormationLineFormatter
+      def self.format(template)
+        new(template).format
+      end
+
+      def initialize(template)
+        @template = template
+      end
+
+      def format
+        @template.flat_map do |lines|
+          lines = lines.to_s if Symbol === lines
+          if String === lines
+            newlines = []
+            lines.count("\n").times do
+              newlines << "\n"
+            end
+            newlines = lines.split("\n").map do |line|
+              "#{line}#{newlines.pop}"
+            end
+            if lines.starts_with?("\n")
+              newlines.insert(0, "\n")
+            end
+            newlines
+          else
+            lines
           end
         end
       end
+    end
 
-      class TemplateContext < AttributeStruct
-        include SparkleAttribute
-        include SparkleAttribute::Aws
-        include Utils::TypeCheckers
-
-        def self.build(vars)
-          ::Class.new(self).tap do |klass|
-            vars.each do |key, value|
-              klass.send(:define_method, key) do
-                value
-              end
-            end
-          end.new(vars)
-        end
-
-        def initialize(vars)
-          self._camel_keys = true
-          @vars = vars
-        end
-
-        def has_var?(var_key)
-          @vars.include?(var_key)
-        end
-      end
-
-      # Splits up long strings with multiple lines in them to multiple strings
-      # in the CF array. Makes the compiled template and diffs more readable.
-      class CloudFormationLineFormatter
-        def self.format(template)
-          new(template).format
-        end
-
-        def initialize(template)
-          @template = template
-        end
-
-        def format
-          @template.flat_map do |lines|
-            lines = lines.to_s if Symbol === lines
-            if String === lines
-              newlines = []
-              lines.count("\n").times do
-                newlines << "\n"
-              end
-              newlines = lines.split("\n").map do |line|
-                "#{line}#{newlines.pop}"
-              end
-              if lines.starts_with?("\n")
-                newlines.insert(0, "\n")
-              end
-              newlines
-            else
-              lines
-            end
-          end
-        end
-      end
-
-      UserDataFileNotFound = ::Class.new(StandardError)
-
+    module UserDataFile
       def _user_data_file(file_name, vars = {})
         file_path = File.join(::SparkleFormation.sparkle_path, 'user_data', file_name)
         template = File.read(file_path)
-        template_context = TemplateContext.build(vars)
-        compiled_template = SfEruby.new(template).evaluate(template_context)
-        base64!(join!(CloudFormationLineFormatter.format(compiled_template)))
+        template_context = StackMaster::SparkleFormation::TemplateContext.build(vars)
+        compiled_template = StackMaster::SparkleFormation::SfEruby.new(template).evaluate(template_context)
+        base64!(join!(StackMaster::SparkleFormation::CloudFormationLineFormatter.format(compiled_template)))
       rescue Errno::ENOENT => e
-        Kernel.raise UserDataFileNotFound, "Could not find user data file at path: #{file_path}"
+        Kernel.raise StackMaster::SparkleFormation::UserDataFileNotFound, "Could not find user data file at path: #{file_path}"
       end
       alias_method :user_data_file!, :_user_data_file
     end
   end
 end
+
+SparkleFormation::SparkleAttribute::Aws.send(:include, StackMaster::SparkleFormation::UserDataFile)

--- a/lib/stack_master/sparkle_formation/user_data_file.rb
+++ b/lib/stack_master/sparkle_formation/user_data_file.rb
@@ -17,10 +17,14 @@ class SparkleFormation
         end
       end
 
+      UserDataFileNotFound = Class.new(StandardError)
+
       def _user_data_file(file_name)
-        file_path = File.join(File.dirname(::SparkleFormation.sparkle_path), 'templates', 'user_data', file_name)
+        file_path = File.join(::SparkleFormation.sparkle_path, 'user_data', file_name)
         template = File.read(file_path)
         base64!(join!(SfEruby.new(template).evaluate(self)))
+      rescue Errno::ENOENT => e
+        Kernel.raise UserDataFileNotFound, "Could not find user data file at path: #{file_path}"
       end
       alias_method :user_data_file!, :_user_data_file
     end

--- a/lib/stack_master/sparkle_formation/user_data_file.rb
+++ b/lib/stack_master/sparkle_formation/user_data_file.rb
@@ -29,11 +29,16 @@ class SparkleFormation
                 value
               end
             end
-          end.new
+          end.new(vars)
         end
 
-        def initialize
+        def initialize(vars)
           self._camel_keys = true
+          @vars = vars
+        end
+
+        def has_var?(var_key)
+          @vars.include?(var_key)
         end
       end
 

--- a/lib/stack_master/sparkle_formation/user_data_file.rb
+++ b/lib/stack_master/sparkle_formation/user_data_file.rb
@@ -24,7 +24,15 @@ class SparkleFormation
         template = File.read(file_path)
 
         compiled_template = SfEruby.new(template).evaluate(self)
-        formatted_cf_template = compiled_template.flat_map do |lines|
+        base64!(join!(_format_user_data_for_cf(compiled_template)))
+      rescue Errno::ENOENT => e
+        Kernel.raise UserDataFileNotFound, "Could not find user data file at path: #{file_path}"
+      end
+      alias_method :user_data_file!, :_user_data_file
+
+      # To split each user data line to it's own string in the final CF JSON array
+      def _format_user_data_for_cf(compiled_template)
+        compiled_template.flat_map do |lines|
           if String === lines
             newlines = []
             lines.count("\n").times do
@@ -37,11 +45,7 @@ class SparkleFormation
             lines
           end
         end
-        base64!(join!(formatted_cf_template))
-      rescue Errno::ENOENT => e
-        Kernel.raise UserDataFileNotFound, "Could not find user data file at path: #{file_path}"
       end
-      alias_method :user_data_file!, :_user_data_file
     end
   end
 end

--- a/lib/stack_master/sparkle_formation/user_data_file.rb
+++ b/lib/stack_master/sparkle_formation/user_data_file.rb
@@ -17,13 +17,28 @@ class SparkleFormation
         end
       end
 
+      class TemplateContext < AttributeStruct
+        include SparkleAttribute
+        include SparkleAttribute::Aws
+        include Utils::TypeCheckers
+
+        def initialize(vars)
+          vars.each do |key, value|
+            self.class.send(:define_method, key) do
+              value
+            end
+          end
+          self._camel_keys = true
+        end
+      end
+
       UserDataFileNotFound = Class.new(StandardError)
 
-      def _user_data_file(file_name)
+      def _user_data_file(file_name, vars = {})
         file_path = File.join(::SparkleFormation.sparkle_path, 'user_data', file_name)
         template = File.read(file_path)
-
-        compiled_template = SfEruby.new(template).evaluate(self)
+        template_context = TemplateContext.new(vars)
+        compiled_template = SfEruby.new(template).evaluate(template_context)
         base64!(join!(_format_user_data_for_cf(compiled_template)))
       rescue Errno::ENOENT => e
         Kernel.raise UserDataFileNotFound, "Could not find user data file at path: #{file_path}"
@@ -33,14 +48,19 @@ class SparkleFormation
       # To split each user data line to it's own string in the final CF JSON array
       def _format_user_data_for_cf(compiled_template)
         compiled_template.flat_map do |lines|
+          lines = lines.to_s if Symbol === lines
           if String === lines
             newlines = []
             lines.count("\n").times do
               newlines << "\n"
             end
-            lines.split("\n").map do |line|
+            newlines = lines.split("\n").map do |line|
               "#{line}#{newlines.pop}"
             end
+            if lines.starts_with?("\n")
+              newlines.insert(0, "\n")
+            end
+            newlines
           else
             lines
           end

--- a/lib/stack_master/sparkle_formation/user_data_file.rb
+++ b/lib/stack_master/sparkle_formation/user_data_file.rb
@@ -1,0 +1,28 @@
+require 'sparkle_formation'
+require 'erubis'
+
+class SparkleFormation
+  module SparkleAttribute
+    module Aws
+      class SfEruby < Erubis::Eruby
+        include Erubis::ArrayEnhancer
+
+        def add_expr(src, code, indicator)
+          case indicator
+            when '='
+              src << " #{@bufvar} << (" << code << ');'
+            else
+              super
+          end
+        end
+      end
+
+      def _user_data_file(file_name)
+        file_path = File.join(File.dirname(::SparkleFormation.sparkle_path), 'templates', 'user_data', file_name)
+        template = File.read(file_path)
+        base64!(join!(SfEruby.new(template).evaluate(self)))
+      end
+      alias_method :user_data_file!, :_user_data_file
+    end
+  end
+end

--- a/lib/stack_master/version.rb
+++ b/lib/stack_master/version.rb
@@ -1,3 +1,3 @@
 module StackMaster
-  VERSION = "0.5.0"
+  VERSION = "0.6.0"
 end

--- a/spec/stack_master/sparkle_formation/user_data_file_spec.rb
+++ b/spec/stack_master/sparkle_formation/user_data_file_spec.rb
@@ -1,0 +1,29 @@
+RSpec.describe SparkleFormation::SparkleAttribute::Aws, '#user_data_file!' do
+  let(:user_data) do
+    <<-EOS
+#!/bin/bash
+
+REGION=<%= region! %>
+echo $REGION
+    EOS
+  end
+  let(:expected_hash) do
+    {"Fn::Base64"=>{"Fn::Join"=>["", ["#!/bin/bash\n\nREGION=", {"Ref"=>"AWS::Region"}, "\n", "echo $REGION\n"]]}}
+  end
+
+  before do
+    klass = Class.new(AttributeStruct)
+    klass.include(SparkleFormation::SparkleAttribute)
+    klass.include(SparkleFormation::SparkleAttribute::Aws)
+    klass.include(SparkleFormation::Utils::TypeCheckers)
+    @attr = klass.new
+    @attr._camel_keys = true
+    @sfn = SparkleFormation.new(:test, :provider => :aws, :sparkle_path => 'spec/fixtures/test')
+  end
+
+  it 'compiles the file and returns a joined version' do
+    allow(SparkleFormation).to receive(:sparkle_path).and_return('a')
+    allow(File).to receive(:read).and_return(user_data)
+    expect(@attr.user_data_file!('test.erb')).to eq expected_hash
+  end
+end

--- a/spec/stack_master/sparkle_formation/user_data_file_spec.rb
+++ b/spec/stack_master/sparkle_formation/user_data_file_spec.rb
@@ -49,7 +49,6 @@ echo $REGION
         {"Fn::Base64"=>{"Fn::Join"=>["", ["#!/bin/bash\n", "test_var", "\n", "yes", "\n"]]}}
       end
 
-
       it 'compiles the file and returns a joined version' do
         expect(@attr.user_data_file!('test.erb', my_custom_var: :test_var)).to eq expected_hash
         expect(@attr.user_data_file!('test.erb', my_custom_var: 'test_var')).to eq expected_hash

--- a/spec/stack_master/sparkle_formation/user_data_file_spec.rb
+++ b/spec/stack_master/sparkle_formation/user_data_file_spec.rb
@@ -8,7 +8,7 @@ echo $REGION
     EOS
   end
   let(:expected_hash) do
-    {"Fn::Base64"=>{"Fn::Join"=>["", ["#!/bin/bash\n\nREGION=", {"Ref"=>"AWS::Region"}, "\n", "echo $REGION\n"]]}}
+    {"Fn::Base64"=>{"Fn::Join"=>["", ["#!/bin/bash\n", "\n", "REGION=", {"Ref"=>"AWS::Region"}, "echo $REGION\n"]]}}
   end
 
   before do
@@ -23,7 +23,7 @@ echo $REGION
   end
 
   it 'reads from the user_data dir in templates' do
-    expect(File).to receive(:read).with('/templates_dir/user_data/test.erb')
+    expect(File).to receive(:read).with('/templates_dir/user_data/test.erb').and_return(user_data)
     @attr.user_data_file!('test.erb')
   end
 

--- a/spec/stack_master/sparkle_formation/user_data_file_spec.rb
+++ b/spec/stack_master/sparkle_formation/user_data_file_spec.rb
@@ -6,10 +6,11 @@ RSpec.describe SparkleFormation::SparkleAttribute::Aws, '#user_data_file!' do
 REGION=<%= region! %>
 echo $REGION
 <%= ref!(:test) %> <%= ref!(:test_2) %>
+<%= has_var?(:test) ? "echo 'yes'" : "echo 'no'" %>
     EOS
   end
   let(:expected_hash) do
-    {"Fn::Base64"=>{"Fn::Join"=>["", ["#!/bin/bash\n", "\n", "REGION=", {"Ref"=>"AWS::Region"}, "\n", "echo $REGION\n", {"Ref"=>"Test"}, " ", {"Ref"=>"Test2"}, "\n"]]}}
+    {"Fn::Base64"=>{"Fn::Join"=>["", ["#!/bin/bash\n", "\n", "REGION=", {"Ref"=>"AWS::Region"}, "\n", "echo $REGION\n", {"Ref"=>"Test"}, " ", {"Ref"=>"Test2"}, "\n", "echo 'no'", "\n"]]}}
   end
 
   before do
@@ -41,10 +42,11 @@ echo $REGION
         <<-EOS
 #!/bin/bash
 <%= my_custom_var %>
+<%= has_var?(:my_custom_var) ? "yes" : "no" %>
         EOS
       end
       let(:expected_hash) do
-        {"Fn::Base64"=>{"Fn::Join"=>["", ["#!/bin/bash\n", "test_var", "\n"]]}}
+        {"Fn::Base64"=>{"Fn::Join"=>["", ["#!/bin/bash\n", "test_var", "\n", "yes", "\n"]]}}
       end
 
 

--- a/spec/stack_master/sparkle_formation/user_data_file_spec.rb
+++ b/spec/stack_master/sparkle_formation/user_data_file_spec.rb
@@ -35,6 +35,24 @@ echo $REGION
     it 'compiles the file and returns a joined version' do
       expect(@attr.user_data_file!('test.erb')).to eq expected_hash
     end
+
+    context 'with custom vars' do
+      let(:user_data) do
+        <<-EOS
+#!/bin/bash
+<%= my_custom_var %>
+        EOS
+      end
+      let(:expected_hash) do
+        {"Fn::Base64"=>{"Fn::Join"=>["", ["#!/bin/bash\n", "test_var", "\n"]]}}
+      end
+
+
+      it 'compiles the file and returns a joined version' do
+        expect(@attr.user_data_file!('test.erb', my_custom_var: :test_var)).to eq expected_hash
+        expect(@attr.user_data_file!('test.erb', my_custom_var: 'test_var')).to eq expected_hash
+      end
+    end
   end
 
   context "when the file doesn't exist" do

--- a/spec/stack_master/sparkle_formation/user_data_file_spec.rb
+++ b/spec/stack_master/sparkle_formation/user_data_file_spec.rb
@@ -5,10 +5,11 @@ RSpec.describe SparkleFormation::SparkleAttribute::Aws, '#user_data_file!' do
 
 REGION=<%= region! %>
 echo $REGION
+<%= ref!(:test) %> <%= ref!(:test_2) %>
     EOS
   end
   let(:expected_hash) do
-    {"Fn::Base64"=>{"Fn::Join"=>["", ["#!/bin/bash\n", "\n", "REGION=", {"Ref"=>"AWS::Region"}, "echo $REGION\n"]]}}
+    {"Fn::Base64"=>{"Fn::Join"=>["", ["#!/bin/bash\n", "\n", "REGION=", {"Ref"=>"AWS::Region"}, "\n", "echo $REGION\n", {"Ref"=>"Test"}, " ", {"Ref"=>"Test2"}, "\n"]]}}
   end
 
   before do
@@ -19,7 +20,6 @@ echo $REGION
     klass.include(SparkleFormation::Utils::TypeCheckers)
     @attr = klass.new
     @attr._camel_keys = true
-    @sfn = SparkleFormation.new(:test, :provider => :aws, :sparkle_path => 'spec/fixtures/test')
   end
 
   it 'reads from the user_data dir in templates' do

--- a/spec/stack_master/sparkle_formation/user_data_file_spec.rb
+++ b/spec/stack_master/sparkle_formation/user_data_file_spec.rb
@@ -64,7 +64,7 @@ echo $REGION
     it 'raises a specific error' do
       expect {
         @attr.user_data_file!('test.erb')
-      }.to raise_error(SparkleFormation::SparkleAttribute::Aws::UserDataFileNotFound)
+      }.to raise_error(StackMaster::SparkleFormation::UserDataFileNotFound)
     end
   end
 end

--- a/stack_master.gemspec
+++ b/stack_master.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "diffy"
   spec.add_dependency "erubis"
   spec.add_dependency "colorize"
-  spec.add_dependency "activesupport"
+  spec.add_dependency "activesupport", "~> 4.2"
   spec.add_dependency "sparkle_formation", "~> 1.1"
   spec.add_dependency "table_print"
   spec.add_dependency "dotgpg"

--- a/stack_master.gemspec
+++ b/stack_master.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "virtus"
   spec.add_dependency "aws-sdk", "~> 2.2.31"
   spec.add_dependency "diffy"
+  spec.add_dependency "erubis"
   spec.add_dependency "colorize"
   spec.add_dependency "activesupport"
   spec.add_dependency "sparkle_formation", "~> 1.1"


### PR DESCRIPTION
Based on the code in this comment https://github.com/sparkleformation/sparkle_formation/issues/54#issuecomment-143136818

With this change, you can write the following in templates:

```
  user_data user_data_file!('web.erb', role: :web)
```

It will look in templates/user_data/* for user data files, read the template and compile it with each line being a separate string in the final array. The files can look like this and make use of SF helpers:

```
 #!/bin/bash
 
REGION=<%= region! %>
ROLE=<%= has_var?(:role) ? role : 'hmm' %>
echo $REGION
```

Renders like this:

```
+        "UserData": {
+          "Fn::Base64": {
+            "Fn::Join": [
+              "",
+              [
+                "#!/bin/bash\n",
+                "\n",
+                "REGION=",
+                {
+                  "Ref": "AWS::Region"
+                },
+                "ROLE=web",
+                "\n",
+                "echo $REGION\n"
+              ]
+            ]
+          }
+        }
+
```

Ref: https://github.com/envato/stack_master/issues/104