### PR TITLE
if a load on a resolver fails, try singularizing it.

### DIFF
--- a/lib/stack_master/parameter_resolver.rb
+++ b/lib/stack_master/parameter_resolver.rb
@@ -30,7 +30,11 @@ module StackMaster
     def require_parameter_resolver(file_name)
       require "stack_master/parameter_resolvers/#{file_name}"
     rescue LoadError
-      raise ResolverNotFound.new(file_name)
+      if file_name == file_name.singularize
+        raise ResolverNotFound.new(file_name)
+      else
+        require_parameter_resolver(file_name.singularize)
+      end
     end
 
     def load_parameter_resolver(class_name)

--- a/spec/stack_master/parameter_resolver_spec.rb
+++ b/spec/stack_master/parameter_resolver_spec.rb
@@ -99,5 +99,21 @@ RSpec.describe StackMaster::ParameterResolver do
 
       parameter_resolver.resolve
     end
+
+    context "using an array resolver" do
+      let(:params) do
+        {
+          param: { other_dummy_resolvers: [1, 2] }
+        }
+      end
+
+      it "tries to load the plural and singular forms" do
+        expect(parameter_resolver).to receive(:require_parameter_resolver).with("other_dummy_resolvers").once.and_call_original.ordered
+        expect(parameter_resolver).to receive(:require_parameter_resolver).with("other_dummy_resolver").once.ordered
+        expect(parameter_resolver).to receive(:call_resolver).and_return nil
+
+        parameter_resolver.resolve
+      end
+    end
   end
 end


### PR DESCRIPTION
This fixes an issue if you've got the first reference to a resolver in the array form, e.g:

stack_master.yml:
```
stacks:
  main:
    nat-subnet-a:
      template: nat-subnet.json
    nat-subnet-b:
      template: nat-subnet.json
    cache-cluster:
      template: redis-cache-cluster.json
```

parameters/main/redis_cache_cluster.yml:

```
subnets:
  stack_outputs:
    - nat-subnet-a/SubnetId
    - nat-subnet-b/SubnetId
```