### PR TITLE
Allow nesting user_data files

### DIFF
--- a/lib/stack_master/sparkle_formation/template_file.rb
+++ b/lib/stack_master/sparkle_formation/template_file.rb
@@ -45,7 +45,7 @@ module StackMaster
       end
 
       def render(file_name, vars = {})
-        Template.render(@prefix, file_name, @vars.merge(vars))
+        Template.render(@prefix, file_name, vars)
       end
     end
 


### PR DESCRIPTION
This is meant to let us DRY up our user data templates that have common parts, ala Rails templates:

```
# in dj.sh.erb

<%= render ‘common.sh.erb’ %>
# some more DJ specific instructions
```

I've only tested it in the console so far.

- [ ] Add a spec