### PR TITLE
Get the original template of a stack

### DIFF
--- a/lib/stack_master/stack.rb
+++ b/lib/stack_master/stack.rb
@@ -41,7 +41,7 @@ module StackMaster
         params_hash[param_struct.parameter_key] = param_struct.parameter_value
         params_hash
       end
-      template_body ||= cf.get_template(stack_name: stack_name).template_body
+      template_body ||= cf.get_template(stack_name: stack_name, template_stage: 'Original').template_body
       template_format = TemplateUtils.identify_template_format(template_body)
       stack_policy_body ||= cf.get_stack_policy(stack_name: stack_name).stack_policy_body
       outputs = cf_stack.outputs


### PR DESCRIPTION
This is the second part for #176. (The first part is #178.)

SAM templates have two template stages: `Original` and `Processed`.
Although [`get_template` API reference](http://docs.aws.amazon.com/sdkforruby/api/Aws/CloudFormation/Client.html#get_template-instance_method) says the `template_stage` parameter of the API is `Original` by default, the API somehow seems to return a processed template rather than original.
So specify `template_stage: 'Original'` explicitly to get the original template of a stack.
