### PR TITLE
Release the lock on aws-sdk version 2.6

### DIFF
--- a/stack_master.gemspec
+++ b/stack_master.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "timecop"
   spec.add_dependency "ruby-progressbar"
   spec.add_dependency "commander"
-  spec.add_dependency "aws-sdk", "~> 2.6.26"
+  spec.add_dependency "aws-sdk", "~> 2.6"
   spec.add_dependency "diffy"
   spec.add_dependency "erubis"
   spec.add_dependency "colorize"


### PR DESCRIPTION
Allow any version from 2.6  to < 3 to be installed.

The hard lock is a little restrictive if you have a Gemfile and you are doing other things with the aws-sdk. It changes, new features are added and you can't use those feature with this lock. 

AWS is generally pretty good with semantic versioning. As long as we don't do a major upgrade to version 3, I would think a softer lock should work.