### PR TITLE
Use a change set when creating a stack

### DIFF
--- a/lib/stack_master/aws_driver/cloud_formation.rb
+++ b/lib/stack_master/aws_driver/cloud_formation.rb
@@ -23,6 +23,7 @@ module StackMaster
                           :describe_stack_resources,
                           :get_template,
                           :get_stack_policy,
+                          :set_stack_policy,
                           :describe_stack_events,
                           :update_stack,
                           :create_stack,

--- a/lib/stack_master/cli.rb
+++ b/lib/stack_master/cli.rb
@@ -41,7 +41,7 @@ module StackMaster
         c.summary = 'Creates or updates a stack'
         c.description = "Creates or updates a stack. Shows a diff of the proposed stack's template and parameters. Tails stack events until CloudFormation has completed."
         c.example 'update a stack named myapp-vpc in us-east-1', 'stack_master apply us-east-1 myapp-vpc'
-        c.option '--on-failure ACTION', String, 'Action to take on CREATE_FAILURE. Valid Values: [ DO_NOTHING | ROLLBACK | DELETE ]. Default: ROLLBACK'
+        c.option '--on-failure ACTION', String, "Action to take on CREATE_FAILURE. Valid Values: [ DO_NOTHING | ROLLBACK | DELETE ]. Default: ROLLBACK\nNote: You cannot use this option with Serverless Application Model (SAM) templates."
         c.action do |args, options|
           options.defaults config: default_config_file
           execute_stacks_command(StackMaster::Commands::Apply, args, options)

--- a/lib/stack_master/commands/apply.rb
+++ b/lib/stack_master/commands/apply.rb
@@ -12,7 +12,7 @@ module StackMaster
         @stack_definition = stack_definition
         @from_time = Time.now
         @options = options
-        @options.on_failure ||= @config.stack_defaults['on_failure']
+        @options.on_failure ||= nil
       end
 
       def perform
@@ -88,8 +88,7 @@ module StackMaster
 
       def create_stack_directly
         failed!('Stack creation aborted') unless ask?('Create stack (y/n)? ')
-        on_failure = @options.on_failure || 'ROLLBACK'
-        cf.create_stack(stack_options.merge(on_failure: on_failure))
+        cf.create_stack(stack_options.merge(on_failure: @options.on_failure))
       end
 
       def ask_to_cancel_stack_update

--- a/lib/stack_master/test_driver/cloud_formation.rb
+++ b/lib/stack_master/test_driver/cloud_formation.rb
@@ -87,6 +87,8 @@ module StackMaster
         options.merge!(change_set_id: id)
         @change_sets[id] = options
         @change_sets[options.fetch(:change_set_name)] = options
+        stack_name = options.fetch(:stack_name)
+        add_stack(stack_name: stack_name, stack_status: 'REVIEW_IN_PROGRESS') unless @stacks[stack_name]
         OpenStruct.new(id: id)
       end
 
@@ -106,7 +108,7 @@ module StackMaster
       def execute_change_set(options)
         change_set_id = options.fetch(:change_set_name)
         change_set = @change_sets.fetch(change_set_id)
-        update_stack(change_set)
+        @stacks[change_set.fetch(:stack_name)].attributes = change_set
       end
 
       def delete_change_set(options)
@@ -140,6 +142,10 @@ module StackMaster
 
       def get_stack_policy(options)
         OpenStruct.new(stack_policy_body: @stack_policies[options.fetch(:stack_name)])
+      end
+
+      def set_stack_policy(options)
+        @stack_policies[options.fetch(:stack_name)] = options[:stack_policy_body]
       end
 
       def describe_stack_events(options)

--- a/lib/stack_master/test_driver/cloud_formation.rb
+++ b/lib/stack_master/test_driver/cloud_formation.rb
@@ -153,12 +153,6 @@ module StackMaster
         OpenStruct.new(stack_events: events, next_token: nil)
       end
 
-      def update_stack(options)
-        stack_name = options.fetch(:stack_name)
-        @stacks[stack_name].attributes = options
-        @stack_policies[stack_name] = options[:stack_policy_body]
-      end
-
       def create_stack(options)
         stack_name = options.fetch(:stack_name)
         add_stack(options)

--- a/spec/stack_master/commands/apply_spec.rb
+++ b/spec/stack_master/commands/apply_spec.rb
@@ -159,7 +159,9 @@ RSpec.describe StackMaster::Commands::Apply do
 
     context 'on_failure option is set' do
       it 'calls the create stack API method' do
-        config.stack_defaults['on_failure'] = 'ROLLBACK'
+        options = Commander::Command::Options.new
+        options.on_failure = 'ROLLBACK'
+        StackMaster::Commands::Apply.perform(config, stack_definition, options)
         apply
         expect(cf).to have_received(:create_stack).with(
           stack_name: stack_name,
@@ -174,15 +176,6 @@ RSpec.describe StackMaster::Commands::Apply do
           role_arn: role_arn,
           notification_arns: [notification_arn],
           on_failure: 'ROLLBACK'
-        )
-      end
-
-      it 'on_failure can be passed in options' do
-        options = Commander::Command::Options.new
-        options.on_failure = 'DELETE'
-        StackMaster::Commands::Apply.perform(config, stack_definition, options)
-        expect(cf).to have_received(:create_stack).with(
-          hash_including(on_failure: 'DELETE')
         )
       end
     end

--- a/spec/stack_master/test_driver/cloud_formation_spec.rb
+++ b/spec/stack_master/test_driver/cloud_formation_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe StackMaster::TestDriver::CloudFormation do
       test_cf_driver.create_stack(stack_id: "1", stack_name: 'stack-1')
       test_cf_driver.create_stack(stack_id: "2", stack_name: 'stack-2')
       expect(test_cf_driver.describe_stacks.stacks.map(&:stack_id)).to eq(["1", "2"])
-
     end
 
     it 'adds and gets stack events' do
@@ -21,6 +20,12 @@ RSpec.describe StackMaster::TestDriver::CloudFormation do
     it 'sets and gets templates' do
       test_cf_driver.set_template('stack-1', 'blah')
       expect(test_cf_driver.get_template(stack_name: 'stack-1').template_body).to eq 'blah'
+    end
+
+    it 'sets and gets stack policies' do
+      stack_policy_body = '{}'
+      test_cf_driver.set_stack_policy(stack_name: 'stack-1', stack_policy_body: stack_policy_body)
+      expect(test_cf_driver.get_stack_policy(stack_name: 'stack-1').stack_policy_body).to eq(stack_policy_body)
     end
   end
 
@@ -38,6 +43,14 @@ RSpec.describe StackMaster::TestDriver::CloudFormation do
       change_set = test_cf_driver.describe_change_set(change_set_name: 'change-set-1')
       expect(change_set.change_set_id).to eq change_set_id
       expect(change_set.change_set_name).to eq 'change-set-1'
+    end
+
+    it 'creates stacks using change sets and describes stacks' do
+      change_set1 = test_cf_driver.create_change_set(change_set_name: 'change-set-1', stack_name: 'stack-1', change_set_type: 'CREATE')
+      change_set2 = test_cf_driver.create_change_set(change_set_name: 'change-set-2', stack_name: 'stack-2', change_set_type: 'CREATE')
+      test_cf_driver.execute_change_set(change_set_name: change_set1.id)
+      test_cf_driver.execute_change_set(change_set_name: change_set2.id)
+      expect(test_cf_driver.describe_stacks.stacks.map(&:stack_name)).to eq(['stack-1', 'stack-2'])
     end
   end
 


### PR DESCRIPTION
This resolves #177.

- Use a change set when creating a stack, instead of calling `create_stack` API
  - This allows users to review all of the resources to be created before creating a stack
- Set a stack policy after the change set is applied
  - Call `set_stack_policy` API after the stack events are complete since we cannot set a stack policy during the stack change (i.e. `*_IN_PROGRESS` state)

This is also the first part for #176.