### PR TITLE
Use autoload and remove virtus dependency

### DIFF
--- a/lib/stack_master.rb
+++ b/lib/stack_master.rb
@@ -2,67 +2,78 @@ require "commander"
 require "yaml"
 require "virtus"
 require "aws-sdk"
-require "diffy"
 require "colorize"
-require "table_print"
 require 'active_support/core_ext/string'
-require "erb"
-require 'sparkle_formation'
-require 'dotgpg'
-require 'ruby-progressbar'
-
-require "stack_master/ctrl_c"
-require "stack_master/sparkle_formation/user_data_file"
-require "stack_master/command"
-require "stack_master/version"
-require "stack_master/stack"
-require "stack_master/prompter"
-require "stack_master/aws_driver/cloud_formation"
-require "stack_master/test_driver/cloud_formation"
-require "stack_master/stack_events/fetcher"
-require "stack_master/stack_events/presenter"
-require "stack_master/stack_events/streamer"
-require "stack_master/stack_states"
-require "stack_master/stack_status"
-require "stack_master/sns_topic_finder"
-require "stack_master/security_group_finder"
-require "stack_master/parameter_loader"
-require "stack_master/parameter_resolver"
-require "stack_master/resolver_array"
-require "stack_master/parameter_resolvers/ami_finder"
-require "stack_master/parameter_resolvers/stack_output"
-require "stack_master/parameter_resolvers/secret"
-require "stack_master/parameter_resolvers/sns_topic_name"
-require "stack_master/parameter_resolvers/security_group"
-require "stack_master/parameter_resolvers/latest_ami_by_tags"
-require "stack_master/parameter_resolvers/latest_ami"
-require "stack_master/utils"
-require "stack_master/config"
-require "stack_master/paged_response_accumulator"
-require "stack_master/stack_definition"
-require "stack_master/template_compiler"
-require "stack_master/template_compilers/sparkle_formation"
-require "stack_master/template_compilers/json"
-require "stack_master/template_compilers/yaml"
-require "stack_master/template_compilers/cfndsl"
-require "stack_master/commands/terminal_helper"
-require "stack_master/commands/apply"
-require "stack_master/change_set"
-require "stack_master/commands/events"
-require "stack_master/commands/outputs"
-require "stack_master/commands/init"
-require "stack_master/commands/diff"
-require "stack_master/commands/list_stacks"
-require "stack_master/commands/validate"
-require "stack_master/commands/resources"
-require "stack_master/commands/delete"
-require "stack_master/commands/status"
-require "stack_master/stack_differ"
-require "stack_master/validator"
-require "stack_master/cli"
 
 module StackMaster
   extend self
+
+  autoload :ChangeSet, 'stack_master/change_set'
+  autoload :CLI, 'stack_master/cli'
+  autoload :CtrlC, 'stack_master/ctrl_c'
+  autoload :Command, 'stack_master/command'
+  autoload :Version, 'stack_master/version'
+  autoload :Stack, 'stack_master/stack'
+  autoload :Prompter, 'stack_master/prompter'
+  autoload :StackStates, 'stack_master/stack_states'
+  autoload :StackStatus, 'stack_master/stack_status'
+  autoload :SnsTopicFinder, 'stack_master/sns_topic_finder'
+  autoload :SecurityGroupFinder, 'stack_master/security_group_finder'
+  autoload :ParameterLoader, 'stack_master/parameter_loader'
+  autoload :ParameterResolver, 'stack_master/parameter_resolver'
+  autoload :ResolverArray, 'stack_master/resolver_array'
+  autoload :Resolver, 'stack_master/resolver_array'
+  autoload :Utils, 'stack_master/utils'
+  autoload :Config, 'stack_master/config'
+  autoload :PagedResponseAccumulator, 'stack_master/paged_response_accumulator'
+  autoload :StackDefinition, 'stack_master/stack_definition'
+  autoload :TemplateCompiler, 'stack_master/template_compiler'
+
+  autoload :StackDiffer, 'stack_master/stack_differ'
+  autoload :Validator, 'stack_master/validator'
+
+  require 'stack_master/template_compilers/sparkle_formation'
+  require 'stack_master/template_compilers/json'
+  require 'stack_master/template_compilers/yaml'
+  require 'stack_master/template_compilers/cfndsl'
+
+  module Commands
+    autoload :TerminalHelper, 'stack_master/commands/terminal_helper'
+    autoload :Apply, 'stack_master/commands/apply'
+    autoload :Events, 'stack_master/commands/events'
+    autoload :Outputs, 'stack_master/commands/outputs'
+    autoload :Init, 'stack_master/commands/init'
+    autoload :Diff, 'stack_master/commands/diff'
+    autoload :ListStacks, 'stack_master/commands/list_stacks'
+    autoload :Validate, 'stack_master/commands/validate'
+    autoload :Resources, 'stack_master/commands/resources'
+    autoload :Delete, 'stack_master/commands/delete'
+    autoload :Status, 'stack_master/commands/status'
+  end
+
+  module ParameterResolvers
+    autoload :AmiFinder, 'stack_master/parameter_resolvers/ami_finder'
+    autoload :StackOutput, 'stack_master/parameter_resolvers/stack_output'
+    autoload :Secret, 'stack_master/parameter_resolvers/secret'
+    autoload :SnsTopicName, 'stack_master/parameter_resolvers/sns_topic_name'
+    autoload :SecurityGroup, 'stack_master/parameter_resolvers/security_group'
+    autoload :LatestAmiByTags, 'stack_master/parameter_resolvers/latest_ami_by_tags'
+    autoload :LatestAmi, 'stack_master/parameter_resolvers/latest_ami'
+  end
+
+  module AwsDriver
+    autoload :CloudFormation, 'stack_master/aws_driver/cloud_formation'
+  end
+
+  module TestDriver
+    autoload :CloudFormation, 'stack_master/test_driver/cloud_formation'
+  end
+
+  module StackEvents
+    autoload :Fetcher, 'stack_master/stack_events/fetcher'
+    autoload :Presenter, 'stack_master/stack_events/presenter'
+    autoload :Streamer, 'stack_master/stack_events/streamer'
+  end
 
   def interactive?
     !non_interactive?
@@ -126,4 +137,3 @@ module StackMaster
     @stderr = io
   end
 end
-

--- a/lib/stack_master.rb
+++ b/lib/stack_master.rb
@@ -1,6 +1,5 @@
 require "commander"
 require "yaml"
-require "virtus"
 require "aws-sdk"
 require "colorize"
 require 'active_support/core_ext/string'
@@ -8,6 +7,7 @@ require 'active_support/core_ext/string'
 module StackMaster
   extend self
 
+  autoload :Initializable, 'stack_master/utils/initializable'
   autoload :ChangeSet, 'stack_master/change_set'
   autoload :CLI, 'stack_master/cli'
   autoload :CtrlC, 'stack_master/ctrl_c'

--- a/lib/stack_master/cli.rb
+++ b/lib/stack_master/cli.rb
@@ -1,4 +1,5 @@
 require 'commander'
+require 'table_print'
 
 module StackMaster
   class CLI

--- a/lib/stack_master/commands/init.rb
+++ b/lib/stack_master/commands/init.rb
@@ -1,3 +1,5 @@
+require "erb"
+
 module StackMaster
   module Commands
     class Init

--- a/lib/stack_master/commands/list_stacks.rb
+++ b/lib/stack_master/commands/list_stacks.rb
@@ -1,3 +1,5 @@
+require 'table_print'
+
 module StackMaster
   module Commands
     class ListStacks

--- a/lib/stack_master/commands/outputs.rb
+++ b/lib/stack_master/commands/outputs.rb
@@ -1,3 +1,5 @@
+require 'table_print'
+
 module StackMaster
   module Commands
     class Outputs

--- a/lib/stack_master/commands/status.rb
+++ b/lib/stack_master/commands/status.rb
@@ -1,3 +1,6 @@
+require 'table_print'
+require 'ruby-progressbar'
+
 module StackMaster
   module Commands
     class Status

--- a/lib/stack_master/parameter_resolvers/secret.rb
+++ b/lib/stack_master/parameter_resolvers/secret.rb
@@ -1,3 +1,5 @@
+require 'dotgpg'
+
 module StackMaster
   module ParameterResolvers
     class Secret < Resolver

--- a/lib/stack_master/stack.rb
+++ b/lib/stack_master/stack.rb
@@ -2,18 +2,18 @@ module StackMaster
   class Stack
     MAX_TEMPLATE_SIZE = 51200
 
-    include Virtus.model
+    attr_reader :stack_name,
+                :region,
+                :stack_id,
+                :stack_status,
+                :parameters,
+                :template_body,
+                :notification_arns,
+                :outputs,
+                :stack_policy_body,
+                :tags
 
-    attribute :stack_name, String
-    attribute :region, String
-    attribute :stack_id, String
-    attribute :stack_status, String
-    attribute :parameters, Hash
-    attribute :template_body, String
-    attribute :notification_arns, Array[String]
-    attribute :outputs, Array
-    attribute :stack_policy_body, String
-    attribute :tags, Hash
+    include Utils::Initializable
 
     def template_hash
       if template_body

--- a/lib/stack_master/stack_definition.rb
+++ b/lib/stack_master/stack_definition.rb
@@ -1,17 +1,34 @@
 module StackMaster
   class StackDefinition
-    include Virtus.value_object(strict: true, required: false)
+    attr_accessor :region,
+                  :stack_name,
+                  :template,
+                  :tags,
+                  :notification_arns,
+                  :base_dir,
+                  :secret_file,
+                  :stack_policy_file,
+                  :additional_parameter_lookup_dirs
 
-    values do
-      attribute :region, String
-      attribute :stack_name, String
-      attribute :template, String
-      attribute :tags, Hash
-      attribute :notification_arns, Array[String]
-      attribute :base_dir, String
-      attribute :secret_file, String
-      attribute :stack_policy_file, String
-      attribute :additional_parameter_lookup_dirs, Array[String]
+    include Utils::Initializable
+
+    def initialize(attributes = {})
+      @additional_parameter_lookup_dirs = []
+      @notification_arns = []
+      super
+    end
+
+    def ==(other)
+      self.class === other &&
+        @region == other.region &&
+        @stack_name == other.stack_name &&
+        @template == other.template &&
+        @tags == other.tags &&
+        @notification_arns == other.notification_arns &&
+        @base_dir == other.base_dir &&
+        @secret_file == other.secret_file &&
+        @stack_policy_file == other.stack_policy_file &&
+        @additional_parameter_lookup_dirs == other.additional_parameter_lookup_dirs
     end
 
     def template_file_path
@@ -19,7 +36,7 @@ module StackMaster
     end
 
     def parameter_files
-      [ default_parameter_file_path, region_parameter_file_path ] + additional_parameter_lookup_file_paths
+      [ default_parameter_file_path, region_parameter_file_path, additional_parameter_lookup_file_paths ].flatten.compact
     end
 
     def stack_policy_file_path
@@ -29,6 +46,7 @@ module StackMaster
     private
 
     def additional_parameter_lookup_file_paths
+      return unless additional_parameter_lookup_dirs
       additional_parameter_lookup_dirs.map do |a|
         File.join(base_dir, 'parameters', a, "#{underscored_stack_name}.yml")
       end

--- a/lib/stack_master/stack_differ.rb
+++ b/lib/stack_master/stack_differ.rb
@@ -1,3 +1,5 @@
+require "diffy"
+
 module StackMaster
   class StackDiffer
     def initialize(proposed_stack, current_stack)

--- a/lib/stack_master/stack_events/fetcher.rb
+++ b/lib/stack_master/stack_events/fetcher.rb
@@ -1,5 +1,5 @@
 module StackMaster
-  class StackEvents
+  module StackEvents
     class Fetcher
       def self.fetch(*args)
         new(*args).fetch

--- a/lib/stack_master/stack_events/presenter.rb
+++ b/lib/stack_master/stack_events/presenter.rb
@@ -1,5 +1,5 @@
 module StackMaster
-  class StackEvents
+  module StackEvents
     class Presenter
       def self.print_event(io, event)
         new(io).print_event(event)

--- a/lib/stack_master/stack_events/streamer.rb
+++ b/lib/stack_master/stack_events/streamer.rb
@@ -1,5 +1,5 @@
 module StackMaster
-  class StackEvents
+  module StackEvents
     class Streamer
       def self.stream(*args, &block)
         new(*args, &block).stream

--- a/lib/stack_master/template_compiler.rb
+++ b/lib/stack_master/template_compiler.rb
@@ -3,7 +3,9 @@ module StackMaster
     TemplateCompilationFailed = Class.new(RuntimeError)
 
     def self.compile(config, template_file_path)
-      template_compiler_for_file(template_file_path, config).compile(template_file_path)
+      compiler = template_compiler_for_file(template_file_path, config)
+      compiler.require_dependencies
+      compiler.compile(template_file_path)
     rescue
       raise TemplateCompilationFailed.new("Failed to compile #{template_file_path}.")
     end

--- a/lib/stack_master/template_compilers/cfndsl.rb
+++ b/lib/stack_master/template_compilers/cfndsl.rb
@@ -1,9 +1,11 @@
 module StackMaster::TemplateCompilers
   class Cfndsl
+    def self.require_dependencies
+      require 'cfndsl'
+    end
 
     def self.compile(template_file_path)
-      require 'cfndsl'
-      CfnDsl.eval_file_with_extras(template_file_path).to_json
+      ::CfnDsl.eval_file_with_extras(template_file_path).to_json
     end
 
     StackMaster::TemplateCompiler.register(:cfndsl, self)

--- a/lib/stack_master/template_compilers/json.rb
+++ b/lib/stack_master/template_compilers/json.rb
@@ -3,6 +3,10 @@ module StackMaster::TemplateCompilers
     MAX_TEMPLATE_SIZE = 51200
     private_constant :MAX_TEMPLATE_SIZE
 
+    def self.require_dependencies
+      require 'json'
+    end
+
     def self.compile(template_file_path)
       template_body = File.read(template_file_path)
       if template_body.size > MAX_TEMPLATE_SIZE

--- a/lib/stack_master/template_compilers/sparkle_formation.rb
+++ b/lib/stack_master/template_compilers/sparkle_formation.rb
@@ -1,5 +1,10 @@
 module StackMaster::TemplateCompilers
   class SparkleFormation
+    def self.require_dependencies
+      require 'sparkle_formation'
+      require 'stack_master/sparkle_formation/user_data_file'
+    end
+
     def self.compile(template_file_path)
       ::SparkleFormation.sparkle_path = File.dirname(template_file_path)
       JSON.pretty_generate(::SparkleFormation.compile(template_file_path))

--- a/lib/stack_master/template_compilers/yaml.rb
+++ b/lib/stack_master/template_compilers/yaml.rb
@@ -1,5 +1,9 @@
 module StackMaster::TemplateCompilers
   class Yaml
+    def self.require_dependencies
+      require 'yaml'
+      require 'json'
+    end
 
     def self.compile(template_file_path)
       template_body = File.read(template_file_path)

--- a/lib/stack_master/test_driver/cloud_formation.rb
+++ b/lib/stack_master/test_driver/cloud_formation.rb
@@ -1,48 +1,62 @@
 module StackMaster
   module TestDriver
     class Stack
-      include Virtus.model
-      attribute :stack_id, String
-      attribute :stack_name, String
-      attribute :description, String
-      attribute :parameters, Array[OpenStruct]
-      attribute :creation_time, String
-      attribute :last_update_time, String
-      attribute :stack_status, String
-      attribute :stack_status_reason, String
-      attribute :disable_rollback, String
-      attribute :notification_arns, Array
-      attribute :timeout_in_minutes, Integer
-      attribute :capabilities, Array
-      attribute :outputs, Array[OpenStruct]
-      attribute :tags, Array[OpenStruct]
+      attr_reader :stack_id,
+                  :stack_name,
+                  :description,
+                  :parameters,
+                  :creation_time,
+                  :last_update_time,
+                  :stack_status,
+                  :stack_status_reason,
+                  :disable_rollback,
+                  :notification_arns,
+                  :timeout_in_minutes,
+                  :capabilities,
+                  :outputs,
+                  :tags
+
+      include Utils::Initializable
+
+      def parameters
+        @parameters.map do |hash|
+          OpenStruct.new(parameter_key: hash[:parameter_key],
+                         parameter_value: hash[:parameter_value])
+        end
+      end
     end
 
     class StackEvent
-      include Virtus.model
-      attribute :stack_id, String
-      attribute :event_id, String
-      attribute :stack_name, String
-      attribute :logical_resource_id, String
-      attribute :physical_resource_id, String
-      attribute :resource_type, String
-      attribute :timestamp, Time
-      attribute :resource_status, String
-      attribute :resource_status_reason, String
-      attribute :resource_properties, String
+      attr_reader :stack_id,
+                  :event_id,
+                  :stack_name,
+                  :logical_resource_id,
+                  :physical_resource_id,
+                  :resource_type,
+                  :timestamp,
+                  :resource_status,
+                  :resource_status_reason,
+                  :resource_properties
+
+      include Utils::Initializable
+
+      def timestamp
+        Time.parse(@timestamp) if @timestamp
+      end
     end
 
     class StackResource
-      include Virtus.model
-      attribute :stack_name, String
-      attribute :stack_id, String
-      attribute :logical_resource_id, String
-      attribute :physical_resource_id, String
-      attribute :resource_type, String
-      attribute :timestamp, Time
-      attribute :resource_status, String
-      attribute :resource_status_reason, String
-      attribute :description, String
+      attr_reader :stack_name,
+                  :stack_id,
+                  :logical_resource_id,
+                  :physical_resource_id,
+                  :resource_type,
+                  :timestamp,
+                  :resource_status,
+                  :resource_status_reason,
+                  :description
+
+      include Utils::Initializable
     end
 
     class CloudFormation

--- a/lib/stack_master/utils.rb
+++ b/lib/stack_master/utils.rb
@@ -1,5 +1,17 @@
 module StackMaster
   module Utils
+    module Initializable
+      def initialize(attributes = {})
+        self.attributes = attributes
+      end
+
+      def attributes=(attributes)
+        attributes.each do |k, v|
+          instance_variable_set("@#{k}", v)
+        end
+      end
+    end
+
     extend self
 
     def hash_to_aws_parameters(params)

--- a/spec/stack_master/sparkle_formation/user_data_file_spec.rb
+++ b/spec/stack_master/sparkle_formation/user_data_file_spec.rb
@@ -1,3 +1,5 @@
+require 'stack_master/sparkle_formation/user_data_file'
+
 RSpec.describe SparkleFormation::SparkleAttribute::Aws, '#user_data_file!' do
   let(:user_data) do
     <<-EOS

--- a/spec/stack_master/template_compiler_spec.rb
+++ b/spec/stack_master/template_compiler_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe StackMaster::TemplateCompiler do
     let(:template_file_path) { '/base_dir/templates/template.fab' }
 
     class TestTemplateCompiler
+      def self.require_dependencies; end
       def self.compile(template_file_path); end
     end
 

--- a/spec/stack_master/template_compilers/cfndsl_spec.rb
+++ b/spec/stack_master/template_compilers/cfndsl_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe StackMaster::TemplateCompilers::Cfndsl do
+  before(:all) { described_class.require_dependencies }
+
   describe '.compile' do
     def compile
       described_class.compile(template_file_path)

--- a/stack_master.gemspec
+++ b/stack_master.gemspec
@@ -27,7 +27,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "timecop"
   spec.add_dependency "ruby-progressbar"
   spec.add_dependency "commander"
-  spec.add_dependency "virtus"
   spec.add_dependency "aws-sdk", "~> 2.2.31"
   spec.add_dependency "diffy"
   spec.add_dependency "erubis"


### PR DESCRIPTION
By using autoload we will avoid loading dependencies when they aren't actually needed for the command that is being run.

Removes dependency on Virtus.