### PR TITLE
Update version of aws-sdk

### DIFF
--- a/lib/stack_master/version.rb
+++ b/lib/stack_master/version.rb
@@ -1,3 +1,3 @@
 module StackMaster
-  VERSION = "0.9.0"
+  VERSION = "0.9.1"
 end

--- a/lib/stack_master/version.rb
+++ b/lib/stack_master/version.rb
@@ -1,3 +1,3 @@
 module StackMaster
-  VERSION = "0.9.1"
+  VERSION = "0.10.0"
 end

--- a/stack_master.gemspec
+++ b/stack_master.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "timecop"
   spec.add_dependency "ruby-progressbar"
   spec.add_dependency "commander"
-  spec.add_dependency "aws-sdk", "~> 2.2.31"
+  spec.add_dependency "aws-sdk", "~> 2.6.26"
   spec.add_dependency "diffy"
   spec.add_dependency "erubis"
   spec.add_dependency "colorize"


### PR DESCRIPTION
The current version of `aws-sdk` is pinned at 2.2.31, which is quite old.  Any projects which declare `stack_master` in their Gemfile are stuck on that old version.

Update to the most recently-released version.