### PR TITLE
Adding support for cfndsl external parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,23 @@ the following lines to your `stack_master.yml`.
 template_compilers:
   rb: cfndsl
 ```
+## Using external parameters with cfndsl
+In your stack_master.yml file specify cfndsl_external_parameters: file.yml
+file.yml will be loaded from a directory named external_parameters
+Example
+```yaml
+region_aliases:
+  production: ap-southeast-2
+  staging: ap-southeast-2
+template_compilers:
+  rb: cfndsl
+stacks:
+  production:
+    s3:
+      template: s3.rb
+      cfndsl_external_parameters: s3.yml
 
+```
 ## Parameters
 
 Parameters are loaded from multiple YAML files, merged from the following lookup paths:

--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ my_parameter:
     - value2
 ```
 
-## User Data Files in SparkleFormation templates
+## ERB Template Files in SparkleFormation templates
 
 An extension to SparkleFormation is the `user_data_file!` method, which evaluates templates in `templates/user_data/[file_name]`. Most of the usual SparkleFormation methods are available in user data templates. Example:
 
@@ -344,6 +344,27 @@ And used like this in SparkleFormation templates:
 ```
 # templates/app.rb
   user_data user_data_file!('app.erb', role: :worker)
+```
+
+You can also use the `joined_file!` method which evaluates templates in `templates/config/[file_name]`. It is similar to `user_data_file!` but doesn't do base64 encoding. Example:
+
+```
+# templates/config/someconfig.conf.erb
+my_variable=<%= ref!(:foo) %>
+my_other_variable=<%= account_id! %>
+```
+
+```
+# templates/ecs_task.rb
+container_definitions array!(
+  -> {
+    command array!(
+      "-e",
+      joined_file!('someconfig.conf.erb')
+    )
+    ...
+  }
+)
 ```
 
 ## Commands

--- a/README.md
+++ b/README.md
@@ -329,6 +329,19 @@ my_parameter:
     - value2
 ```
 
+Array parameter values can include nested parameter resolvers.
+
+For example, given the following parameter definition:
+```
+my_parameter:
+  - stack_output: my-stack/output # value resolves to 'value1'
+  - value2
+```
+The parameter value will resolve to:
+```
+my_parameter: 'value1,value2'
+```
+
 ## ERB Template Files in SparkleFormation templates
 
 An extension to SparkleFormation is the `user_data_file!` method, which evaluates templates in `templates/user_data/[file_name]`. Most of the usual SparkleFormation methods are available in user data templates. Example:

--- a/lib/stack_master.rb
+++ b/lib/stack_master.rb
@@ -24,6 +24,7 @@ module StackMaster
   autoload :ResolverArray, 'stack_master/resolver_array'
   autoload :Resolver, 'stack_master/resolver_array'
   autoload :Utils, 'stack_master/utils'
+  autoload :TemplateUtils, 'stack_master/template_utils'
   autoload :Config, 'stack_master/config'
   autoload :PagedResponseAccumulator, 'stack_master/paged_response_accumulator'
   autoload :StackDefinition, 'stack_master/stack_definition'

--- a/lib/stack_master/commands/apply.rb
+++ b/lib/stack_master/commands/apply.rb
@@ -103,7 +103,7 @@ module StackMaster
         if use_s3?
           s3.url(bucket: @s3_config['bucket'], prefix: @s3_config['prefix'], region: @s3_config['region'], template: @stack_definition.s3_template_file_name)
         else
-          proposed_stack.maybe_compressed_template_body
+          proposed_stack.template
         end
       end
 
@@ -112,7 +112,7 @@ module StackMaster
         @stack_definition.s3_files.tap do |files|
           files[@stack_definition.s3_template_file_name] = {
             path: @stack_definition.template_file_path,
-            body: proposed_stack.maybe_compressed_template_body
+            body: proposed_stack.template
           }
         end
       end

--- a/lib/stack_master/parameter_resolver.rb
+++ b/lib/stack_master/parameter_resolver.rb
@@ -47,7 +47,7 @@ module StackMaster
 
     def resolve_parameter_value(key, parameter_value)
       return parameter_value.to_s if Numeric === parameter_value || parameter_value == true || parameter_value == false
-      return parameter_value.join(',') if Array === parameter_value
+      return resolve_array_parameter_values(key, parameter_value).join(',') if Array === parameter_value
       return parameter_value unless Hash === parameter_value
       validate_parameter_value!(key, parameter_value)
 
@@ -59,6 +59,12 @@ module StackMaster
       call_resolver(resolver_class_name, value)
     rescue Aws::CloudFormation::Errors::ValidationError
       raise InvalidParameter, $!.message
+    end
+
+    def resolve_array_parameter_values(key, parameter_values)
+      parameter_values.reduce([]) do |values, parameter_value|
+        values << resolve_parameter_value(key, parameter_value)
+      end
     end
 
     def call_resolver(class_name, value)

--- a/lib/stack_master/sparkle_formation/template_file.rb
+++ b/lib/stack_master/sparkle_formation/template_file.rb
@@ -23,23 +23,29 @@ module StackMaster
       include ::SparkleFormation::SparkleAttribute::Aws
       include ::SparkleFormation::Utils::TypeCheckers
 
-      def self.build(vars)
+      def self.build(vars, prefix)
         ::Class.new(self).tap do |klass|
           vars.each do |key, value|
             klass.send(:define_method, key) do
               value
             end
           end
-        end.new(vars)
+
+        end.new(vars, prefix)
       end
 
-      def initialize(vars)
+      def initialize(vars, prefix)
         self._camel_keys = true
         @vars = vars
+        @prefix = prefix
       end
 
       def has_var?(var_key)
         @vars.include?(var_key)
+      end
+
+      def render(file_name, vars = {})
+        Template.render(@prefix, file_name, vars)
       end
     end
 
@@ -80,7 +86,7 @@ module StackMaster
       def self.render(prefix, file_name, vars)
         file_path = File.join(::SparkleFormation.sparkle_path, prefix, file_name)
         template = File.read(file_path)
-        template_context = TemplateContext.build(vars)
+        template_context = TemplateContext.build(vars, prefix)
         compiled_template = SfEruby.new(template).evaluate(template_context)
         CloudFormationLineFormatter.format(compiled_template)
       rescue Errno::ENOENT => e

--- a/lib/stack_master/sparkle_formation/template_file.rb
+++ b/lib/stack_master/sparkle_formation/template_file.rb
@@ -3,7 +3,7 @@ require 'erubis'
 
 module StackMaster
   module SparkleFormation
-    UserDataFileNotFound = ::Class.new(StandardError)
+    TemplateFileNotFound = ::Class.new(StandardError)
 
     class SfEruby < Erubis::Eruby
       include Erubis::ArrayEnhancer
@@ -76,15 +76,28 @@ module StackMaster
       end
     end
 
-    module UserDataFile
-      def _user_data_file(file_name, vars = {})
-        file_path = File.join(::SparkleFormation.sparkle_path, 'user_data', file_name)
+    module Template
+      def self.render(prefix, file_name, vars)
+        file_path = File.join(::SparkleFormation.sparkle_path, prefix, file_name)
         template = File.read(file_path)
         template_context = TemplateContext.build(vars)
         compiled_template = SfEruby.new(template).evaluate(template_context)
-        base64!(join!(CloudFormationLineFormatter.format(compiled_template)))
+        CloudFormationLineFormatter.format(compiled_template)
       rescue Errno::ENOENT => e
-        Kernel.raise UserDataFileNotFound, "Could not find user data file at path: #{file_path}"
+        Kernel.raise TemplateFileNotFound, "Could not find template file at path: #{file_path}"
+      end
+    end
+
+    module JoinedFile
+      def _joined_file(file_name, vars = {})
+        join!(Template.render('joined_file', file_name, vars))
+      end
+      alias_method :joined_file!, :_joined_file
+    end
+
+    module UserDataFile
+      def _user_data_file(file_name, vars = {})
+        base64!(join!(Template.render('user_data', file_name, vars)))
       end
       alias_method :user_data_file!, :_user_data_file
     end
@@ -92,3 +105,5 @@ module StackMaster
 end
 
 SparkleFormation::SparkleAttribute::Aws.send(:include, StackMaster::SparkleFormation::UserDataFile)
+SparkleFormation::SparkleAttribute::Aws.send(:include, StackMaster::SparkleFormation::JoinedFile)
+

--- a/lib/stack_master/stack.rb
+++ b/lib/stack_master/stack.rb
@@ -61,7 +61,7 @@ module StackMaster
 
     def self.generate(stack_definition, config)
       parameter_hash = ParameterLoader.load(stack_definition.parameter_files)
-      template_body = TemplateCompiler.compile(config, stack_definition.template_file_path, stack_definition)
+      template_body = TemplateCompiler.compile(config, stack_definition.template_file_path, stack_definition.cfndsl_external_parameters)
       template_format = TemplateUtils.identify_template_format(template_body)
       parameters = ParameterResolver.resolve(config, stack_definition, parameter_hash)
       stack_policy_body = if stack_definition.stack_policy_file_path

--- a/lib/stack_master/stack.rb
+++ b/lib/stack_master/stack.rb
@@ -61,7 +61,7 @@ module StackMaster
 
     def self.generate(stack_definition, config)
       parameter_hash = ParameterLoader.load(stack_definition.parameter_files)
-      template_body = TemplateCompiler.compile(config, stack_definition.template_file_path)
+      template_body = TemplateCompiler.compile(config, stack_definition.template_file_path, stack_definition)
       template_format = TemplateUtils.identify_template_format(template_body)
       parameters = ParameterResolver.resolve(config, stack_definition, parameter_hash)
       stack_policy_body = if stack_definition.stack_policy_file_path

--- a/lib/stack_master/stack_definition.rb
+++ b/lib/stack_master/stack_definition.rb
@@ -8,6 +8,7 @@ module StackMaster
                   :base_dir,
                   :secret_file,
                   :stack_policy_file,
+                  :cfndsl_external_parameters,
                   :additional_parameter_lookup_dirs,
                   :s3,
                   :files
@@ -19,6 +20,7 @@ module StackMaster
       @notification_arns = []
       @s3 = {}
       @files = []
+      @cfndsl_external_parameters = []
       super
     end
 
@@ -30,6 +32,7 @@ module StackMaster
         @tags == other.tags &&
         @notification_arns == other.notification_arns &&
         @base_dir == other.base_dir &&
+        @cfndsl_external_parameters == other.cfndsl_external_parameters &&
         @secret_file == other.secret_file &&
         @stack_policy_file == other.stack_policy_file &&
         @additional_parameter_lookup_dirs == other.additional_parameter_lookup_dirs &&

--- a/lib/stack_master/stack_differ.rb
+++ b/lib/stack_master/stack_differ.rb
@@ -15,7 +15,7 @@ module StackMaster
     def current_template
       return '' unless @current_stack
       return @current_stack.template_body unless @current_stack.template_format == :json
-      JSON.pretty_generate(@current_stack.template_hash)
+      JSON.pretty_generate(TemplateUtils.template_hash(@current_stack.template_body))
     end
 
     def current_parameters

--- a/lib/stack_master/template_compiler.rb
+++ b/lib/stack_master/template_compiler.rb
@@ -2,10 +2,10 @@ module StackMaster
   class TemplateCompiler
     TemplateCompilationFailed = Class.new(RuntimeError)
 
-    def self.compile(config, template_file_path, stack_definition)
+    def self.compile(config, template_file_path, cfndsl_external_parameters)
       compiler = template_compiler_for_file(template_file_path, config)
       compiler.require_dependencies
-      compiler.compile(config, template_file_path, stack_definition)
+      compiler.compile(config, template_file_path, cfndsl_external_parameters)
     rescue
       raise TemplateCompilationFailed.new("Failed to compile #{template_file_path}.")
     end

--- a/lib/stack_master/template_compiler.rb
+++ b/lib/stack_master/template_compiler.rb
@@ -2,10 +2,10 @@ module StackMaster
   class TemplateCompiler
     TemplateCompilationFailed = Class.new(RuntimeError)
 
-    def self.compile(config, template_file_path)
+    def self.compile(config, template_file_path, stack_definition)
       compiler = template_compiler_for_file(template_file_path, config)
       compiler.require_dependencies
-      compiler.compile(template_file_path)
+      compiler.compile(config, template_file_path, stack_definition)
     rescue
       raise TemplateCompilationFailed.new("Failed to compile #{template_file_path}.")
     end

--- a/lib/stack_master/template_compilers/cfndsl.rb
+++ b/lib/stack_master/template_compilers/cfndsl.rb
@@ -4,10 +4,10 @@ module StackMaster::TemplateCompilers
       require 'cfndsl'
     end
 
-    def self.compile(config, template_file_path, stack_definition)
+    def self.compile(config, template_file_path, cfndsl_external_parameters)
       params = []
       params.push([:yaml, File.join(config.base_dir, 'external_parameters', 
-                  stack_definition.cfndsl_external_parameters)]) if stack_definition.cfndsl_external_parameters.length > 0
+                  cfndsl_external_parameters)]) if cfndsl_external_parameters.length > 0
       ::CfnDsl.eval_file_with_extras(template_file_path, params).to_json
     end
 

--- a/lib/stack_master/template_compilers/cfndsl.rb
+++ b/lib/stack_master/template_compilers/cfndsl.rb
@@ -6,9 +6,16 @@ module StackMaster::TemplateCompilers
 
     def self.compile(config, template_file_path, cfndsl_external_parameters)
       params = []
+      if cfndsl_external_parameters.is_a?(Array)
+        cfndsl_external_parameters.each do |cfndsl_param|
+          params.push([:yaml, File.join(config.base_dir, 'external_parameters',
+                 cfndsl_param)])      
+          end
+      else
       params.push([:yaml, File.join(config.base_dir, 'external_parameters', 
                   cfndsl_external_parameters)]) if cfndsl_external_parameters.length > 0
       ::CfnDsl.eval_file_with_extras(template_file_path, params).to_json
+      end
     end
 
     StackMaster::TemplateCompiler.register(:cfndsl, self)

--- a/lib/stack_master/template_compilers/cfndsl.rb
+++ b/lib/stack_master/template_compilers/cfndsl.rb
@@ -6,7 +6,8 @@ module StackMaster::TemplateCompilers
 
     def self.compile(config, template_file_path, stack_definition)
       params = []
-      params.push([:yaml, File.join(config.base_dir, 'external_parameters', stack_definition.cfndsl_external_parameters)]) if stack_definition.cfndsl_external_parameters.length > 0
+      params.push([:yaml, File.join(config.base_dir, 'external_parameters', 
+                  stack_definition.cfndsl_external_parameters)]) if stack_definition.cfndsl_external_parameters.length > 0
       ::CfnDsl.eval_file_with_extras(template_file_path, params).to_json
     end
 

--- a/lib/stack_master/template_compilers/cfndsl.rb
+++ b/lib/stack_master/template_compilers/cfndsl.rb
@@ -4,8 +4,11 @@ module StackMaster::TemplateCompilers
       require 'cfndsl'
     end
 
-    def self.compile(template_file_path)
-      ::CfnDsl.eval_file_with_extras(template_file_path).to_json
+    def self.compile(config, template_file_path, stack_definition)
+      params = []
+      params.push([:yaml, File.join(config.base_dir, 'external_parameters', stack_definition.cfndsl_external_parameters)]) if !stack_definition.cfndsl_external_parameters.nil? 
+#      params.push([:yaml, "#{stack_definition.cfndsl_external_parameters}"]) if !stack_definition.cfndsl_external_parameters.nil? 
+      ::CfnDsl.eval_file_with_extras(template_file_path, params).to_json
     end
 
     StackMaster::TemplateCompiler.register(:cfndsl, self)

--- a/lib/stack_master/template_compilers/cfndsl.rb
+++ b/lib/stack_master/template_compilers/cfndsl.rb
@@ -6,8 +6,7 @@ module StackMaster::TemplateCompilers
 
     def self.compile(config, template_file_path, stack_definition)
       params = []
-      params.push([:yaml, File.join(config.base_dir, 'external_parameters', stack_definition.cfndsl_external_parameters)]) if !stack_definition.cfndsl_external_parameters.nil? 
-#      params.push([:yaml, "#{stack_definition.cfndsl_external_parameters}"]) if !stack_definition.cfndsl_external_parameters.nil? 
+      params.push([:yaml, File.join(config.base_dir, 'external_parameters', stack_definition.cfndsl_external_parameters)]) if stack_definition.cfndsl_external_parameters.length > 0
       ::CfnDsl.eval_file_with_extras(template_file_path, params).to_json
     end
 

--- a/lib/stack_master/template_compilers/cfndsl.rb
+++ b/lib/stack_master/template_compilers/cfndsl.rb
@@ -12,10 +12,10 @@ module StackMaster::TemplateCompilers
                  cfndsl_param)])      
           end
       else
-      params.push([:yaml, File.join(config.base_dir, 'external_parameters', 
+        params.push([:yaml, File.join(config.base_dir, 'external_parameters',
                   cfndsl_external_parameters)]) if cfndsl_external_parameters.length > 0
-      ::CfnDsl.eval_file_with_extras(template_file_path, params).to_json
       end
+      ::CfnDsl.eval_file_with_extras(template_file_path, params).to_json
     end
 
     StackMaster::TemplateCompiler.register(:cfndsl, self)

--- a/lib/stack_master/template_compilers/json.rb
+++ b/lib/stack_master/template_compilers/json.rb
@@ -7,7 +7,7 @@ module StackMaster::TemplateCompilers
       require 'json'
     end
 
-    def self.compile(template_file_path)
+    def self.compile(config, template_file_path, stack_definition)
       template_body = File.read(template_file_path)
       if template_body.size > MAX_TEMPLATE_SIZE
         # Parse the json and rewrite compressed

--- a/lib/stack_master/template_compilers/sparkle_formation.rb
+++ b/lib/stack_master/template_compilers/sparkle_formation.rb
@@ -5,7 +5,7 @@ module StackMaster::TemplateCompilers
       require 'stack_master/sparkle_formation/template_file'
     end
 
-    def self.compile(template_file_path)
+    def self.compile(config, template_file_path, stack_definition)
       ::SparkleFormation.sparkle_path = File.dirname(template_file_path)
       JSON.pretty_generate(::SparkleFormation.compile(template_file_path))
     end

--- a/lib/stack_master/template_compilers/sparkle_formation.rb
+++ b/lib/stack_master/template_compilers/sparkle_formation.rb
@@ -2,7 +2,7 @@ module StackMaster::TemplateCompilers
   class SparkleFormation
     def self.require_dependencies
       require 'sparkle_formation'
-      require 'stack_master/sparkle_formation/user_data_file'
+      require 'stack_master/sparkle_formation/template_file'
     end
 
     def self.compile(template_file_path)

--- a/lib/stack_master/template_compilers/yaml.rb
+++ b/lib/stack_master/template_compilers/yaml.rb
@@ -5,7 +5,7 @@ module StackMaster::TemplateCompilers
       require 'json'
     end
 
-    def self.compile(template_file_path)
+    def self.compile(config, template_file_path, stack_definition)
       File.read(template_file_path)
     end
 

--- a/lib/stack_master/template_utils.rb
+++ b/lib/stack_master/template_utils.rb
@@ -1,0 +1,31 @@
+module StackMaster
+  module TemplateUtils
+    MAX_TEMPLATE_SIZE = 51200
+    MAX_S3_TEMPLATE_SIZE = 460800
+
+    extend self
+
+    def identify_template_format(template_body)
+      return :json if template_body =~ /^{/x # ignore leading whitespaces
+      :yaml
+    end
+
+    def template_hash(template_body=nil)
+      return unless template_body
+      template_format = identify_template_format(template_body)
+      case template_format
+      when :json
+        JSON.parse(template_body)
+      when :yaml
+        YAML.load(template_body)
+      end
+    end
+
+    def maybe_compressed_template_body(template_body)
+      # Do not compress the template if it's not JSON because parsing YAML as a hash ignores
+      # CloudFormation-specific tags such as !Ref
+      return template_body if template_body.size <= MAX_TEMPLATE_SIZE || identify_template_format(template_body) != :json
+      JSON.dump(template_hash(template_body))
+    end
+  end
+end

--- a/lib/stack_master/validator.rb
+++ b/lib/stack_master/validator.rb
@@ -11,7 +11,7 @@ module StackMaster
 
     def perform
       StackMaster.stdout.print "#{@stack_definition.stack_name}: "
-      template_body = TemplateCompiler.compile(@config, @stack_definition.template_file_path)
+      template_body = Stack.generate(@stack_definition, @config).maybe_compressed_template_body
       cf.validate_template(template_body: template_body)
       StackMaster.stdout.puts "valid"
       true

--- a/lib/stack_master/validator.rb
+++ b/lib/stack_master/validator.rb
@@ -11,7 +11,7 @@ module StackMaster
 
     def perform
       StackMaster.stdout.print "#{@stack_definition.stack_name}: "
-      template_body = TemplateCompiler.compile(@config, @stack_definition.template_file_path, @stack_definition)
+      template_body = TemplateCompiler.compile(@config, @stack_definition.template_file_path, @stack_definition.cfndsl_external_parameters)
       cf.validate_template(template_body: TemplateUtils.maybe_compressed_template_body(template_body))
       StackMaster.stdout.puts "valid"
       true

--- a/lib/stack_master/validator.rb
+++ b/lib/stack_master/validator.rb
@@ -11,8 +11,8 @@ module StackMaster
 
     def perform
       StackMaster.stdout.print "#{@stack_definition.stack_name}: "
-      template_body = Stack.generate(@stack_definition, @config).maybe_compressed_template_body
-      cf.validate_template(template_body: template_body)
+      template_body = TemplateCompiler.compile(@config, @stack_definition.template_file_path)
+      cf.validate_template(template_body: TemplateUtils.maybe_compressed_template_body(template_body))
       StackMaster.stdout.puts "valid"
       true
     rescue Aws::CloudFormation::Errors::ValidationError => e

--- a/lib/stack_master/validator.rb
+++ b/lib/stack_master/validator.rb
@@ -11,7 +11,7 @@ module StackMaster
 
     def perform
       StackMaster.stdout.print "#{@stack_definition.stack_name}: "
-      template_body = TemplateCompiler.compile(@config, @stack_definition.template_file_path)
+      template_body = TemplateCompiler.compile(@config, @stack_definition.template_file_path, @stack_definition)
       cf.validate_template(template_body: TemplateUtils.maybe_compressed_template_body(template_body))
       StackMaster.stdout.puts "valid"
       true

--- a/lib/stack_master/version.rb
+++ b/lib/stack_master/version.rb
@@ -1,3 +1,3 @@
 module StackMaster
-  VERSION = "0.11.0"
+  VERSION = "0.12.0"
 end

--- a/lib/stack_master/version.rb
+++ b/lib/stack_master/version.rb
@@ -1,3 +1,3 @@
 module StackMaster
-  VERSION = "0.12.1"
+  VERSION = "0.13.0"
 end

--- a/lib/stack_master/version.rb
+++ b/lib/stack_master/version.rb
@@ -1,3 +1,3 @@
 module StackMaster
-  VERSION = "0.10.1"
+  VERSION = "0.10.2"
 end

--- a/lib/stack_master/version.rb
+++ b/lib/stack_master/version.rb
@@ -1,3 +1,3 @@
 module StackMaster
-  VERSION = "0.10.2"
+  VERSION = "0.11.0"
 end

--- a/lib/stack_master/version.rb
+++ b/lib/stack_master/version.rb
@@ -1,3 +1,3 @@
 module StackMaster
-  VERSION = "0.10.0"
+  VERSION = "0.10.1"
 end

--- a/lib/stack_master/version.rb
+++ b/lib/stack_master/version.rb
@@ -1,3 +1,3 @@
 module StackMaster
-  VERSION = "0.12.0"
+  VERSION = "0.12.1"
 end

--- a/lib/stack_master/version.rb
+++ b/lib/stack_master/version.rb
@@ -1,3 +1,3 @@
 module StackMaster
-  VERSION = "0.9.0"
+  VERSION = "0.10.0"
 end

--- a/spec/fixtures/parameters/myapp_vpc_with_secrets.yml
+++ b/spec/fixtures/parameters/myapp_vpc_with_secrets.yml
@@ -1,0 +1,3 @@
+param_1: 'hello'
+param_2:
+  secret: world

--- a/spec/fixtures/stack_master.yml
+++ b/spec/fixtures/stack_master.yml
@@ -32,6 +32,8 @@ stacks:
         - test_arn_2
     myapp_web:
       template: myapp_web.rb
+    myapp_vpc_with_secrets:
+      template: myapp_vpc.json
   ap-southeast-2:
     myapp_vpc:
       template: myapp_vpc.rb

--- a/spec/stack_master/commands/status_spec.rb
+++ b/spec/stack_master/commands/status_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe StackMaster::Commands::Status do
     end
 
     context "some parameters are different" do
-      let(:stack1) { double(:stack1, template_hash: {}, template_format: :json, parameters_with_defaults: {a: 1}, stack_status: 'UPDATE_COMPLETE') }
-      let(:stack2) { double(:stack2, template_hash: {}, template_format: :json, parameters_with_defaults: {a: 2}, stack_status: 'CREATE_COMPLETE') }
+      let(:stack1) { double(:stack1, template_body: '{}', template_hash: {}, template_format: :json, parameters_with_defaults: {a: 1}, stack_status: 'UPDATE_COMPLETE') }
+      let(:stack2) { double(:stack2, template_body: '{}', template_hash: {}, template_format: :json, parameters_with_defaults: {a: 2}, stack_status: 'CREATE_COMPLETE') }
       let(:proposed_stack1) { double(:proposed_stack1, template_body: "{}", template_format: :json, parameters_with_defaults: {a: 1}) }
       let(:proposed_stack2) { double(:proposed_stack2, template_body: "{}", template_format: :json, parameters_with_defaults: {a: 1}) }
 
@@ -29,8 +29,8 @@ RSpec.describe StackMaster::Commands::Status do
     end
 
     context "some templates are different" do
-      let(:stack1) { double(:stack1, template_hash: {foo: 'bar'}, template_format: :json, parameters_with_defaults: {a: 1}, stack_status: 'UPDATE_COMPLETE') }
-      let(:stack2) { double(:stack2, template_hash: {}, template_format: :json, parameters_with_defaults: {a: 1}, stack_status: 'CREATE_COMPLETE') }
+      let(:stack1) { double(:stack1, template_body: '{"foo": "bar"}', template_hash: {foo: 'bar'}, template_format: :json, parameters_with_defaults: {a: 1}, stack_status: 'UPDATE_COMPLETE') }
+      let(:stack2) { double(:stack2, template_body: '{}', template_hash: {}, template_format: :json, parameters_with_defaults: {a: 1}, stack_status: 'CREATE_COMPLETE') }
       let(:proposed_stack1) { double(:proposed_stack1, template_body: "{}", template_format: :json, parameters_with_defaults: {a: 1}) }
       let(:proposed_stack2) { double(:proposed_stack2, template_body: "{}", template_format: :json, parameters_with_defaults: {a: 1}) }
 

--- a/spec/stack_master/config_spec.rb
+++ b/spec/stack_master/config_spec.rb
@@ -53,12 +53,12 @@ RSpec.describe StackMaster::Config do
 
     it 'can filter by region only' do
       stacks = loaded_config.filter('us-east-1')
-      expect(stacks.size).to eq 2
+      expect(stacks.size).to eq 3
     end
 
     it 'can return all stack definitions with no filters' do
       stacks = loaded_config.filter
-      expect(stacks.size).to eq 4
+      expect(stacks.size).to eq 5
     end
   end
 

--- a/spec/stack_master/parameter_resolver_spec.rb
+++ b/spec/stack_master/parameter_resolver_spec.rb
@@ -66,6 +66,16 @@ RSpec.describe StackMaster::ParameterResolver do
     }.to_not raise_error
   end
 
+  context 'when array values contain resolver hashes' do
+    it 'returns the comma separated string values returned by the resolvers' do
+      expect(resolve(param: [1, { my_resolver: 2 }])).to eq(param: '1,10')
+    end
+
+    it 'returns nested array values' do
+      expect(resolve(param: [[1, { my_resolver: 3 }], { my_resolver: 2 }])).to eq(param: '1,15,10')
+    end
+  end
+
   context 'when given a proper resolve hash' do
     it 'returns the value returned by the resolver as the parameter value' do
       expect(resolve(param: { my_resolver: 2 })).to eq(param: 10)

--- a/spec/stack_master/stack_spec.rb
+++ b/spec/stack_master/stack_spec.rb
@@ -4,6 +4,15 @@ RSpec.describe StackMaster::Stack do
   let(:stack_id) { '1' }
   let(:stack_policy_body) { '{}' }
   let(:cf) { Aws::CloudFormation::Client.new }
+  let(:stack_definition) do
+    StackMaster::StackDefinition.new(
+        region: 'us-east-1',
+        stack_name: 'myapp_vpc',
+        template: 'myapp_vpc.json',
+        tags: { 'environment' => 'production' },
+        base_dir: File.expand_path('spec/fixtures'),
+    )
+  end
   subject(:stack) { StackMaster::Stack.find(region, stack_name) }
 
   before do
@@ -83,7 +92,7 @@ RSpec.describe StackMaster::Stack do
     before do
       allow(StackMaster::ParameterLoader).to receive(:load).and_return(parameter_hash)
       allow(StackMaster::ParameterResolver).to receive(:resolve).and_return(resolved_parameters)
-      allow(StackMaster::TemplateCompiler).to receive(:compile).with(config, stack_definition.template_file_path).and_return(template_body)
+      allow(StackMaster::TemplateCompiler).to receive(:compile).with(config, stack_definition.template_file_path, stack_definition).and_return(template_body)
       allow(File).to receive(:read).with(stack_definition.stack_policy_file_path).and_return(stack_policy_body)
     end
 

--- a/spec/stack_master/stack_spec.rb
+++ b/spec/stack_master/stack_spec.rb
@@ -124,26 +124,6 @@ RSpec.describe StackMaster::Stack do
     end
   end
 
-  describe "#maybe_compressed_template_body" do
-    subject(:maybe_compressed_template_body) do
-      stack.maybe_compressed_template_body
-    end
-    context "undersized json" do
-      let(:stack) { described_class.new(template_body: '{     }' ) }
-
-      it "leaves the json alone if it's not too large" do
-        expect(maybe_compressed_template_body).to eq('{     }')
-      end
-    end
-
-    context "oversized json" do
-      let(:stack) { described_class.new(template_body: "{#{' ' * 60000}}", template_format: :json) }
-      it "compresses the json when it's overly bulbous" do
-        expect(maybe_compressed_template_body).to eq('{}')
-      end
-    end
-  end
-
   describe '#too_big?' do
     let(:big_stack) { described_class.new(template_body: "{\"a\":\"#{'x' * 500000}\"}") }
     let(:medium_stack) { described_class.new(template_body: "{\"a\":\"#{'x' * 60000}\"}") }

--- a/spec/stack_master/stack_spec.rb
+++ b/spec/stack_master/stack_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe StackMaster::Stack do
     before do
       allow(StackMaster::ParameterLoader).to receive(:load).and_return(parameter_hash)
       allow(StackMaster::ParameterResolver).to receive(:resolve).and_return(resolved_parameters)
-      allow(StackMaster::TemplateCompiler).to receive(:compile).with(config, stack_definition.template_file_path, stack_definition).and_return(template_body)
+      allow(StackMaster::TemplateCompiler).to receive(:compile).with(config, stack_definition.template_file_path, stack_definition.cfndsl_external_parameters).and_return(template_body)
       allow(File).to receive(:read).with(stack_definition.stack_policy_file_path).and_return(stack_policy_body)
     end
 

--- a/spec/stack_master/template_compiler_spec.rb
+++ b/spec/stack_master/template_compiler_spec.rb
@@ -2,10 +2,19 @@ RSpec.describe StackMaster::TemplateCompiler do
   describe '.compile' do
     let(:config) { double(template_compilers: { fab: :test_template_compiler }) }
     let(:template_file_path) { '/base_dir/templates/template.fab' }
+    let(:stack_definition) do
+      StackMaster::StackDefinition.new(
+        region: 'us-east-1',
+        stack_name: 'myapp_vpc',
+        template: 'myapp_vpc.json',
+        tags: { 'environment' => 'production' },
+        base_dir: File.expand_path('spec/fixtures'),
+      )
+    end
 
     class TestTemplateCompiler
       def self.require_dependencies; end
-      def self.compile(template_file_path); end
+      def self.compile(config, template_file_path, stack_definition); end
     end
 
     context 'when a template compiler is registered for the given file type' do
@@ -14,15 +23,15 @@ RSpec.describe StackMaster::TemplateCompiler do
       }
 
       it 'compiles the template using the relevant template compiler' do
-        expect(TestTemplateCompiler).to receive(:compile).with(template_file_path)
-        StackMaster::TemplateCompiler.compile(config, template_file_path)
+        expect(TestTemplateCompiler).to receive(:compile).with(config, template_file_path, stack_definition)
+        StackMaster::TemplateCompiler.compile(config, template_file_path, stack_definition)
       end
 
       context 'when template compilation fails' do
         before { allow(TestTemplateCompiler).to receive(:compile).and_raise(RuntimeError) }
 
         it 'raise TemplateCompilationFailed exception' do
-          expect{ StackMaster::TemplateCompiler.compile(config, template_file_path)
+          expect{ StackMaster::TemplateCompiler.compile(config, template_file_path, stack_definition)
           }.to raise_error(
                  StackMaster::TemplateCompiler::TemplateCompilationFailed,"Failed to compile #{template_file_path}.")
         end

--- a/spec/stack_master/template_compilers/cfndsl_spec.rb
+++ b/spec/stack_master/template_compilers/cfndsl_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe StackMaster::TemplateCompilers::Cfndsl do
 
   describe '.compile' do
     def compile
-      described_class.compile(config, template_file_path, stack_definition)
+      described_class.compile(config, template_file_path, stack_definition.cfndsl_external_parameters)
     end
 
     context 'valid cfndsl template' do

--- a/spec/stack_master/template_compilers/cfndsl_spec.rb
+++ b/spec/stack_master/template_compilers/cfndsl_spec.rb
@@ -1,9 +1,19 @@
 RSpec.describe StackMaster::TemplateCompilers::Cfndsl do
+  let(:config) { StackMaster::Config.new({'stacks' => {}}, '/base_dir') }
+  let(:stack_definition) do
+    StackMaster::StackDefinition.new(
+      region: 'us-east-1',
+      stack_name: 'myapp_vpc',
+      template: 'myapp_vpc.json',
+      tags: { 'environment' => 'production' },
+      base_dir: File.expand_path('spec/fixtures'),
+    )
+  end
   before(:all) { described_class.require_dependencies }
 
   describe '.compile' do
     def compile
-      described_class.compile(template_file_path)
+      described_class.compile(config, template_file_path, stack_definition)
     end
 
     context 'valid cfndsl template' do

--- a/spec/stack_master/template_compilers/json_spec.rb
+++ b/spec/stack_master/template_compilers/json_spec.rb
@@ -1,7 +1,17 @@
 RSpec.describe StackMaster::TemplateCompilers::Json do
+  let(:config) { double(template_compilers: { fab: :test_template_compiler }) }
+  let(:stack_definition) do
+    StackMaster::StackDefinition.new(
+      region: 'us-east-1',
+      stack_name: 'myapp_vpc',
+      template: 'myapp_vpc.json',
+      tags: { 'environment' => 'production' },
+      base_dir: File.expand_path('spec/fixtures'),
+    )
+  end
   describe '.compile' do
     def compile
-      described_class.compile(template_file_path)
+      described_class.compile(config, template_file_path, stack_definition)
     end
 
     let(:template_file_path) { '/base_dir/templates/template.json' }

--- a/spec/stack_master/template_compilers/sparkle_formation_spec.rb
+++ b/spec/stack_master/template_compilers/sparkle_formation_spec.rb
@@ -1,7 +1,18 @@
 RSpec.describe StackMaster::TemplateCompilers::SparkleFormation do
+  let(:config) { double(template_compilers: { fab: :test_template_compiler }) }
+  let(:stack_definition) do
+    StackMaster::StackDefinition.new(
+      region: 'us-east-1',
+      stack_name: 'myapp_vpc',
+      template: 'myapp_vpc.json',
+      tags: { 'environment' => 'production' },
+      base_dir: File.expand_path('spec/fixtures'),
+    )
+  end
+
   describe '.compile' do
     def compile
-      described_class.compile(template_file_path)
+      described_class.compile(config, template_file_path, stack_definition)
     end
 
     before do

--- a/spec/stack_master/template_compilers/yaml_spec.rb
+++ b/spec/stack_master/template_compilers/yaml_spec.rb
@@ -1,7 +1,18 @@
 RSpec.describe StackMaster::TemplateCompilers::Yaml do
+  let(:config) { double(template_compilers: { fab: :test_template_compiler }) }
+  let(:stack_definition) do
+    StackMaster::StackDefinition.new(
+      region: 'us-east-1',
+      stack_name: 'myapp_vpc',
+      template: 'myapp_vpc.json',
+      tags: { 'environment' => 'production' },
+      base_dir: File.expand_path('spec/fixtures'),
+    )
+  end
+
   describe '.compile' do
     def compile
-      described_class.compile(template_file_path)
+      described_class.compile(config, template_file_path, stack_definition)
     end
 
     context 'valid YAML template' do

--- a/spec/stack_master/template_utils_spec.rb
+++ b/spec/stack_master/template_utils_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe StackMaster::TemplateUtils do
+  describe "#maybe_compressed_template_body" do
+    subject(:maybe_compressed_template_body) do
+      described_class.maybe_compressed_template_body(template_body)
+    end
+    context "undersized json" do
+      let(:template_body) { '{     }' }
+
+      it "leaves the json alone if it's not too large" do
+        expect(maybe_compressed_template_body).to eq('{     }')
+      end
+    end
+
+    context "oversized json" do
+      let(:template_body) { "{#{' ' * 60000}}" }
+      it "compresses the json when it's overly bulbous" do
+        expect(maybe_compressed_template_body).to eq('{}')
+      end
+    end
+  end
+end

--- a/stack_master.gemspec
+++ b/stack_master.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "timecop"
   spec.add_dependency "ruby-progressbar"
   spec.add_dependency "commander"
-  spec.add_dependency "aws-sdk", "~> 2.2.31"
+  spec.add_dependency "aws-sdk", "~> 2.6.26"
   spec.add_dependency "diffy"
   spec.add_dependency "erubis"
   spec.add_dependency "colorize"


### PR DESCRIPTION
To resolve this issue https://github.com/envato/stack_master/issues/143 Given I needed to access both stack_definition and config within the template compiler I have modified a few files and updated to 0.9.1 though I can revert that if required! This is a awesome piece of software I must say!