### PR TITLE
Bump SparkleFormation Version

### DIFF
--- a/stack_master.gemspec
+++ b/stack_master.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "erubis"
   spec.add_dependency "colorize"
   spec.add_dependency "activesupport", "~> 4.2"
-  spec.add_dependency "sparkle_formation", "~> 1.1"
+  spec.add_dependency "sparkle_formation"
   spec.add_dependency "table_print"
   spec.add_dependency "dotgpg"
   spec.add_dependency "deep_merge"


### PR DESCRIPTION
This bumps `sparkle_formation` to latest. 

Fixes #168 