### PR TITLE
retry throttling errors on CloudFormation#validate_template

### DIFF
--- a/lib/stack_master/aws_driver/cloud_formation.rb
+++ b/lib/stack_master/aws_driver/cloud_formation.rb
@@ -19,12 +19,17 @@ module StackMaster
                           :get_stack_policy,
                           :describe_stack_events,
                           :update_stack,
-                          :create_stack,
-                          :validate_template
+                          :create_stack
 
       def describe_stacks(options)
         retry_with_backoff do
           cf.describe_stacks(options)
+        end
+      end
+
+      def validate_template(options)
+        retry_with_backoff do
+          cf.validate_template(options)
         end
       end
 


### PR DESCRIPTION
This ought to fix #131.  It may be worth switching to the retryable gem at some point.