### PR TITLE
Fix tests not finding SecureRandom

### DIFF
--- a/lib/stack_master/test_driver/cloud_formation.rb
+++ b/lib/stack_master/test_driver/cloud_formation.rb
@@ -1,3 +1,5 @@
+require 'securerandom'
+
 module StackMaster
   module TestDriver
     class Stack


### PR DESCRIPTION
No idea why this doesn't fail in travis but it does on my system locally