### PR TITLE
Make Change Set output more visible

### DIFF
--- a/features/apply.feature
+++ b/features/apply.feature
@@ -207,9 +207,10 @@ Feature: Apply command
       | Stack diff:                                                                    |
       | -    "TestSg2": {                                                              |
       | Parameters diff: No changes                                                    |
-      | ==========                                                                     |
+      | ========================================                                       |
       | Proposed change set:                                                           |
       | Replace                                                                        |
+      | ========================================                                       |
       | Apply change set (y/n)?                                                              |
     Then the exit status should be 0
 

--- a/features/apply.feature
+++ b/features/apply.feature
@@ -207,6 +207,7 @@ Feature: Apply command
       | Stack diff:                                                                    |
       | -    "TestSg2": {                                                              |
       | Parameters diff: No changes                                                    |
+      | ==========                                                                     |
       | Proposed change set:                                                           |
       | Replace                                                                        |
       | Apply change set (y/n)?                                                              |

--- a/lib/stack_master/change_set.rb
+++ b/lib/stack_master/change_set.rb
@@ -42,11 +42,11 @@ module StackMaster
     end
 
     def display(io)
-      io.puts <<~EOL
+      io.puts <<-EOL
 
-      ==========
-      Proposed change set:
-      EOL
+==========
+Proposed change set:
+EOL
       @response.changes.each do |change|
         display_resource_change(io, change.resource_change)
       end

--- a/lib/stack_master/change_set.rb
+++ b/lib/stack_master/change_set.rb
@@ -42,9 +42,11 @@ module StackMaster
     end
 
     def display(io)
-      io.puts "
+      io.puts <<~EOL
+
       ==========
-      Proposed change set:"
+      Proposed change set:
+      EOL
       @response.changes.each do |change|
         display_resource_change(io, change.resource_change)
       end

--- a/lib/stack_master/change_set.rb
+++ b/lib/stack_master/change_set.rb
@@ -42,7 +42,9 @@ module StackMaster
     end
 
     def display(io)
-      io.puts "Proposed change set:"
+      io.puts "
+      ==========
+      Proposed change set:"
       @response.changes.each do |change|
         display_resource_change(io, change.resource_change)
       end

--- a/lib/stack_master/change_set.rb
+++ b/lib/stack_master/change_set.rb
@@ -44,12 +44,13 @@ module StackMaster
     def display(io)
       io.puts <<-EOL
 
-==========
+========================================
 Proposed change set:
 EOL
       @response.changes.each do |change|
         display_resource_change(io, change.resource_change)
       end
+io.puts "========================================"
     end
 
     def failed?


### PR DESCRIPTION
## Context

At the moment the change set output isn't easily distinguishable from the JSON and Parameter diff.

```
Stack diff: No changes
Parameters diff:
 ---
 LambdaAlias: current
 LambdaFunction: my_lambda_function
-MaxBatchSize: '1'
+MaxBatchSize: '10'
 StreamArn: arn:aws:kinesis:us-east-1:012345678910:stream/foo
Proposed change set:
Modify AWS::Lambda::EventSourceMapping EventSource
- Properties.BatchSize. Triggered by: DirectModification(Dynamic).
- Properties.BatchSize. Triggered by: ParameterReference.MaxBatchSize.
Apply change set (y/n)?
```

This has tripped people up in the past where they have not noticed the change set and even deleted production databases.
I believe the Change Set is the single most important thing people should look at and therefore the most visible.

## Change

Make the output more visible by adding a line break and border to the change set.

Before:
![screen shot 2018-02-21 at 3 07 05 pm](https://user-images.githubusercontent.com/2901882/36462695-03f98de2-1719-11e8-8726-b07fd1386254.png)


After:
![screen shot 2018-02-21 at 3 19 18 pm](https://user-images.githubusercontent.com/2901882/36462944-a056d05e-171a-11e8-8e7d-735aa0e20ad0.png)
