### PR TITLE
Improve reporting of validation errors in parameter resolvers

### DIFF
--- a/lib/stack_master/parameter_resolver.rb
+++ b/lib/stack_master/parameter_resolver.rb
@@ -57,6 +57,8 @@ module StackMaster
       value = parameter_value.values.first
       resolver_class_name = resolver_name.camelize
       call_resolver(resolver_class_name, value)
+    rescue Aws::CloudFormation::Errors::ValidationError
+      raise InvalidParameter, $!.message
     end
 
     def call_resolver(class_name, value)


### PR DESCRIPTION
I had a mistake in my parameter resolvers were I was referring to a stack that didn't exist. This was showing up when I did a `stack_master status`. The error that was coming back was correct but not helpful in identifying where my problem was.

```
Aws::CloudFormation::Errors::ValidationError Stack with id customercollections does not exist
```

This PR improves the error message to give more feedback as to what is causing the problem. The new error looks something like this:

```
error: Unable to resolve parameter "CustomerCollectionsCodeDeployEndpoint" value causing error: Stack with id customercollections does not exist.
```

Basically it translates the AWS ValidationError into a InvalidParameter error which is caught further up the stack. The message generated upstream could use some improvement IMO but I left it alone for now.