### PR TITLE
Using aws sdk buildin retry plugin instead of own implementation

### DIFF
--- a/lib/stack_master/aws_driver/cloud_formation.rb
+++ b/lib/stack_master/aws_driver/cloud_formation.rb
@@ -20,36 +20,15 @@ module StackMaster
                           :describe_stack_events,
                           :update_stack,
                           :create_stack,
-                          :validate_template
-
-      def describe_stacks(options)
-        retry_with_backoff do
-          cf.describe_stacks(options)
-        end
-      end
+                          :validate_template,
+                          :describe_stacks
 
       private
 
       def cf
-        @cf ||= Aws::CloudFormation::Client.new(region: @region)
+        @cf ||= Aws::CloudFormation::Client.new(region: @region, retry_limit: 10)
       end
 
-      def retry_with_backoff
-        delay       = 1
-        max_delay   = 30
-        begin
-          yield
-        rescue Aws::CloudFormation::Errors::Throttling => e
-          if e.message =~ /Rate exceeded/
-            sleep delay
-            delay *= 2
-            if delay > max_delay
-              delay = max_delay
-            end
-            retry
-          end
-        end
-      end
     end
   end
 end

--- a/spec/stack_master/commands/delete_spec.rb
+++ b/spec/stack_master/commands/delete_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe StackMaster::Commands::Delete do
 
   before do
     StackMaster.cloud_formation_driver.set_region(region)
-    allow(Aws::CloudFormation::Client).to receive(:new).with(region: region).and_return(cf)
+    allow(Aws::CloudFormation::Client).to receive(:new).with(region: region, retry_limit: 10).and_return(cf)
     allow(delete).to receive(:ask?).and_return('y')
     allow(StackMaster::StackEvents::Streamer).to receive(:stream)
   end

--- a/spec/stack_master/commands/status_spec.rb
+++ b/spec/stack_master/commands/status_spec.rb
@@ -41,23 +41,4 @@ RSpec.describe StackMaster::Commands::Status do
     end
   end
 
-  context "handles AWS throttling" do
-    let(:throttle_exception)  { Aws::CloudFormation::Errors::Throttling.new(double(), "Rate exceeded.") }
-    let(:stack1) { double(:stack1, template_hash: {}, parameters_with_defaults: {a: 1}, stack_status: 'UPDATE_COMPLETE') }
-    let(:stack2) { double(:stack2, template_hash: {}, parameters_with_defaults: {a: 2}, stack_status: 'CREATE_COMPLETE') }
-    let(:proposed_stack1) { double(:proposed_stack1, template_body: "{}", parameters_with_defaults: {a: 1}) }
-    let(:proposed_stack2) { double(:proposed_stack2, template_body: "{}", parameters_with_defaults: {a: 1}) }
-
-    it "doubles the sleep time across calls" do
-      call_count = 0
-      expect(cf).to receive(:describe_stacks).at_least(1).times do 
-        call_count += 1
-        call_count <= 3 ? raise(throttle_exception) : double(stacks: double(first: nil))
-      end
-      expect(StackMaster.cloud_formation_driver).to receive(:sleep).with(1).ordered
-      expect(StackMaster.cloud_formation_driver).to receive(:sleep).with(2).ordered
-      expect(StackMaster.cloud_formation_driver).to receive(:sleep).with(4).ordered
-      expect { status.perform }.to_not raise_exception
-    end
-  end
 end


### PR DESCRIPTION
Maybe we should use the builtin retry plugin instead of an own implementation. Fixes #150 too.