### PR TITLE
Support customizing the template directory + sparkle path

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,6 +390,37 @@ container_definitions array!(
 )
 ```
 
+## Compiler Options & Alternate Template Directories
+
+StackMaster allows you to separate your stack definitions and parameters from your templates by way of a `template_dir` key in your stack_master.yml.
+You can also pass compiler-specific options to the template compiler to further customize SparkleFormation or CfnDsl's behavior.  Combining the 2 lets you move your SFN templates away from your stack definitions.  For example, if your project is laid out as:
+
+```
+project-root
+|-- envs
+  |-- env-1
+    |-- stack_master.yml
+  |-- env-2
+    |-- stack_master.yml
+|-- sparkle
+  |-- templates
+    |-- my-stack.rb
+```
+
+Your env-1/stack_master.yml files can reference common templates by setting:
+
+```
+template_dir: ../../sparkle/templates
+stack_defaults:
+  compiler_options:
+    sparkle_path: ../../sparkle
+
+stacks:
+  us-east-1:
+    my-stack:
+      template: my-stack.rb
+```
+
 ## Commands
 
 ```bash

--- a/lib/stack_master/config.rb
+++ b/lib/stack_master/config.rb
@@ -12,6 +12,7 @@ module StackMaster
 
     attr_accessor :stacks,
                   :base_dir,
+                  :template_dir,
                   :stack_defaults,
                   :region_defaults,
                   :region_aliases,
@@ -33,6 +34,7 @@ module StackMaster
     def initialize(config, base_dir)
       @config = config
       @base_dir = base_dir
+      @template_dir = config.fetch('template_dir', nil)
       @stack_defaults = config.fetch('stack_defaults', {})
       @region_aliases = Utils.underscore_keys_to_hyphen(config.fetch('region_aliases', {}))
       @region_to_aliases = @region_aliases.inject({}) do |hash, (key, value)|
@@ -108,6 +110,7 @@ module StackMaster
             'region' => region,
             'stack_name' => stack_name,
             'base_dir' => @base_dir,
+            'template_dir' => @template_dir,
             'additional_parameter_lookup_dirs' => @region_to_aliases[region])
           @stacks << StackDefinition.new(stack_attributes)
         end

--- a/lib/stack_master/stack.rb
+++ b/lib/stack_master/stack.rb
@@ -63,7 +63,7 @@ module StackMaster
 
     def self.generate(stack_definition, config)
       parameter_hash = ParameterLoader.load(stack_definition.parameter_files)
-      template_body = TemplateCompiler.compile(config, stack_definition.template_file_path)
+      template_body = TemplateCompiler.compile(config, stack_definition.template_file_path, stack_definition.compiler_options)
       template_format = TemplateUtils.identify_template_format(template_body)
       parameters = ParameterResolver.resolve(config, stack_definition, parameter_hash)
       stack_policy_body = if stack_definition.stack_policy_file_path

--- a/lib/stack_master/stack_definition.rb
+++ b/lib/stack_master/stack_definition.rb
@@ -11,12 +11,14 @@ module StackMaster
                   :stack_policy_file,
                   :additional_parameter_lookup_dirs,
                   :s3,
-                  :files
+                  :files,
+                  :compiler_options
 
     include Utils::Initializable
 
     def initialize(attributes = {})
       @additional_parameter_lookup_dirs = []
+      @compiler_options = {}
       @notification_arns = []
       @s3 = {}
       @files = []
@@ -35,7 +37,8 @@ module StackMaster
         @secret_file == other.secret_file &&
         @stack_policy_file == other.stack_policy_file &&
         @additional_parameter_lookup_dirs == other.additional_parameter_lookup_dirs &&
-        @s3 == other.s3
+        @s3 == other.s3 &&
+        @compiler_options == other.compiler_options
     end
 
     def template_dir

--- a/lib/stack_master/stack_definition.rb
+++ b/lib/stack_master/stack_definition.rb
@@ -7,6 +7,7 @@ module StackMaster
                   :role_arn,
                   :notification_arns,
                   :base_dir,
+                  :template_dir,
                   :secret_file,
                   :stack_policy_file,
                   :additional_parameter_lookup_dirs,
@@ -23,6 +24,7 @@ module StackMaster
       @s3 = {}
       @files = []
       super
+      @template_dir ||= File.join(@base_dir, 'templates')
     end
 
     def ==(other)
@@ -41,12 +43,8 @@ module StackMaster
         @compiler_options == other.compiler_options
     end
 
-    def template_dir
-      File.join(base_dir, 'templates')
-    end
-
     def template_file_path
-      File.join(template_dir, template)
+      File.expand_path(File.join(template_dir, template))
     end
 
     def files_dir

--- a/lib/stack_master/template_compiler.rb
+++ b/lib/stack_master/template_compiler.rb
@@ -2,7 +2,7 @@ module StackMaster
   class TemplateCompiler
     TemplateCompilationFailed = Class.new(RuntimeError)
 
-    def self.compile(config, template_file_path, compiler_options={})
+    def self.compile(config, template_file_path, compiler_options = {})
       compiler = template_compiler_for_file(template_file_path, config)
       compiler.require_dependencies
       compiler.compile(template_file_path, compiler_options)

--- a/lib/stack_master/template_compiler.rb
+++ b/lib/stack_master/template_compiler.rb
@@ -2,10 +2,10 @@ module StackMaster
   class TemplateCompiler
     TemplateCompilationFailed = Class.new(RuntimeError)
 
-    def self.compile(config, template_file_path)
+    def self.compile(config, template_file_path, compiler_options={})
       compiler = template_compiler_for_file(template_file_path, config)
       compiler.require_dependencies
-      compiler.compile(template_file_path)
+      compiler.compile(template_file_path, compiler_options)
     rescue
       raise TemplateCompilationFailed.new("Failed to compile #{template_file_path}.")
     end

--- a/lib/stack_master/template_compilers/cfndsl.rb
+++ b/lib/stack_master/template_compilers/cfndsl.rb
@@ -4,7 +4,7 @@ module StackMaster::TemplateCompilers
       require 'cfndsl'
     end
 
-    def self.compile(template_file_path, compiler_options={})
+    def self.compile(template_file_path, compiler_options = {})
       ::CfnDsl.eval_file_with_extras(template_file_path).to_json
     end
 

--- a/lib/stack_master/template_compilers/cfndsl.rb
+++ b/lib/stack_master/template_compilers/cfndsl.rb
@@ -4,7 +4,7 @@ module StackMaster::TemplateCompilers
       require 'cfndsl'
     end
 
-    def self.compile(template_file_path)
+    def self.compile(template_file_path, compiler_options={})
       ::CfnDsl.eval_file_with_extras(template_file_path).to_json
     end
 

--- a/lib/stack_master/template_compilers/json.rb
+++ b/lib/stack_master/template_compilers/json.rb
@@ -7,7 +7,7 @@ module StackMaster::TemplateCompilers
       require 'json'
     end
 
-    def self.compile(template_file_path)
+    def self.compile(template_file_path, compiler_options={})
       template_body = File.read(template_file_path)
       if template_body.size > MAX_TEMPLATE_SIZE
         # Parse the json and rewrite compressed

--- a/lib/stack_master/template_compilers/json.rb
+++ b/lib/stack_master/template_compilers/json.rb
@@ -7,7 +7,7 @@ module StackMaster::TemplateCompilers
       require 'json'
     end
 
-    def self.compile(template_file_path, compiler_options={})
+    def self.compile(template_file_path, compiler_options = {})
       template_body = File.read(template_file_path)
       if template_body.size > MAX_TEMPLATE_SIZE
         # Parse the json and rewrite compressed

--- a/lib/stack_master/template_compilers/sparkle_formation.rb
+++ b/lib/stack_master/template_compilers/sparkle_formation.rb
@@ -5,7 +5,7 @@ module StackMaster::TemplateCompilers
       require 'stack_master/sparkle_formation/template_file'
     end
 
-    def self.compile(template_file_path)
+    def self.compile(template_file_path, compiler_options={})
       ::SparkleFormation.sparkle_path = File.dirname(template_file_path)
       JSON.pretty_generate(::SparkleFormation.compile(template_file_path))
     end

--- a/lib/stack_master/template_compilers/sparkle_formation.rb
+++ b/lib/stack_master/template_compilers/sparkle_formation.rb
@@ -5,8 +5,13 @@ module StackMaster::TemplateCompilers
       require 'stack_master/sparkle_formation/template_file'
     end
 
-    def self.compile(template_file_path, compiler_options={})
-      ::SparkleFormation.sparkle_path = File.dirname(template_file_path)
+    def self.compile(template_file_path, compiler_options = {})
+      if compiler_options["sparkle_path"]
+        ::SparkleFormation.sparkle_path = File.expand_path(compiler_options["sparkle_path"])
+      else
+        ::SparkleFormation.sparkle_path = File.dirname(template_file_path)
+      end
+
       JSON.pretty_generate(::SparkleFormation.compile(template_file_path))
     end
 

--- a/lib/stack_master/template_compilers/yaml.rb
+++ b/lib/stack_master/template_compilers/yaml.rb
@@ -5,7 +5,7 @@ module StackMaster::TemplateCompilers
       require 'json'
     end
 
-    def self.compile(template_file_path)
+    def self.compile(template_file_path, compiler_options={})
       File.read(template_file_path)
     end
 

--- a/lib/stack_master/template_compilers/yaml.rb
+++ b/lib/stack_master/template_compilers/yaml.rb
@@ -5,7 +5,7 @@ module StackMaster::TemplateCompilers
       require 'json'
     end
 
-    def self.compile(template_file_path, compiler_options={})
+    def self.compile(template_file_path, compiler_options = {})
       File.read(template_file_path)
     end
 

--- a/lib/stack_master/validator.rb
+++ b/lib/stack_master/validator.rb
@@ -11,7 +11,7 @@ module StackMaster
 
     def perform
       StackMaster.stdout.print "#{@stack_definition.stack_name}: "
-      template_body = TemplateCompiler.compile(@config, @stack_definition.template_file_path)
+      template_body = TemplateCompiler.compile(@config, @stack_definition.template_file_path, @stack_definition.compiler_options)
       cf.validate_template(template_body: TemplateUtils.maybe_compressed_template_body(template_body))
       StackMaster.stdout.puts "valid"
       true

--- a/spec/stack_master/stack_spec.rb
+++ b/spec/stack_master/stack_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe StackMaster::Stack do
     before do
       allow(StackMaster::ParameterLoader).to receive(:load).and_return(parameter_hash)
       allow(StackMaster::ParameterResolver).to receive(:resolve).and_return(resolved_parameters)
-      allow(StackMaster::TemplateCompiler).to receive(:compile).with(config, stack_definition.template_file_path).and_return(template_body)
+      allow(StackMaster::TemplateCompiler).to receive(:compile).with(config, stack_definition.template_file_path, stack_definition.compiler_options).and_return(template_body)
       allow(File).to receive(:read).with(stack_definition.stack_policy_file_path).and_return(stack_policy_body)
     end
 

--- a/spec/stack_master/template_compiler_spec.rb
+++ b/spec/stack_master/template_compiler_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe StackMaster::TemplateCompiler do
 
     class TestTemplateCompiler
       def self.require_dependencies; end
-      def self.compile(template_file_path); end
+      def self.compile(template_file_path, compile_options); end
     end
 
     context 'when a template compiler is registered for the given file type' do
@@ -14,8 +14,14 @@ RSpec.describe StackMaster::TemplateCompiler do
       }
 
       it 'compiles the template using the relevant template compiler' do
-        expect(TestTemplateCompiler).to receive(:compile).with(template_file_path)
+        expect(TestTemplateCompiler).to receive(:compile).with(template_file_path, anything)
         StackMaster::TemplateCompiler.compile(config, template_file_path)
+      end
+
+      it 'passes compile_options to the template compiler' do
+        opts = {foo: 1, bar: true, baz: "meh"}
+        expect(TestTemplateCompiler).to receive(:compile).with(template_file_path, opts)
+        StackMaster::TemplateCompiler.compile(config, template_file_path, opts)
       end
 
       context 'when template compilation fails' do

--- a/spec/stack_master/template_compilers/sparkle_formation_spec.rb
+++ b/spec/stack_master/template_compilers/sparkle_formation_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe StackMaster::TemplateCompilers::SparkleFormation do
 
       it 'expands the given path' do
         compile
-        expect(SparkleFormation.sparkle_path).to match /^\/.+\/foo/
+        expect(SparkleFormation.sparkle_path).to match %r{^/.+/foo}
       end
     end
   end

--- a/spec/stack_master/template_compilers/sparkle_formation_spec.rb
+++ b/spec/stack_master/template_compilers/sparkle_formation_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe StackMaster::TemplateCompilers::SparkleFormation do
   describe '.compile' do
     def compile
-      described_class.compile(template_file_path)
+      described_class.compile(template_file_path, compiler_options)
     end
 
     before do
@@ -9,6 +9,7 @@ RSpec.describe StackMaster::TemplateCompilers::SparkleFormation do
     end
 
     let(:template_file_path) { '/base_dir/templates/template.rb' }
+    let(:compiler_options) { {} }
 
     it 'compiles with sparkleformation' do
       expect(compile).to eq("{\n}")
@@ -17,6 +18,20 @@ RSpec.describe StackMaster::TemplateCompilers::SparkleFormation do
     it 'sets the appropriate sparkle_path' do
       compile
       expect(SparkleFormation.sparkle_path).to eq File.dirname(template_file_path)
+    end
+
+    context 'with a custom sparkle_path' do
+      let(:compiler_options)  { { "sparkle_path" => '../foo' } }
+
+      it 'does not use the default path' do
+        compile
+        expect(SparkleFormation.sparkle_path).to_not eq File.dirname(template_file_path)
+      end
+
+      it 'expands the given path' do
+        compile
+        expect(SparkleFormation.sparkle_path).to match /^\/.+\/foo/
+      end
     end
   end
 end


### PR DESCRIPTION
This is somewhat related/inspired by my earlier work on https://github.com/envato/stack_master/pull/120, but for use with sparkleformation instead of cfndsl.

The main motivation here is that it enables sharing across projects by giving a common place to stick templates, and relaxes some assumptions for more exotic setups (e.g. sparkle path is not necessarily just `dirname(file)`).