### PR TITLE
Feature/region wide parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ Parameters are loaded from multiple YAML files, merged from the following lookup
 - parameters/[region]/[underscored_stack_name].yml
 - parameters/[region_alias]/[underscored_stack_name].yaml
 - parameters/[region_alias]/[underscored_stack_name].yml
+- parameters/[region_alias].yml
+- parameters/[region].yml
 
 A simple parameter file could look like this:
 

--- a/lib/stack_master/stack_definition.rb
+++ b/lib/stack_master/stack_definition.rb
@@ -68,7 +68,7 @@ module StackMaster
     end
 
     def parameter_files
-      [ default_parameter_file_path, region_parameter_file_path, additional_parameter_lookup_file_paths ].flatten.compact
+      [ default_parameter_file_path, region_parameter_file_path, additional_parameter_lookup_file_paths, common_parameter_file_path ].flatten.compact
     end
 
     def stack_policy_file_path
@@ -94,6 +94,19 @@ module StackMaster
 
     def default_parameter_file_path
       Dir.glob(File.join(base_dir, 'parameters', "#{underscored_stack_name}.y*ml"))
+    end
+
+    def common_parameter_file_path
+      paths = []
+      if additional_parameter_lookup_dirs
+        paths += additional_parameter_lookup_dirs.map do |a|
+          File.join(base_dir, 'parameters', "#{a}.yml")
+        end
+      end
+
+      paths << File.join(base_dir, 'parameters', "#{region}.yml")
+
+      paths
     end
 
     def underscored_stack_name

--- a/spec/stack_master/stack_definition_spec.rb
+++ b/spec/stack_master/stack_definition_spec.rb
@@ -40,6 +40,8 @@ RSpec.describe StackMaster::StackDefinition do
       "/base_dir/parameters/#{stack_name}.yml",
       "/base_dir/parameters/#{region}/#{stack_name}.yaml",
       "/base_dir/parameters/#{region}/#{stack_name}.yml",
+      "/base_dir/parameters/#{region}.yaml",
+      "/base_dir/parameters/#{region}.yml"
     ])
   end
 
@@ -64,6 +66,8 @@ RSpec.describe StackMaster::StackDefinition do
         "/base_dir/parameters/#{region}/#{stack_name}.yml",
         "/base_dir/parameters/production/#{stack_name}.yaml",
         "/base_dir/parameters/production/#{stack_name}.yml",
+        "/base_dir/parameters/#{region}.yaml",
+        "/base_dir/parameters/#{region}.yml"
       ])
     end
   end


### PR DESCRIPTION
Allows to define common, region-wide parameters that are shared between multiple stack (i.e. VpcId, subnets etc). Works well with base templates that defines common parameters.