### PR TITLE
Add stackifier command

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,7 @@ stack_master events [region-or-alias] [stack-name] # Display events for a stack
 stack_master outputs [region-or-alias] [stack-name] # Display outputs for a stack
 stack_master resources [region-or-alias] [stack-name] # Display outputs for a stack
 stack_master status # Displays the status of each stack
+stack_master stackify [input-file] # Turns a basic cloudformation template into stackmaster syntax
 ```
 
 ## Applying updates

--- a/lib/stack_master.rb
+++ b/lib/stack_master.rb
@@ -45,6 +45,7 @@ module StackMaster
     autoload :Outputs, 'stack_master/commands/outputs'
     autoload :Init, 'stack_master/commands/init'
     autoload :Diff, 'stack_master/commands/diff'
+    autoload :Stackify, 'stack_master/commands/stackify'
     autoload :ListStacks, 'stack_master/commands/list_stacks'
     autoload :Validate, 'stack_master/commands/validate'
     autoload :Resources, 'stack_master/commands/resources'

--- a/lib/stack_master/cli.rb
+++ b/lib/stack_master/cli.rb
@@ -84,6 +84,16 @@ module StackMaster
         end
       end
 
+      command :stackify do |c|
+        c.syntax = 'stack_master stackify [input_file]'
+        c.summary = "Turns a raw JSON stack (or part thereof) into a stackmaster template"
+        c.description = "Turns a raw JSON stack (or part thereof) into a stackmaster template"
+        c.example 'convert a file named my_stack.json', 'stack_master stackify my_stack.json'
+        c.action do |args|
+          puts StackMaster::Commands::Stackify.new(File.read(args[0])).perform
+        end
+      end
+
       command :events do |c|
         c.syntax = 'stack_master events [region_or_alias] [stack_name]'
         c.summary = "Shows events for a stack"

--- a/lib/stack_master/commands/stackify.rb
+++ b/lib/stack_master/commands/stackify.rb
@@ -1,0 +1,61 @@
+module StackMaster
+  module Commands
+    class Stackify
+      include Command
+      include Commander::UI
+
+      def initialize(input_data)
+        @input_data = input_data
+      end
+
+      def perform
+        generate_output(JSON.parse(@input_data))
+      end
+
+      private
+
+      def generate_output(input, depth=0)
+        indent = " " * (depth * 2)
+        output = []
+        if Hash === input
+          input.each do |k,v|
+            k = k.underscore
+            if k == 'resources'
+              v.each do |rk,rv|
+                output << "#{indent}resources.#{rk.underscore} do"
+                output += generate_output(rv, depth+1)
+                output << "#{indent}end"
+              end
+            elsif Array === v
+              if v.all?{|x| Hash === x}
+                output << "#{indent}#{k} _array("
+                output += generate_output(v, depth+1)
+                output << "#{indent})"
+              else
+                output << "#{indent}#{k} #{v.to_s}"
+              end
+            elsif Hash === v
+              output << "#{indent}#{k} do"
+              output += generate_output(v, depth+1)
+              output << "#{indent}end"
+            elsif String === v
+              output << "#{indent}#{k} '#{v}'"
+            else
+              output << "#{indent}#{k} #{v}"
+            end
+          end
+        elsif Array === input
+          input.each do |x|
+            output << "#{indent}-> {"
+            output += generate_output(x, depth+1)
+            output << "#{indent}},"
+          end
+        else
+          output << "#{indent}'#{input}'"
+        end
+        output
+      end
+
+    end
+  end
+end

--- a/spec/fixtures/templates/stackifier/cloudfront.json
+++ b/spec/fixtures/templates/stackifier/cloudfront.json
@@ -1,0 +1,46 @@
+{
+    "AWSTemplateFormatVersion" : "2010-09-09",
+    "Resources" : {
+        "myDistribution" : {
+            "Type" : "AWS::CloudFront::Distribution",
+            "Properties" : {
+                "DistributionConfig" : {
+                    "Origins" : [ {
+                        "DomainName" : "mybucket.s3.amazonaws.com",
+                        "Id" : "myS3Origin",
+                        "S3OriginConfig" : {
+                            "OriginAccessIdentity" : "origin-access-identity/cloudfront/E127EXAMPLE51Z"
+                        }
+                    }],
+                    "Enabled" : "true",
+                    "Comment" : "Some comment",
+                    "DefaultRootObject" : "index.html",
+                    "Logging" : {
+                        "IncludeCookies" : "false",
+                        "Bucket" : "mylogs.s3.amazonaws.com",
+                        "Prefix" : "myprefix"
+                    },
+                    "Aliases" : [ "mysite.example.com", "yoursite.example.com" ],
+                    "DefaultCacheBehavior" : {
+                        "AllowedMethods" : [ "DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT" ],  
+                        "TargetOriginId" : "myS3Origin",
+                        "ForwardedValues" : {
+                            "QueryString" : "false",
+                            "Cookies" : { "Forward" : "none" }
+                        },
+                        "TrustedSigners" : [ "1234567890EX", "1234567891EX" ],
+                        "ViewerProtocolPolicy" : "allow-all"
+                    },
+                   "PriceClass" : "PriceClass_200",
+                   "Restrictions" : {
+                       "GeoRestriction" : {
+                           "RestrictionType" : "whitelist",
+                           "Locations" : [ "AQ", "CV" ]
+                       }
+                   },
+                   "ViewerCertificate" : { "CloudFrontDefaultCertificate" : "true" }  
+                }
+            }
+        }
+    }
+}

--- a/spec/fixtures/templates/stackifier/cloudfront.rb
+++ b/spec/fixtures/templates/stackifier/cloudfront.rb
@@ -1,0 +1,48 @@
+aws_template_format_version '2010-09-09'
+resources.my_distribution do
+  type 'AWS::CloudFront::Distribution'
+  properties do
+    distribution_config do
+      origins _array(
+        -> {
+          domain_name 'mybucket.s3.amazonaws.com'
+          id 'myS3Origin'
+          s3_origin_config do
+            origin_access_identity 'origin-access-identity/cloudfront/E127EXAMPLE51Z'
+          end
+        },
+      )
+      enabled 'true'
+      comment 'Some comment'
+      default_root_object 'index.html'
+      logging do
+        include_cookies 'false'
+        bucket 'mylogs.s3.amazonaws.com'
+        prefix 'myprefix'
+      end
+      aliases ["mysite.example.com", "yoursite.example.com"]
+      default_cache_behavior do
+        allowed_methods ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+        target_origin_id 'myS3Origin'
+        forwarded_values do
+          query_string 'false'
+          cookies do
+            forward 'none'
+          end
+        end
+        trusted_signers ["1234567890EX", "1234567891EX"]
+        viewer_protocol_policy 'allow-all'
+      end
+      price_class 'PriceClass_200'
+      restrictions do
+        geo_restriction do
+          restriction_type 'whitelist'
+          locations ["AQ", "CV"]
+        end
+      end
+      viewer_certificate do
+        cloud_front_default_certificate 'true'
+      end
+    end
+  end
+end

--- a/spec/stack_master/commands/stackify_spec.rb
+++ b/spec/stack_master/commands/stackify_spec.rb
@@ -1,0 +1,12 @@
+RSpec.describe StackMaster::Commands::Stackify do
+  let(:input_data) { File.read('spec/fixtures/templates/stackifier/cloudfront.json') }
+  let(:expected)   { File.read('spec/fixtures/templates/stackifier/cloudfront.rb').gsub("\n","\n") }
+
+  subject(:stackify) { described_class.perform(input_data) }
+
+  describe '#perform' do
+    it "generates a valid output" do
+      expect(stackify.perform.join("\n")).to eq(expected)
+    end
+  end
+end


### PR DESCRIPTION
I've recently been in the position where I've had to translate a cloudformation example into stack master.  It was tedious typing all the bits out, so I made a quick task to take an example file as input and turn it into a stack-master file. 

For example, the JSON found here: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/quickref-cloudfront.html

Usage is `stack_master stackify [input-file]` and will output to STDOUT.