### PR TITLE
Support cfndsl external parameters and disabling bindings

### DIFF
--- a/lib/stack_master/config.rb
+++ b/lib/stack_master/config.rb
@@ -12,6 +12,7 @@ module StackMaster
 
     attr_accessor :stacks,
                   :base_dir,
+                  :template_dir,
                   :stack_defaults,
                   :region_defaults,
                   :region_aliases,
@@ -33,6 +34,7 @@ module StackMaster
     def initialize(config, base_dir)
       @config = config
       @base_dir = base_dir
+      @template_dir = config.fetch('template_dir', nil)
       @stack_defaults = config.fetch('stack_defaults', {})
       @region_aliases = Utils.underscore_keys_to_hyphen(config.fetch('region_aliases', {}))
       @region_to_aliases = @region_aliases.inject({}) do |hash, (key, value)|
@@ -108,6 +110,7 @@ module StackMaster
             'region' => region,
             'stack_name' => stack_name,
             'base_dir' => @base_dir,
+            'template_dir' => @template_dir,
             'additional_parameter_lookup_dirs' => @region_to_aliases[region])
           @stacks << StackDefinition.new(stack_attributes)
         end

--- a/lib/stack_master/stack.rb
+++ b/lib/stack_master/stack.rb
@@ -61,7 +61,7 @@ module StackMaster
 
     def self.generate(stack_definition, config)
       parameter_hash = ParameterLoader.load(stack_definition.parameter_files)
-      template_body = TemplateCompiler.compile(config, stack_definition.template_file_path)
+      template_body = TemplateCompiler.compile(config, stack_definition.template_file_path, stack_definition.compiler_options)
       template_format = TemplateUtils.identify_template_format(template_body)
       parameters = ParameterResolver.resolve(config, stack_definition, parameter_hash)
       stack_policy_body = if stack_definition.stack_policy_file_path

--- a/lib/stack_master/stack_definition.rb
+++ b/lib/stack_master/stack_definition.rb
@@ -10,12 +10,14 @@ module StackMaster
                   :stack_policy_file,
                   :additional_parameter_lookup_dirs,
                   :s3,
-                  :files
+                  :files,
+                  :compiler_options
 
     include Utils::Initializable
 
     def initialize(attributes = {})
       @additional_parameter_lookup_dirs = []
+      @compiler_options = {}
       @notification_arns = []
       @s3 = {}
       @files = []
@@ -33,7 +35,8 @@ module StackMaster
         @secret_file == other.secret_file &&
         @stack_policy_file == other.stack_policy_file &&
         @additional_parameter_lookup_dirs == other.additional_parameter_lookup_dirs &&
-        @s3 == other.s3
+        @s3 == other.s3 &&
+        @compiler_options == other.compiler_options
     end
 
     def template_dir

--- a/lib/stack_master/stack_definition.rb
+++ b/lib/stack_master/stack_definition.rb
@@ -6,6 +6,7 @@ module StackMaster
                   :tags,
                   :notification_arns,
                   :base_dir,
+                  :template_dir,
                   :secret_file,
                   :stack_policy_file,
                   :additional_parameter_lookup_dirs,
@@ -22,6 +23,7 @@ module StackMaster
       @s3 = {}
       @files = []
       super
+      @template_dir ||= File.join(@base_dir, 'templates')
     end
 
     def ==(other)
@@ -39,12 +41,8 @@ module StackMaster
         @compiler_options == other.compiler_options
     end
 
-    def template_dir
-      File.join(base_dir, 'templates')
-    end
-
     def template_file_path
-      File.join(template_dir, template)
+      File.expand_path(File.join(template_dir, template))
     end
 
     def files_dir

--- a/lib/stack_master/template_compiler.rb
+++ b/lib/stack_master/template_compiler.rb
@@ -2,7 +2,7 @@ module StackMaster
   class TemplateCompiler
     TemplateCompilationFailed = Class.new(RuntimeError)
 
-    def self.compile(config, template_file_path, compiler_options={})
+    def self.compile(config, template_file_path, compiler_options = {})
       compiler = template_compiler_for_file(template_file_path, config)
       compiler.require_dependencies
       compiler.compile(template_file_path, compiler_options)

--- a/lib/stack_master/template_compiler.rb
+++ b/lib/stack_master/template_compiler.rb
@@ -2,10 +2,10 @@ module StackMaster
   class TemplateCompiler
     TemplateCompilationFailed = Class.new(RuntimeError)
 
-    def self.compile(config, template_file_path)
+    def self.compile(config, template_file_path, compiler_options={})
       compiler = template_compiler_for_file(template_file_path, config)
       compiler.require_dependencies
-      compiler.compile(template_file_path)
+      compiler.compile(template_file_path, compiler_options)
     rescue
       raise TemplateCompilationFailed.new("Failed to compile #{template_file_path}.")
     end

--- a/lib/stack_master/template_compilers/cfndsl.rb
+++ b/lib/stack_master/template_compilers/cfndsl.rb
@@ -4,7 +4,7 @@ module StackMaster::TemplateCompilers
       require 'cfndsl'
     end
 
-    def self.compile(template_file_path, compiler_options={})
+    def self.compile(template_file_path, compiler_options = {})
       if compiler_options["disable_binding"]
         ::CfnDsl.disable_binding
       end

--- a/lib/stack_master/template_compilers/cfndsl.rb
+++ b/lib/stack_master/template_compilers/cfndsl.rb
@@ -5,11 +5,8 @@ module StackMaster::TemplateCompilers
     end
 
     def self.compile(template_file_path, compiler_options = {})
-      if compiler_options["disable_binding"]
-        ::CfnDsl.disable_binding
-      end
-
       extras = Array(compiler_options["external_parameters"])
+      ::CfnDsl.disable_binding if !extras.empty?
       ::CfnDsl.eval_file_with_extras(template_file_path, extras).to_json
     end
 

--- a/lib/stack_master/template_compilers/cfndsl.rb
+++ b/lib/stack_master/template_compilers/cfndsl.rb
@@ -5,7 +5,12 @@ module StackMaster::TemplateCompilers
     end
 
     def self.compile(template_file_path, compiler_options={})
-      ::CfnDsl.eval_file_with_extras(template_file_path).to_json
+      if compiler_options["disable_binding"]
+        ::CfnDsl.disable_binding
+      end
+
+      extras = Array(compiler_options["external_parameters"])
+      ::CfnDsl.eval_file_with_extras(template_file_path, extras).to_json
     end
 
     StackMaster::TemplateCompiler.register(:cfndsl, self)

--- a/lib/stack_master/template_compilers/cfndsl.rb
+++ b/lib/stack_master/template_compilers/cfndsl.rb
@@ -4,7 +4,7 @@ module StackMaster::TemplateCompilers
       require 'cfndsl'
     end
 
-    def self.compile(template_file_path)
+    def self.compile(template_file_path, compiler_options={})
       ::CfnDsl.eval_file_with_extras(template_file_path).to_json
     end
 

--- a/lib/stack_master/template_compilers/json.rb
+++ b/lib/stack_master/template_compilers/json.rb
@@ -7,7 +7,7 @@ module StackMaster::TemplateCompilers
       require 'json'
     end
 
-    def self.compile(template_file_path)
+    def self.compile(template_file_path, compiler_options={})
       template_body = File.read(template_file_path)
       if template_body.size > MAX_TEMPLATE_SIZE
         # Parse the json and rewrite compressed

--- a/lib/stack_master/template_compilers/json.rb
+++ b/lib/stack_master/template_compilers/json.rb
@@ -7,7 +7,7 @@ module StackMaster::TemplateCompilers
       require 'json'
     end
 
-    def self.compile(template_file_path, compiler_options={})
+    def self.compile(template_file_path, compiler_options = {})
       template_body = File.read(template_file_path)
       if template_body.size > MAX_TEMPLATE_SIZE
         # Parse the json and rewrite compressed

--- a/lib/stack_master/template_compilers/sparkle_formation.rb
+++ b/lib/stack_master/template_compilers/sparkle_formation.rb
@@ -5,7 +5,7 @@ module StackMaster::TemplateCompilers
       require 'stack_master/sparkle_formation/template_file'
     end
 
-    def self.compile(template_file_path)
+    def self.compile(template_file_path, compiler_options={})
       ::SparkleFormation.sparkle_path = File.dirname(template_file_path)
       JSON.pretty_generate(::SparkleFormation.compile(template_file_path))
     end

--- a/lib/stack_master/template_compilers/sparkle_formation.rb
+++ b/lib/stack_master/template_compilers/sparkle_formation.rb
@@ -5,7 +5,7 @@ module StackMaster::TemplateCompilers
       require 'stack_master/sparkle_formation/template_file'
     end
 
-    def self.compile(template_file_path, compiler_options={})
+    def self.compile(template_file_path, compiler_options = {})
       ::SparkleFormation.sparkle_path = File.dirname(template_file_path)
       JSON.pretty_generate(::SparkleFormation.compile(template_file_path))
     end

--- a/lib/stack_master/template_compilers/sparkle_formation.rb
+++ b/lib/stack_master/template_compilers/sparkle_formation.rb
@@ -6,7 +6,12 @@ module StackMaster::TemplateCompilers
     end
 
     def self.compile(template_file_path, compiler_options = {})
-      ::SparkleFormation.sparkle_path = File.dirname(template_file_path)
+      if compiler_options["sparkle_path"]
+        ::SparkleFormation.sparkle_path = File.expand_path(compiler_options["sparkle_path"])
+      else
+        ::SparkleFormation.sparkle_path = File.dirname(template_file_path)
+      end
+
       JSON.pretty_generate(::SparkleFormation.compile(template_file_path))
     end
 

--- a/lib/stack_master/template_compilers/yaml.rb
+++ b/lib/stack_master/template_compilers/yaml.rb
@@ -5,7 +5,7 @@ module StackMaster::TemplateCompilers
       require 'json'
     end
 
-    def self.compile(template_file_path)
+    def self.compile(template_file_path, compiler_options={})
       File.read(template_file_path)
     end
 

--- a/lib/stack_master/template_compilers/yaml.rb
+++ b/lib/stack_master/template_compilers/yaml.rb
@@ -5,7 +5,7 @@ module StackMaster::TemplateCompilers
       require 'json'
     end
 
-    def self.compile(template_file_path, compiler_options={})
+    def self.compile(template_file_path, compiler_options = {})
       File.read(template_file_path)
     end
 

--- a/lib/stack_master/validator.rb
+++ b/lib/stack_master/validator.rb
@@ -11,7 +11,7 @@ module StackMaster
 
     def perform
       StackMaster.stdout.print "#{@stack_definition.stack_name}: "
-      template_body = TemplateCompiler.compile(@config, @stack_definition.template_file_path)
+      template_body = TemplateCompiler.compile(@config, @stack_definition.template_file_path, @stack_definition.compiler_options)
       cf.validate_template(template_body: TemplateUtils.maybe_compressed_template_body(template_body))
       StackMaster.stdout.puts "valid"
       true

--- a/spec/stack_master/stack_spec.rb
+++ b/spec/stack_master/stack_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe StackMaster::Stack do
     before do
       allow(StackMaster::ParameterLoader).to receive(:load).and_return(parameter_hash)
       allow(StackMaster::ParameterResolver).to receive(:resolve).and_return(resolved_parameters)
-      allow(StackMaster::TemplateCompiler).to receive(:compile).with(config, stack_definition.template_file_path).and_return(template_body)
+      allow(StackMaster::TemplateCompiler).to receive(:compile).with(config, stack_definition.template_file_path, stack_definition.compiler_options).and_return(template_body)
       allow(File).to receive(:read).with(stack_definition.stack_policy_file_path).and_return(stack_policy_body)
     end
 

--- a/spec/stack_master/template_compiler_spec.rb
+++ b/spec/stack_master/template_compiler_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe StackMaster::TemplateCompiler do
 
     class TestTemplateCompiler
       def self.require_dependencies; end
-      def self.compile(template_file_path); end
+      def self.compile(template_file_path, compile_options); end
     end
 
     context 'when a template compiler is registered for the given file type' do
@@ -14,8 +14,14 @@ RSpec.describe StackMaster::TemplateCompiler do
       }
 
       it 'compiles the template using the relevant template compiler' do
-        expect(TestTemplateCompiler).to receive(:compile).with(template_file_path)
+        expect(TestTemplateCompiler).to receive(:compile).with(template_file_path, anything)
         StackMaster::TemplateCompiler.compile(config, template_file_path)
+      end
+
+      it 'passes compile_options to the template compiler' do
+        opts = {foo: 1, bar: true, baz: "meh"}
+        expect(TestTemplateCompiler).to receive(:compile).with(template_file_path, opts)
+        StackMaster::TemplateCompiler.compile(config, template_file_path, opts)
       end
 
       context 'when template compilation fails' do

--- a/spec/stack_master/template_compilers/cfndsl_spec.rb
+++ b/spec/stack_master/template_compilers/cfndsl_spec.rb
@@ -17,25 +17,18 @@ RSpec.describe StackMaster::TemplateCompilers::Cfndsl do
       end
     end
 
-    context 'with compiler options' do
+    context 'with external_parameters' do
       let(:template_file_path) { 'spec/fixtures/templates/rb/cfndsl/sample.rb' }
+      let(:compiler_options)  { { "external_parameters" => 'foo/bar.yml' } }
 
-      context 'with bindings disabled' do
-        let(:compiler_options)  { { "disable_binding" => true } }
-
-        it 'tells CfnDsl to disable bindings' do
-          expect(::CfnDsl).to receive(:disable_binding)
-          compile
-        end
+      it 'tells CfnDsl to use an external parameter file' do
+        expect(CfnDsl).to receive(:eval_file_with_extras).with(anything, ['foo/bar.yml'])
+        compile
       end
 
-      context 'with external_parameters' do
-        let(:compiler_options)  { { "external_parameters" => 'foo/bar.yml' } }
-
-        it 'tells CfnDsl to use an external parameter file' do
-          expect(CfnDsl).to receive(:eval_file_with_extras).with(anything, ['foo/bar.yml'])
-          compile
-        end
+      it 'disables bindings' do
+        expect(::CfnDsl).to receive(:disable_binding)
+        compile
       end
     end
   end

--- a/spec/stack_master/template_compilers/cfndsl_spec.rb
+++ b/spec/stack_master/template_compilers/cfndsl_spec.rb
@@ -3,16 +3,39 @@ RSpec.describe StackMaster::TemplateCompilers::Cfndsl do
 
   describe '.compile' do
     def compile
-      described_class.compile(template_file_path)
+      described_class.compile(template_file_path, compiler_options)
     end
 
     context 'valid cfndsl template' do
       let(:template_file_path) { 'spec/fixtures/templates/rb/cfndsl/sample.rb' }
       let(:valid_compiled_json_path) { 'spec/fixtures/templates/rb/cfndsl/sample.json' }
+      let(:compiler_options) { {} }
 
       it 'produces valid JSON' do
         valid_compiled_json = File.read(valid_compiled_json_path)
         expect(JSON.parse(compile)).to eq(JSON.parse(valid_compiled_json))
+      end
+    end
+
+    context 'with compiler options' do
+      let(:template_file_path) { 'spec/fixtures/templates/rb/cfndsl/sample.rb' }
+
+      context 'with bindings disabled' do
+        let(:compiler_options)  { { "disable_binding" => true } }
+
+        it 'tells CfnDsl to disable bindings' do
+          expect(::CfnDsl).to receive(:disable_binding)
+          compile
+        end
+      end
+
+      context 'with external_parameters' do
+        let(:compiler_options)  { { "external_parameters" => 'foo/bar.yml' } }
+
+        it 'tells CfnDsl to use an external parameter file' do
+          expect(CfnDsl).to receive(:eval_file_with_extras).with(anything, ['foo/bar.yml'])
+          compile
+        end
       end
     end
   end

--- a/spec/stack_master/template_compilers/sparkle_formation_spec.rb
+++ b/spec/stack_master/template_compilers/sparkle_formation_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe StackMaster::TemplateCompilers::SparkleFormation do
   describe '.compile' do
     def compile
-      described_class.compile(template_file_path)
+      described_class.compile(template_file_path, compiler_options)
     end
 
     before do
@@ -9,6 +9,7 @@ RSpec.describe StackMaster::TemplateCompilers::SparkleFormation do
     end
 
     let(:template_file_path) { '/base_dir/templates/template.rb' }
+    let(:compiler_options) { {} }
 
     it 'compiles with sparkleformation' do
       expect(compile).to eq("{\n}")
@@ -17,6 +18,20 @@ RSpec.describe StackMaster::TemplateCompilers::SparkleFormation do
     it 'sets the appropriate sparkle_path' do
       compile
       expect(SparkleFormation.sparkle_path).to eq File.dirname(template_file_path)
+    end
+
+    context 'with a custom sparkle_path' do
+      let(:compiler_options)  { { "sparkle_path" => '../foo' } }
+
+      it 'does not use the default path' do
+        compile
+        expect(SparkleFormation.sparkle_path).to_not eq File.dirname(template_file_path)
+      end
+
+      it 'expands the given path' do
+        compile
+        expect(SparkleFormation.sparkle_path).to match /^\/.+\/foo/
+      end
     end
   end
 end


### PR DESCRIPTION
I'm posting this PR for feedback on this proof of concept.  It is likely not ready for merge yet.

My motivation here was to take advantage of cfndsl's support for compile-time variables.  I've always found it awkward that we have great templating power on the ruby side (and full?  nearly full? information on the CF state), but the manifestation is via CF parameters and not direct interpolation into the templates.  There are times when I want that to shorten my templates, for example by using a loop with a table of values to spread N servers across M availability zones.

What this does so far:
- Adds a pass-through key for compiler-level parameters to be specified on the stack.
- Uses the above the support 2 things for CfnDsl:
  - Call disable_binding, recommended if using ruby external_parameters.
  - Support compile-time variables (aka `external_parameters`)

If this is vaguely sane, I think next thing would be to add some reasonable default lookup strategy so we can observe the same naming convention for these parameters as we do for regular CF parameters.

Rough examples:

stack_master.yml:

```
stacks:
  us-east-1:
    nat-subnet-az-b:
      template: nat-subnet.cfndsl
      compiler_options:
        disable_binding: true
        external_parameters:
          -
            - !ruby/symbol yaml
            - cfndsl_params/us-east-1/nat_subnet_az_b.yml
```

nat-subnet.cfndsl:

```
CloudFormation do
  descr = external_parameters.fetch(:description, "Create some subnets")
  msg   = external_parameters.fetch(:fun_msg, "A default")
  Description descr
  Output(:FunMessage, msg)
end
```

cfn_params/us-east-1/nat_subnet_az_b.yml:

```
fun_msg: "WHEEEE"
```
