### PR TITLE
Test against Ruby 2.3 series

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 rvm:
   - 2.2
-  - 2.3
+  - 2.3.1
 sudo: false
 script:
   - bundle exec rake spec features

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 rvm:
   - 2.2
+  - 2.3
 sudo: false
 script:
   - bundle exec rake spec features


### PR DESCRIPTION
This PR let Travis know we want to test the codebase against the latest Ruby 2.3.x. I think the gem should support Ruby 2.3 because this series is now getting more popular as 2.4 series is wrapping up for release soon.

There are fews deprecation warning, but no broken features AFAIK. Should this PR get accepted, I will cook new PRs to address those aforementioned warnings.

cc @stevehodgkiss 