### PR TITLE
Compress the template when we attempt to validate it

### DIFF
--- a/lib/stack_master/validator.rb
+++ b/lib/stack_master/validator.rb
@@ -11,7 +11,7 @@ module StackMaster
 
     def perform
       StackMaster.stdout.print "#{@stack_definition.stack_name}: "
-      template_body = TemplateCompiler.compile(@config, @stack_definition.template_file_path)
+      template_body = Stack.generate(@stack_definition, @config).maybe_compressed_template_body
       cf.validate_template(template_body: template_body)
       StackMaster.stdout.puts "valid"
       true


### PR DESCRIPTION
Issue
----

When attempting to validate a stack that applies cleanly, StackMaster reports the stack is invalid:

```
 invalid. 1 validation error detected: Value '{
...
}' at 'templateBody' failed to satisfy constraint: Member must have length less than or equal to 51200
```

It appears that while the template is small enough that it can be compressed and applied, the validation command is not compressing it.

Fix
----

Use Stack.generate to create the template, as it shrinks the template body and provides consistent behaviour between the apply and validate methods.