### PR TITLE
Cloudformation service role support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ region_aliases:
 stack_defaults:
   tags:
     application: my-awesome-app
+  role_arn: service_role_arn
 region_defaults:
   us-east-1:
     secret_file: production.yml.gpg

--- a/lib/stack_master/commands/apply.rb
+++ b/lib/stack_master/commands/apply.rb
@@ -122,6 +122,7 @@ module StackMaster
           stack_name: stack_name,
           parameters: proposed_stack.aws_parameters,
           capabilities: ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+          role_arn: proposed_stack.role_arn,
           notification_arns: proposed_stack.notification_arns,
           stack_policy_body: proposed_stack.stack_policy_body,
           template_method => template_value

--- a/lib/stack_master/stack.rb
+++ b/lib/stack_master/stack.rb
@@ -7,6 +7,7 @@ module StackMaster
                 :parameters,
                 :template_body,
                 :template_format,
+                :role_arn,
                 :notification_arns,
                 :outputs,
                 :stack_policy_body,
@@ -52,6 +53,7 @@ module StackMaster
           template_body: template_body,
           template_format: template_format,
           outputs: outputs,
+          role_arn: cf_stack.role_arn,
           notification_arns: cf_stack.notification_arns,
           stack_policy_body: stack_policy_body,
           stack_status: cf_stack.stack_status)
@@ -73,6 +75,7 @@ module StackMaster
           parameters: parameters,
           template_body: template_body,
           template_format: template_format,
+          role_arn: stack_definition.role_arn,
           notification_arns: stack_definition.notification_arns,
           stack_policy_body: stack_policy_body)
     end

--- a/lib/stack_master/stack_definition.rb
+++ b/lib/stack_master/stack_definition.rb
@@ -4,6 +4,7 @@ module StackMaster
                   :stack_name,
                   :template,
                   :tags,
+                  :role_arn,
                   :notification_arns,
                   :base_dir,
                   :secret_file,
@@ -28,6 +29,7 @@ module StackMaster
         @stack_name == other.stack_name &&
         @template == other.template &&
         @tags == other.tags &&
+        @role_arn == other.role_arn &&
         @notification_arns == other.notification_arns &&
         @base_dir == other.base_dir &&
         @secret_file == other.secret_file &&

--- a/lib/stack_master/test_driver/cloud_formation.rb
+++ b/lib/stack_master/test_driver/cloud_formation.rb
@@ -10,6 +10,7 @@ module StackMaster
                   :stack_status,
                   :stack_status_reason,
                   :disable_rollback,
+                  :role_arn,
                   :notification_arns,
                   :timeout_in_minutes,
                   :capabilities,

--- a/spec/fixtures/stack_master.yml
+++ b/spec/fixtures/stack_master.yml
@@ -15,6 +15,7 @@ region_defaults:
       environment: production
     notification_arns:
       - test_arn
+    role_arn: test_service_role_arn
     secret_file: production.yml.gpg
     stack_policy_file: my_policy.json
   staging:
@@ -23,6 +24,7 @@ region_defaults:
       test_override: 1
     notification_arns:
       - test_arn_3
+    role_arn: test_service_role_arn3
     secret_file: staging.yml.gpg
 stacks:
   us-east-1:
@@ -30,6 +32,7 @@ stacks:
       template: myapp_vpc.json
       notification_arns:
         - test_arn_2
+      role_arn: test_service_role_arn2
     myapp_web:
       template: myapp_web.rb
     myapp_vpc_with_secrets:
@@ -39,6 +42,7 @@ stacks:
       template: myapp_vpc.rb
       notification_arns:
         - test_arn_4
+      role_arn: test_service_role_arn4
     myapp_web:
       template: myapp_web
       tags:

--- a/spec/stack_master/commands/apply_spec.rb
+++ b/spec/stack_master/commands/apply_spec.rb
@@ -4,12 +4,13 @@ RSpec.describe StackMaster::Commands::Apply do
   let(:region) { 'us-east-1' }
   let(:stack_name) { 'myapp-vpc' }
   let(:config) { double(find_stack: stack_definition) }
+  let(:role_arn) { 'test_service_role_arn' }
   let(:notification_arn) { 'test_arn' }
   let(:stack_definition) { StackMaster::StackDefinition.new(base_dir: '/base_dir', region: region, stack_name: stack_name) }
   let(:template_body) { '{}' }
   let(:template_format) { :json }
   let(:parameters) { { 'param_1' => 'hello' } }
-  let(:proposed_stack) { StackMaster::Stack.new(template_body: template_body, template_format: template_format, tags: { 'environment' => 'production' } , parameters: parameters, notification_arns: [notification_arn], stack_policy_body: stack_policy_body ) }
+  let(:proposed_stack) { StackMaster::Stack.new(template_body: template_body, template_format: template_format, tags: { 'environment' => 'production' } , parameters: parameters, role_arn: role_arn, notification_arns: [notification_arn], stack_policy_body: stack_policy_body ) }
   let(:stack_policy_body) { '{}' }
 
   before do
@@ -47,6 +48,7 @@ RSpec.describe StackMaster::Commands::Apply do
           { parameter_key: 'param_1', parameter_value: 'hello' }
         ],
         capabilities: ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+        role_arn: role_arn,
         notification_arns: [notification_arn],
         stack_policy_body: stack_policy_body
       )
@@ -134,6 +136,7 @@ RSpec.describe StackMaster::Commands::Apply do
             value: 'production'
           }],
         capabilities: ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+        role_arn: role_arn,
         notification_arns: [notification_arn],
         stack_policy_body: stack_policy_body,
         on_failure: 'ROLLBACK'

--- a/spec/stack_master/config_spec.rb
+++ b/spec/stack_master/config_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe StackMaster::Config do
       tags: { 'application' => 'my-awesome-blog', 'environment' => 'production' },
       s3: { 'bucket' => 'my-bucket', 'region' => 'us-east-1' },
       notification_arns: ['test_arn', 'test_arn_2'],
+      role_arn: 'test_service_role_arn2',
       base_dir: base_dir,
       secret_file: 'production.yml.gpg',
       stack_policy_file: 'my_policy.json',
@@ -87,12 +88,14 @@ RSpec.describe StackMaster::Config do
     expect(loaded_config.region_defaults).to eq({
       'us-east-1' => {
         'tags' => { 'environment' => 'production' },
+        'role_arn' => 'test_service_role_arn',
         'notification_arns' => ['test_arn'],
         'secret_file' => 'production.yml.gpg',
         'stack_policy_file' => 'my_policy.json'
       },
       'ap-southeast-2' => {
         'tags' => {'environment' => 'staging', 'test_override' => 1 },
+        'role_arn' => 'test_service_role_arn3',
         'notification_arns' => ['test_arn_3'],
         'secret_file' => 'staging.yml.gpg'
       }
@@ -117,6 +120,7 @@ RSpec.describe StackMaster::Config do
         'test_override' => 1
       },
       s3: { 'bucket' => 'my-bucket', 'region' => 'us-east-1' },
+      role_arn: 'test_service_role_arn4',
       notification_arns: ['test_arn_3', 'test_arn_4'],
       template: 'myapp_vpc.rb',
       base_dir: base_dir,
@@ -133,6 +137,7 @@ RSpec.describe StackMaster::Config do
         'test_override' => 2
       },
       s3: { 'bucket' => 'my-bucket', 'region' => 'us-east-1' },
+      role_arn: 'test_service_role_arn3',
       notification_arns: ['test_arn_3'],
       template: 'myapp_web',
       base_dir: base_dir,

--- a/spec/stack_master/stack_spec.rb
+++ b/spec/stack_master/stack_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe StackMaster::Stack do
         ]
       }
       before do
-        cf.stub_responses(:describe_stacks, stacks: [{ stack_id: stack_id, stack_name: stack_name, creation_time: Time.now, stack_status: 'UPDATE_COMPLETE', parameters: parameters, notification_arns: ['test_arn']}])
+        cf.stub_responses(:describe_stacks, stacks: [{ stack_id: stack_id, stack_name: stack_name, creation_time: Time.now, stack_status: 'UPDATE_COMPLETE', parameters: parameters, notification_arns: ['test_arn'], role_arn: 'test_service_role_arn'}])
         cf.stub_responses(:get_template, template_body: "{}")
         cf.stub_responses(:get_stack_policy, stack_policy_body: stack_policy_body)
       end
@@ -36,6 +36,10 @@ RSpec.describe StackMaster::Stack do
         expect(stack.parameters).to eq({'param1' => 'value1', 'param2' => 'value2'})
       end
 
+      it 'sets role_arn' do
+        expect(stack.role_arn).to eq('test_service_role_arn')
+      end
+      
       it 'sets notification_arns' do
         expect(stack.notification_arns).to eq(['test_arn'])
       end
@@ -70,7 +74,7 @@ RSpec.describe StackMaster::Stack do
 
   describe '.generate' do
     let(:tags) { { 'tag1' => 'value1' } }
-    let(:stack_definition) { StackMaster::StackDefinition.new(region: region, stack_name: stack_name, tags: tags, base_dir: '/base_dir', template: template_file_name, notification_arns: ['test_arn'], stack_policy_file: 'no_replace_rds.json') }
+    let(:stack_definition) { StackMaster::StackDefinition.new(region: region, stack_name: stack_name, tags: tags, base_dir: '/base_dir', template: template_file_name, notification_arns: ['test_arn'], role_arn: 'test_service_role_arn', stack_policy_file: 'no_replace_rds.json') }
     let(:config) { StackMaster::Config.new({'stacks' => {}}, '/base_dir') }
     subject(:stack) { StackMaster::Stack.generate(stack_definition, config) }
     let(:parameter_hash) { { 'DbPassword' => { 'secret' => 'db_password' } } }
@@ -107,6 +111,10 @@ RSpec.describe StackMaster::Stack do
       expect(stack.template_body).to eq template_body
     end
 
+    it 'has role_arn' do
+      expect(stack.role_arn).to eq 'test_service_role_arn'
+    end
+    
     it 'has notification_arns' do
       expect(stack.notification_arns).to eq ['test_arn']
     end


### PR DESCRIPTION
Initial support of Cloudformation Service Roles: 

http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-iam-servicerole.html
