### PR TITLE
Add support for nested parameter resolvers for array values

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,19 @@ my_parameter:
     - value2
 ```
 
+Array parameter values can include nested parameter resolvers.
+
+For example, given the following parameter definition:
+```
+my_parameter:
+  - stack_output: my-stack/output # value resolves to 'value1'
+  - value2
+```
+The parameter value will resolve to:
+```
+my_parameter: 'value1,value2'
+```
+
 ## ERB Template Files in SparkleFormation templates
 
 An extension to SparkleFormation is the `user_data_file!` method, which evaluates templates in `templates/user_data/[file_name]`. Most of the usual SparkleFormation methods are available in user data templates. Example:

--- a/lib/stack_master/parameter_resolver.rb
+++ b/lib/stack_master/parameter_resolver.rb
@@ -47,7 +47,7 @@ module StackMaster
 
     def resolve_parameter_value(key, parameter_value)
       return parameter_value.to_s if Numeric === parameter_value || parameter_value == true || parameter_value == false
-      return parameter_value.join(',') if Array === parameter_value
+      return resolve_array_parameter_values(key, parameter_value).join(',') if Array === parameter_value
       return parameter_value unless Hash === parameter_value
       validate_parameter_value!(key, parameter_value)
 
@@ -59,6 +59,12 @@ module StackMaster
       call_resolver(resolver_class_name, value)
     rescue Aws::CloudFormation::Errors::ValidationError
       raise InvalidParameter, $!.message
+    end
+
+    def resolve_array_parameter_values(key, parameter_values)
+      parameter_values.reduce([]) do |values, parameter_value|
+        values << resolve_parameter_value(key, parameter_value)
+      end
     end
 
     def call_resolver(class_name, value)

--- a/spec/stack_master/parameter_resolver_spec.rb
+++ b/spec/stack_master/parameter_resolver_spec.rb
@@ -66,6 +66,16 @@ RSpec.describe StackMaster::ParameterResolver do
     }.to_not raise_error
   end
 
+  context 'when array values contain resolver hashes' do
+    it 'returns the comma separated string values returned by the resolvers' do
+      expect(resolve(param: [1, { my_resolver: 2 }])).to eq(param: '1,10')
+    end
+
+    it 'returns nested array values' do
+      expect(resolve(param: [[1, { my_resolver: 3 }], { my_resolver: 2 }])).to eq(param: '1,15,10')
+    end
+  end
+
   context 'when given a proper resolve hash' do
     it 'returns the value returned by the resolver as the parameter value' do
       expect(resolve(param: { my_resolver: 2 })).to eq(param: 10)


### PR DESCRIPTION
Add support for resolving array parameter values using parameter resolvers. This is particularly useful when building up array values from various sources.

For example, given the following parameter definition:
```
my_parameter:
  - stack_output: my-stack/output # value resolves to 'value1'
  - value2
```
The parameter value will resolve to:
```
my_parameter: 'value1,value2'
```