### PR TITLE
Adding support for output parameters in a different region

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,11 +167,20 @@ region/account, even though the resolved values will be different.
 ### Stack Output
 
 The stack output parameter resolver looks up outputs from other stacks in the
-same region. The expected format is `[stack-name]/[OutputName]`.
+same or different region. The expected format is `[(region|region-alias):]stack-name/(OutputName|output_name)`.
 
 ```yaml
 vpc_id:
+  # Output from a stack in the same region
   stack_output: my-vpc-stack/VpcId
+
+bucket_name:
+  # Output from a stack in a different region
+  stack_output: us-east-1:init-bucket/bucket_name
+
+zone_name:
+  # Output from a stack in a different region using its alias
+  stack_output: global:hosted-zone/ZoneName
 ```
 
 This is the most used parameter resolver because it enables stacks to be split
@@ -306,7 +315,7 @@ vpc_id:
 
 Most resolvers support taking an array of values that will each be resolved.
 Unless stated otherwise in the documentation, the array version of the
-resolver will be named with the [pluralized](http://api.rubyonrails.org/classes/ActiveSupport/Inflector.html#method-i-pluralize) 
+resolver will be named with the [pluralized](http://api.rubyonrails.org/classes/ActiveSupport/Inflector.html#method-i-pluralize)
 name of the original resolver.
 
 When creating a new resolver, one can automatically create the array resolver by adding a `array_resolver` statement

--- a/lib/stack_master/aws_driver/cloud_formation.rb
+++ b/lib/stack_master/aws_driver/cloud_formation.rb
@@ -3,6 +3,8 @@ module StackMaster
     class CloudFormation
       extend Forwardable
 
+      attr_reader :region
+
       def set_region(region)
         @region = region
         @cf = nil

--- a/lib/stack_master/aws_driver/cloud_formation.rb
+++ b/lib/stack_master/aws_driver/cloud_formation.rb
@@ -3,11 +3,15 @@ module StackMaster
     class CloudFormation
       extend Forwardable
 
-      attr_reader :region
+      def region
+        @region ||= ENV['AWS_REGION'] || Aws.config[:region] || Aws.shared_config.region
+      end
 
-      def set_region(region)
-        @region = region
-        @cf = nil
+      def set_region(value)
+        if region != value
+          @region = value
+          @cf = nil
+        end
       end
 
       def_delegators :cf, :create_change_set,
@@ -33,7 +37,7 @@ module StackMaster
       private
 
       def cf
-        @cf ||= Aws::CloudFormation::Client.new(region: @region)
+        @cf ||= Aws::CloudFormation::Client.new(region: region)
       end
 
       def retry_with_backoff

--- a/lib/stack_master/parameter_resolvers/stack_output.rb
+++ b/lib/stack_master/parameter_resolvers/stack_output.rb
@@ -17,7 +17,7 @@ module StackMaster
         region, stack_name, output_name = parse!(value)
         stack = find_stack(stack_name, region)
         if stack
-          output = stack.outputs.find { |o| o.output_key == output_name.camelize }
+          output = stack.outputs.find { |stack_output| stack_output.output_key == output_name.camelize }
           if output
             output.output_value
           else

--- a/lib/stack_master/parameter_resolvers/stack_output.rb
+++ b/lib/stack_master/parameter_resolvers/stack_output.rb
@@ -39,7 +39,11 @@ module StackMaster
           raise ArgumentError, 'Stack output values must be in the form of [region:]stack-name/output_name'
         end
 
-        match.captures
+        [
+          match[:region] || cf.region,
+          match[:stack_name],
+          match[:output_name]
+        ]
       end
 
       def find_stack(stack_name, region)
@@ -57,10 +61,6 @@ module StackMaster
 
           @stacks[stack_key] = cf_stack
         end
-      end
-
-      def stack_key(stack_name, region)
-        "#{region || 'any'}:#{stack_name}"
       end
     end
   end

--- a/lib/stack_master/parameter_resolvers/stack_output.rb
+++ b/lib/stack_master/parameter_resolvers/stack_output.rb
@@ -52,7 +52,7 @@ module StackMaster
         stack_key = stack_key(stack_name, unaliased_region)
 
         @stacks.fetch(stack_key) do
-          regional_cf = cf_for_region(region)
+          regional_cf = cf_for_region(unaliased_region)
           cf_stack = regional_cf.describe_stacks(stack_name: stack_name).stacks.first
           @stacks[stack_key] = cf_stack
         end

--- a/lib/stack_master/parameter_resolvers/stack_output.rb
+++ b/lib/stack_master/parameter_resolvers/stack_output.rb
@@ -10,7 +10,7 @@ module StackMaster
         @config = config
         @stack_definition = stack_definition
         @stacks = {}
-        @output_regex = %r{(?:([^:]+):)?([^:/]+)/(.+)}
+        @output_regex = %r{(?:(?<region>[^:]+):)?(?<stack_name>[^:/]+)/(?<output_name>.+)}
       end
 
       def resolve(value)

--- a/lib/stack_master/parameter_resolvers/stack_output.rb
+++ b/lib/stack_master/parameter_resolvers/stack_output.rb
@@ -43,12 +43,18 @@ module StackMaster
       end
 
       def find_stack(stack_name, region)
-        stack_key = stack_key(stack_name, region)
+        unaliased_region = @config.unalias_region(region)
+        stack_key = stack_key(stack_name, unaliased_region)
+
         @stacks.fetch(stack_key) do
           original_region = cf.region
-          cf.set_region(region) if region && original_region != region
+
+          cf.set_region(unaliased_region) if region && original_region != unaliased_region
+
           cf_stack = cf.describe_stacks(stack_name: stack_name).stacks.first
-          cf.set_region(original_region) if region && original_region != region
+
+          cf.set_region(original_region) if region && original_region != unaliased_region
+
           @stacks[stack_key] = cf_stack
         end
       end

--- a/lib/stack_master/parameter_resolvers/stack_output.rb
+++ b/lib/stack_master/parameter_resolvers/stack_output.rb
@@ -10,6 +10,7 @@ module StackMaster
         @config = config
         @stack_definition = stack_definition
         @stacks = {}
+        @cf_drivers = {}
         @output_regex = %r{(?:(?<region>[^:]+):)?(?<stack_name>[^:/]+)/(?<output_name>.+)}
       end
 
@@ -51,15 +52,23 @@ module StackMaster
         stack_key = stack_key(stack_name, unaliased_region)
 
         @stacks.fetch(stack_key) do
-          original_region = cf.region
-
-          cf.set_region(unaliased_region) if region && original_region != unaliased_region
-
-          cf_stack = cf.describe_stacks(stack_name: stack_name).stacks.first
-
-          cf.set_region(original_region) if region && original_region != unaliased_region
-
+          regional_cf = cf_for_region(region)
+          cf_stack = regional_cf.describe_stacks(stack_name: stack_name).stacks.first
           @stacks[stack_key] = cf_stack
+        end
+      end
+
+      def stack_key(stack_name, region)
+        "#{region}:#{stack_name}"
+      end
+
+      def cf_for_region(region)
+        return cf if cf.region == region
+
+        @cf_drivers.fetch(region) do
+          cloud_formation_driver = cf.class.new
+          cloud_formation_driver.set_region(region)
+          @cf_drivers[region] = cloud_formation_driver
         end
       end
     end

--- a/lib/stack_master/test_driver/cloud_formation.rb
+++ b/lib/stack_master/test_driver/cloud_formation.rb
@@ -64,7 +64,9 @@ module StackMaster
         reset
       end
 
-      attr_reader :region
+      def region
+        @region ||= ENV['AWS_REGION'] || Aws.config[:region] || Aws.shared_config.region
+      end
 
       def set_region(region)
         @region = region

--- a/lib/stack_master/test_driver/cloud_formation.rb
+++ b/lib/stack_master/test_driver/cloud_formation.rb
@@ -64,6 +64,8 @@ module StackMaster
         reset
       end
 
+      attr_reader :region
+
       def set_region(region)
         @region = region
       end


### PR DESCRIPTION
There are some scenarios where using outputs from a template in a different region can be handy, for example:

* A stack might create an S3 bucket as part of `region-1`, and its name is needed in a stack which is part of `region-2`.
* When creating EC2 instances through the same stack in multiple regions, we might want to create Route53 record sets that point to the same HostedZone ID, created already by a previous template on `region-1`.
* We might want all our EC2 instances to have the same IAM role, so they all share the same set of permissions (e.g. write access to a S3 bucket). We could create a stack that deploys the IAM role as part of `region-1` and then use its ARN as a parameter for instances created in other regions.

This PR is a first attempt at supporting cross-region template output reference in parameter files.

The syntax is backwards compatible:
`[region:]stack-name/output_name`

* `region` is an optional region or region-alias (e.g. `production`) where the stack is located.
* `stack-name` is the stack name in that region.
* `output_name` is the output name of the stack.

For example:
```
# parameters/my-server.yml
# Note global is an alias of us-east-1 in this case.
instance_type: t2.micro
vpc_id:
  stack_output: my-vpc/vpc_id
public_subnets:
  stack_output: my-vpc/public_subnets
hosted_zone_id:
  stack_output: global:public-hosted-zone/zone_id
hosted_zone_name:
  stack_output: global:public-hosted-zone/zone_name
bastion_role:
  stack_output: global:bastion-host-role/name
```