### PR TITLE
Exit with error if stack ends in a failed state

### DIFF
--- a/spec/stack_master/stack_events/streamer_spec.rb
+++ b/spec/stack_master/stack_events/streamer_spec.rb
@@ -30,4 +30,18 @@ RSpec.describe StackMaster::StackEvents::Streamer do
     StackMaster::StackEvents::Streamer.stream(stack_name, region, sleep_between_fetches: 0, io: io)
     expect(io.string).to include('UPDATE_COMPLETE')
   end
+
+  context "the stack is in a failed state" do
+    let(:events_second_call) {
+      events_first_call + [
+        OpenStruct.new(event_id: '4', resource_status: 'ROLLBACK_FAILED', resource_type: 'AWS::CloudFormation::Stack', logical_resource_id: stack_name, timestamp: Time.now)
+      ]
+    }
+
+    it 'raises an error on failure' do
+      expect {
+        StackMaster::StackEvents::Streamer.stream(stack_name, region, sleep_between_fetches: 0)
+      }.to raise_error(StackMaster::StackEvents::Streamer::StackFailed)
+    end
+  end
 end


### PR DESCRIPTION
This causes `stack_master` to raise an exception and exit if the stack creation/update fails.

Fixes https://github.com/envato/stack_master/issues/174