### PR TITLE
Fixup my foobar in #146

### DIFF
--- a/lib/stack_master.rb
+++ b/lib/stack_master.rb
@@ -24,6 +24,7 @@ module StackMaster
   autoload :ResolverArray, 'stack_master/resolver_array'
   autoload :Resolver, 'stack_master/resolver_array'
   autoload :Utils, 'stack_master/utils'
+  autoload :TemplateUtils, 'stack_master/template_utils'
   autoload :Config, 'stack_master/config'
   autoload :PagedResponseAccumulator, 'stack_master/paged_response_accumulator'
   autoload :StackDefinition, 'stack_master/stack_definition'

--- a/lib/stack_master/commands/apply.rb
+++ b/lib/stack_master/commands/apply.rb
@@ -103,7 +103,7 @@ module StackMaster
         if use_s3?
           s3.url(bucket: @s3_config['bucket'], prefix: @s3_config['prefix'], region: @s3_config['region'], template: @stack_definition.s3_template_file_name)
         else
-          proposed_stack.maybe_compressed_template_body
+          proposed_stack.template
         end
       end
 
@@ -112,7 +112,7 @@ module StackMaster
         @stack_definition.s3_files.tap do |files|
           files[@stack_definition.s3_template_file_name] = {
             path: @stack_definition.template_file_path,
-            body: proposed_stack.maybe_compressed_template_body
+            body: proposed_stack.template
           }
         end
       end

--- a/lib/stack_master/stack.rb
+++ b/lib/stack_master/stack.rb
@@ -1,8 +1,5 @@
 module StackMaster
   class Stack
-    MAX_TEMPLATE_SIZE = 51200
-    MAX_S3_TEMPLATE_SIZE = 460800
-
     attr_reader :stack_name,
                 :region,
                 :stack_id,
@@ -18,25 +15,8 @@ module StackMaster
 
     include Utils::Initializable
 
-    def template_hash
-      return unless template_body
-      @template_hash ||= case template_format
-                         when :json
-                           JSON.parse(template_body)
-                         when :yaml
-                           YAML.load(template_body)
-                         end
-    end
-
-    def maybe_compressed_template_body
-      # Do not compress the template if it's not JSON because parsing YAML as a hash ignores
-      # CloudFormation-specific tags such as !Ref
-      return template_body if template_body.size <= MAX_TEMPLATE_SIZE || template_format != :json
-      @compressed_template_body ||= JSON.dump(template_hash)
-    end
-
     def template_default_parameters
-      template_hash.fetch('Parameters', {}).inject({}) do |result, (parameter_name, description)|
+      TemplateUtils.template_hash(template_format, template).fetch('Parameters', {}).inject({}) do |result, (parameter_name, description)|
         result[parameter_name] = description['Default']
         result
       end
@@ -61,7 +41,7 @@ module StackMaster
         params_hash
       end
       template_body ||= cf.get_template(stack_name: stack_name).template_body
-      template_format = identify_template_format(template_body)
+      template_format = TemplateUtils.identify_template_format(template_body)
       stack_policy_body ||= cf.get_stack_policy(stack_name: stack_name).stack_policy_body
       outputs = cf_stack.outputs
 
@@ -82,7 +62,7 @@ module StackMaster
     def self.generate(stack_definition, config)
       parameter_hash = ParameterLoader.load(stack_definition.parameter_files)
       template_body = TemplateCompiler.compile(config, stack_definition.template_file_path)
-      template_format = identify_template_format(template_body)
+      template_format = TemplateUtils.identify_template_format(template_body)
       parameters = ParameterResolver.resolve(config, stack_definition, parameter_hash)
       stack_policy_body = if stack_definition.stack_policy_file_path
                             File.read(stack_definition.stack_policy_file_path)
@@ -97,19 +77,13 @@ module StackMaster
           stack_policy_body: stack_policy_body)
     end
 
-    def self.identify_template_format(template_body)
-      return :json if template_body =~ /^{/x # ignore leading whitespaces
-      :yaml
-    end
-    private_class_method :identify_template_format
-
     def max_template_size(use_s3)
-      return MAX_S3_TEMPLATE_SIZE if use_s3
-      MAX_TEMPLATE_SIZE
+      return TemplateUtils::MAX_S3_TEMPLATE_SIZE if use_s3
+      TemplateUtils::MAX_TEMPLATE_SIZE
     end
 
     def too_big?(use_s3 = false)
-      maybe_compressed_template_body.size > max_template_size(use_s3)
+      template.size > max_template_size(use_s3)
     end
 
     def aws_parameters
@@ -118,6 +92,10 @@ module StackMaster
 
     def aws_tags
       Utils.hash_to_aws_tags(tags)
+    end
+
+    def template
+      @template ||= TemplateUtils.maybe_compressed_template_body(template_format, template_body)
     end
   end
 end

--- a/lib/stack_master/stack.rb
+++ b/lib/stack_master/stack.rb
@@ -16,7 +16,7 @@ module StackMaster
     include Utils::Initializable
 
     def template_default_parameters
-      TemplateUtils.template_hash(template_format, template).fetch('Parameters', {}).inject({}) do |result, (parameter_name, description)|
+      TemplateUtils.template_hash(template).fetch('Parameters', {}).inject({}) do |result, (parameter_name, description)|
         result[parameter_name] = description['Default']
         result
       end
@@ -95,7 +95,7 @@ module StackMaster
     end
 
     def template
-      @template ||= TemplateUtils.maybe_compressed_template_body(template_format, template_body)
+      @template ||= TemplateUtils.maybe_compressed_template_body(template_body)
     end
   end
 end

--- a/lib/stack_master/stack_differ.rb
+++ b/lib/stack_master/stack_differ.rb
@@ -15,7 +15,7 @@ module StackMaster
     def current_template
       return '' unless @current_stack
       return @current_stack.template_body unless @current_stack.template_format == :json
-      JSON.pretty_generate(@current_stack.template_hash)
+      JSON.pretty_generate(TemplateUtils.template_hash(@current_stack.template_format, @current_stack.template_body))
     end
 
     def current_parameters

--- a/lib/stack_master/stack_differ.rb
+++ b/lib/stack_master/stack_differ.rb
@@ -15,7 +15,7 @@ module StackMaster
     def current_template
       return '' unless @current_stack
       return @current_stack.template_body unless @current_stack.template_format == :json
-      JSON.pretty_generate(TemplateUtils.template_hash(@current_stack.template_format, @current_stack.template_body))
+      JSON.pretty_generate(TemplateUtils.template_hash(@current_stack.template_body))
     end
 
     def current_parameters

--- a/lib/stack_master/template_utils.rb
+++ b/lib/stack_master/template_utils.rb
@@ -10,8 +10,9 @@ module StackMaster
       :yaml
     end
 
-    def template_hash(template_format, template_body=nil)
+    def template_hash(template_body=nil)
       return unless template_body
+      template_format = identify_template_format(template_body)
       case template_format
       when :json
         JSON.parse(template_body)
@@ -20,11 +21,11 @@ module StackMaster
       end
     end
 
-    def maybe_compressed_template_body(template_format, template_body)
+    def maybe_compressed_template_body(template_body)
       # Do not compress the template if it's not JSON because parsing YAML as a hash ignores
       # CloudFormation-specific tags such as !Ref
-      return template_body if template_body.size <= MAX_TEMPLATE_SIZE || template_format != :json
-      JSON.dump(template_hash(template_format, template_body))
+      return template_body if template_body.size <= MAX_TEMPLATE_SIZE || identify_template_format(template_body) != :json
+      JSON.dump(template_hash(template_body))
     end
   end
 end

--- a/lib/stack_master/template_utils.rb
+++ b/lib/stack_master/template_utils.rb
@@ -1,0 +1,30 @@
+module StackMaster
+  module TemplateUtils
+    MAX_TEMPLATE_SIZE = 51200
+    MAX_S3_TEMPLATE_SIZE = 460800
+
+    extend self
+
+    def identify_template_format(template_body)
+      return :json if template_body =~ /^{/x # ignore leading whitespaces
+      :yaml
+    end
+
+    def template_hash(template_format, template_body=nil)
+      return unless template_body
+      case template_format
+      when :json
+        JSON.parse(template_body)
+      when :yaml
+        YAML.load(template_body)
+      end
+    end
+
+    def maybe_compressed_template_body(template_format, template_body)
+      # Do not compress the template if it's not JSON because parsing YAML as a hash ignores
+      # CloudFormation-specific tags such as !Ref
+      return template_body if template_body.size <= MAX_TEMPLATE_SIZE || template_format != :json
+      JSON.dump(template_hash(template_format, template_body))
+    end
+  end
+end

--- a/lib/stack_master/validator.rb
+++ b/lib/stack_master/validator.rb
@@ -11,7 +11,7 @@ module StackMaster
 
     def perform
       StackMaster.stdout.print "#{@stack_definition.stack_name}: "
-      template_body = Stack.generate(@stack_definition, @config).maybe_compressed_template_body
+      template_body = TemplateCompiler.compile(@config, @stack_definition.template_file_path)
       cf.validate_template(template_body: template_body)
       StackMaster.stdout.puts "valid"
       true

--- a/lib/stack_master/validator.rb
+++ b/lib/stack_master/validator.rb
@@ -12,7 +12,7 @@ module StackMaster
     def perform
       StackMaster.stdout.print "#{@stack_definition.stack_name}: "
       template_body = TemplateCompiler.compile(@config, @stack_definition.template_file_path)
-      cf.validate_template(template_body: template_body)
+      cf.validate_template(template_body: TemplateUtils.maybe_compressed_template_body(template_body))
       StackMaster.stdout.puts "valid"
       true
     rescue Aws::CloudFormation::Errors::ValidationError => e

--- a/lib/stack_master/version.rb
+++ b/lib/stack_master/version.rb
@@ -1,3 +1,3 @@
 module StackMaster
-  VERSION = "0.10.1"
+  VERSION = "0.10.2"
 end

--- a/spec/fixtures/parameters/myapp_vpc_with_secrets.yml
+++ b/spec/fixtures/parameters/myapp_vpc_with_secrets.yml
@@ -1,0 +1,3 @@
+param_1: 'hello'
+param_2:
+  secret: world

--- a/spec/fixtures/stack_master.yml
+++ b/spec/fixtures/stack_master.yml
@@ -32,6 +32,8 @@ stacks:
         - test_arn_2
     myapp_web:
       template: myapp_web.rb
+    myapp_vpc_with_secrets:
+      template: myapp_vpc.json
   ap-southeast-2:
     myapp_vpc:
       template: myapp_vpc.rb

--- a/spec/stack_master/commands/status_spec.rb
+++ b/spec/stack_master/commands/status_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe StackMaster::Commands::Status do
     end
 
     context "some parameters are different" do
-      let(:stack1) { double(:stack1, template_hash: {}, template_format: :json, parameters_with_defaults: {a: 1}, stack_status: 'UPDATE_COMPLETE') }
-      let(:stack2) { double(:stack2, template_hash: {}, template_format: :json, parameters_with_defaults: {a: 2}, stack_status: 'CREATE_COMPLETE') }
+      let(:stack1) { double(:stack1, template_body: '{}', template_hash: {}, template_format: :json, parameters_with_defaults: {a: 1}, stack_status: 'UPDATE_COMPLETE') }
+      let(:stack2) { double(:stack2, template_body: '{}', template_hash: {}, template_format: :json, parameters_with_defaults: {a: 2}, stack_status: 'CREATE_COMPLETE') }
       let(:proposed_stack1) { double(:proposed_stack1, template_body: "{}", template_format: :json, parameters_with_defaults: {a: 1}) }
       let(:proposed_stack2) { double(:proposed_stack2, template_body: "{}", template_format: :json, parameters_with_defaults: {a: 1}) }
 
@@ -29,8 +29,8 @@ RSpec.describe StackMaster::Commands::Status do
     end
 
     context "some templates are different" do
-      let(:stack1) { double(:stack1, template_hash: {foo: 'bar'}, template_format: :json, parameters_with_defaults: {a: 1}, stack_status: 'UPDATE_COMPLETE') }
-      let(:stack2) { double(:stack2, template_hash: {}, template_format: :json, parameters_with_defaults: {a: 1}, stack_status: 'CREATE_COMPLETE') }
+      let(:stack1) { double(:stack1, template_body: '{"foo": "bar"}', template_hash: {foo: 'bar'}, template_format: :json, parameters_with_defaults: {a: 1}, stack_status: 'UPDATE_COMPLETE') }
+      let(:stack2) { double(:stack2, template_body: '{}', template_hash: {}, template_format: :json, parameters_with_defaults: {a: 1}, stack_status: 'CREATE_COMPLETE') }
       let(:proposed_stack1) { double(:proposed_stack1, template_body: "{}", template_format: :json, parameters_with_defaults: {a: 1}) }
       let(:proposed_stack2) { double(:proposed_stack2, template_body: "{}", template_format: :json, parameters_with_defaults: {a: 1}) }
 

--- a/spec/stack_master/config_spec.rb
+++ b/spec/stack_master/config_spec.rb
@@ -53,12 +53,12 @@ RSpec.describe StackMaster::Config do
 
     it 'can filter by region only' do
       stacks = loaded_config.filter('us-east-1')
-      expect(stacks.size).to eq 2
+      expect(stacks.size).to eq 3
     end
 
     it 'can return all stack definitions with no filters' do
       stacks = loaded_config.filter
-      expect(stacks.size).to eq 4
+      expect(stacks.size).to eq 5
     end
   end
 

--- a/spec/stack_master/stack_spec.rb
+++ b/spec/stack_master/stack_spec.rb
@@ -124,26 +124,6 @@ RSpec.describe StackMaster::Stack do
     end
   end
 
-  describe "#maybe_compressed_template_body" do
-    subject(:maybe_compressed_template_body) do
-      stack.maybe_compressed_template_body
-    end
-    context "undersized json" do
-      let(:stack) { described_class.new(template_body: '{     }' ) }
-
-      it "leaves the json alone if it's not too large" do
-        expect(maybe_compressed_template_body).to eq('{     }')
-      end
-    end
-
-    context "oversized json" do
-      let(:stack) { described_class.new(template_body: "{#{' ' * 60000}}", template_format: :json) }
-      it "compresses the json when it's overly bulbous" do
-        expect(maybe_compressed_template_body).to eq('{}')
-      end
-    end
-  end
-
   describe '#too_big?' do
     let(:big_stack) { described_class.new(template_body: "{\"a\":\"#{'x' * 500000}\"}") }
     let(:medium_stack) { described_class.new(template_body: "{\"a\":\"#{'x' * 60000}\"}") }

--- a/spec/stack_master/template_utils_spec.rb
+++ b/spec/stack_master/template_utils_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe StackMaster::TemplateUtils do
   describe "#maybe_compressed_template_body" do
     subject(:maybe_compressed_template_body) do
-      described_class.maybe_compressed_template_body(:json, template_body)
+      described_class.maybe_compressed_template_body(template_body)
     end
     context "undersized json" do
       let(:template_body) { '{     }' }

--- a/spec/stack_master/template_utils_spec.rb
+++ b/spec/stack_master/template_utils_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe StackMaster::TemplateUtils do
+  describe "#maybe_compressed_template_body" do
+    subject(:maybe_compressed_template_body) do
+      described_class.maybe_compressed_template_body(:json, template_body)
+    end
+    context "undersized json" do
+      let(:template_body) { '{     }' }
+
+      it "leaves the json alone if it's not too large" do
+        expect(maybe_compressed_template_body).to eq('{     }')
+      end
+    end
+
+    context "oversized json" do
+      let(:template_body) { "{#{' ' * 60000}}" }
+      it "compresses the json when it's overly bulbous" do
+        expect(maybe_compressed_template_body).to eq('{}')
+      end
+    end
+  end
+end


### PR DESCRIPTION
I introduced a breaking change in 0.10.1! This exposed a lack of test coverage for our use case.

We expect to be able to run the validate command from our CI system with only the cloudformation:ValidateStack permission (not a hard requirement) and to not have to resolve secret parameters with GPG keys.

Changes
----

- Create a test for the expected functionality
- Revert #146
- Extract the compression method and it's relatives into a new TemplateUtils class
- Have validate use the TemplateUtils class to compress the stack