### PR TITLE
Enable use of ActiveSupport 5 and above

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: ruby
 matrix:
   include:
-    - rvm: 2.1
+    - rvm: 2.1.10
       gemfile: spec/support/gemfiles/Gemfile.activesupport-4.0.0
-    - rvm: 2.2
-    - rvm: 2.3.1
-    - rvm: 2.4.0
+    - rvm: 2.2.7
+    - rvm: 2.3.4
+    - rvm: 2.4.1
 sudo: false
 script:
   - bundle exec rake spec features

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 language: ruby
-rvm:
-  - 2.1
-  - 2.2
-  - 2.3.1
-  - 2.4.0
+matrix:
+  include:
+    - rvm: 2.1
+      gemfile: spec/support/gemfiles/Gemfile.activesupport-4.0.0
+    - rvm: 2.2
+    - rvm: 2.3.1
+    - rvm: 2.4.0
 sudo: false
 script:
   - bundle exec rake spec features

--- a/spec/support/gemfiles/Gemfile.activesupport-4.0.0
+++ b/spec/support/gemfiles/Gemfile.activesupport-4.0.0
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gemspec :path => '../../../'
+
+gem 'activesupport', '4.0.0'

--- a/stack_master.gemspec
+++ b/stack_master.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "diffy"
   spec.add_dependency "erubis"
   spec.add_dependency "colorize"
-  spec.add_dependency "activesupport", "~> 4.2"
+  spec.add_dependency "activesupport", '>= 4'
   spec.add_dependency "sparkle_formation"
   spec.add_dependency "table_print"
   spec.add_dependency "dotgpg"


### PR DESCRIPTION
Update the dependency on ActiveSupport to allow version 5 and above.

The specs pass on ActiveSupport version `4.0.0`, but not `3.2.22.5`. Hence setting lower bound to version `4`.

ActiveSupport 5 is not compatible with Ruby 2.1 so have added a custom Gemfile for testing Ruby 2.1. It  specifies ActiveSupport 4.0.0. This gets the tests passing on Ruby 2.1 _and_ proves StackMaster works with the ActiveSupport lower bound specified in the gemspec.