### PR TITLE
parameter_store parameter resolver.

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,19 @@ db_password:
   secret: db_password
 ```
 
+### Parameter Store
+An alternative to the secrets store, uses the AWS SSM Parameter store to protect
+secrets.   Expects a parameter of either `String` or `SecureString` type to be present in the
+same region as the stack. You can store the parameter using a command like this
+`aws-vault exec <whatever> -- aws ssm put-parameter --region <region> --name <parameter name> --value <secret> --type (String|SecureString)`
+When doing so make sure you don't accidentally store the secret in your `.bash_history` and
+you will likely want to set the parameter to NoEcho in your template.
+
+```yaml
+db_password:
+  parameter_store: ssm_parameter_name
+```
+
 ### Security Group
 
 Looks up a security group by name and returns the ARN.

--- a/features/apply_with_parameter_store_parameters.feature
+++ b/features/apply_with_parameter_store_parameters.feature
@@ -12,9 +12,9 @@ Feature: Apply command with parameter_store parameter
     And a file named "parameters/vpc.yml" with:
       """
       vpc_cidr:
-        parameter_store: CUCUMBER_TEST_VPC_CIDR
+        parameter_store: "/cucumber-test-vpc-cidr"
       """
-    And a SSM parameter named "CUCUMBER_TEST_VPC_CIDR" with value "10.0.0.0/16" in region "us-east-2"
+    And a SSM parameter named "/cucumber-test-vpc-cidr" with value "10.0.0.0/16" in region "us-east-2"
     And a directory named "templates"
     And a file named "templates/vpc.rb" with:
       """

--- a/features/apply_with_parameter_store_parameters.feature
+++ b/features/apply_with_parameter_store_parameters.feature
@@ -1,0 +1,47 @@
+Feature: Apply command with parameter_store parameter
+
+  Background:
+    Given a file named "stack_master.yml" with:
+      """
+      stacks:
+        us-east-2:
+          vpc:
+            template: vpc.rb
+      """
+    And a directory named "parameters"
+    And a file named "parameters/vpc.yml" with:
+      """
+      vpc_cidr:
+        parameter_store: CUCUMBER_TEST_VPC_CIDR
+      """
+    And a SSM parameter named "CUCUMBER_TEST_VPC_CIDR" with value "10.0.0.0/16" in region "us-east-2"
+    And a directory named "templates"
+    And a file named "templates/vpc.rb" with:
+      """
+      SparkleFormation.new(:vpc) do
+
+        parameters.vpc_cidr do
+          type 'String'
+        end
+
+        resources.vpc do
+          type 'AWS::EC2::VPC'
+          properties do
+            cidr_block ref!(:vpc_cidr)
+          end
+        end
+
+      end
+      """
+
+  Scenario: Run apply and create a new stack
+    Given I stub the following stack events:
+      | stack_id | event_id | stack_name | logical_resource_id | resource_status | resource_type              | timestamp           |
+      | 1        | 1        | vpc        | Vpc                 | CREATE_COMPLETE | AWS::EC2::VPC              | 2020-10-29 00:00:00 |
+      | 1        | 1        | vpc        | vpc                 | CREATE_COMPLETE | AWS::CloudFormation::Stack | 2020-10-29 00:00:00 |
+    When I run `stack_master apply us-east-2 vpc --trace`
+    And the output should contain all of these lines:
+      | +---                  |
+      | +VpcCidr: 10.0.0.0/16 |
+    And the output should match /2020-10-29 00:00:00 (\+|\-)[0-9]{4} vpc AWS::CloudFormation::Stack CREATE_COMPLETE/
+    Then the exit status should be 0

--- a/features/step_definitions/parameter_store_steps.rb
+++ b/features/step_definitions/parameter_store_steps.rb
@@ -1,0 +1,15 @@
+Given(/^(?:a|the) SSM parameter(?: named)? "([^"]*)" with value "([^"]*)" in region "([^"]*)"$/) do |parameter_name, parameter_value, parameter_region|
+  File.open("/tmp/humpy-log", 'a') { |file| file.write("In Here name: #{parameter_name} value: #{parameter_value} \n") }
+  Aws.config[:ssm] = {
+    stub_responses: {
+      get_parameter: {
+        parameter: {
+          name: parameter_name,
+          value: parameter_value,
+          type: "SecureString",
+          version: 1
+        }
+      }
+    }
+  }
+end

--- a/features/step_definitions/parameter_store_steps.rb
+++ b/features/step_definitions/parameter_store_steps.rb
@@ -1,5 +1,4 @@
 Given(/^(?:a|the) SSM parameter(?: named)? "([^"]*)" with value "([^"]*)" in region "([^"]*)"$/) do |parameter_name, parameter_value, parameter_region|
-  File.open("/tmp/humpy-log", 'a') { |file| file.write("In Here name: #{parameter_name} value: #{parameter_value} \n") }
   Aws.config[:ssm] = {
     stub_responses: {
       get_parameter: {

--- a/lib/stack_master.rb
+++ b/lib/stack_master.rb
@@ -61,6 +61,7 @@ module StackMaster
     autoload :LatestAmiByTags, 'stack_master/parameter_resolvers/latest_ami_by_tags'
     autoload :LatestAmi, 'stack_master/parameter_resolvers/latest_ami'
     autoload :Env, 'stack_master/parameter_resolvers/env'
+    autoload :ParameterStore, 'stack_master/parameter_resolvers/parameter_store'
   end
 
   module AwsDriver

--- a/lib/stack_master/parameter_resolvers/parameter_store.rb
+++ b/lib/stack_master/parameter_resolvers/parameter_store.rb
@@ -2,7 +2,7 @@ module StackMaster
   module ParameterResolvers
     class ParameterStore < Resolver
 
-      SecretNotFound = Class.new(StandardError)
+      ParameterNotFound = Class.new(StandardError)
 
       def initialize(config, stack_definition)
         @config = config
@@ -16,7 +16,7 @@ module StackMaster
             with_decryption: true
           )
         rescue Aws::SSM::Errors::ParameterNotFound
-          raise SecretNotFound, "Unable to find key #{value} in Parameter Store"
+          raise ParameterNotFound, "Unable to find #{value} in Parameter Store"
         end
         resp.parameter.value
       end

--- a/lib/stack_master/parameter_resolvers/parameter_store.rb
+++ b/lib/stack_master/parameter_resolvers/parameter_store.rb
@@ -1,0 +1,24 @@
+module StackMaster
+  module ParameterResolvers
+    class ParameterStore < Resolver
+      def initialize(config, stack_definition)
+        @config = config
+        @stack_definition = stack_definition
+      end
+
+      def resolve(value)
+        resp = ssm.get_parameter(
+          name: value,
+          with_decryption: true
+        )
+        resp.parameter.value
+      end
+
+      private
+
+      def ssm
+        @ssm ||= Aws::SSM::Client.new(region: @stack_definition.region)
+      end
+    end
+  end
+end

--- a/lib/stack_master/parameter_resolvers/parameter_store.rb
+++ b/lib/stack_master/parameter_resolvers/parameter_store.rb
@@ -1,16 +1,23 @@
 module StackMaster
   module ParameterResolvers
     class ParameterStore < Resolver
+
+      SecretNotFound = Class.new(StandardError)
+
       def initialize(config, stack_definition)
         @config = config
         @stack_definition = stack_definition
       end
 
       def resolve(value)
-        resp = ssm.get_parameter(
-          name: value,
-          with_decryption: true
-        )
+        begin
+          resp = ssm.get_parameter(
+            name: value,
+            with_decryption: true
+          )
+        rescue Aws::SSM::Errors::ParameterNotFound
+          raise SecretNotFound, "Unable to find key #{value} in Parameter Store"
+        end
         resp.parameter.value
       end
 

--- a/spec/stack_master/parameter_resolvers/parameter_store_spec.rb
+++ b/spec/stack_master/parameter_resolvers/parameter_store_spec.rb
@@ -1,0 +1,50 @@
+RSpec.describe StackMaster::ParameterResolvers::ParameterStore do
+
+  describe '#resolve' do
+
+    let(:config) { double(base_dir: '/base') }
+    let(:stack_definition) { double(stack_name: 'mystack', region: 'us-east-1') }
+    subject(:resolver) { described_class.new(config, stack_definition) }
+    let(:parameter_name) { 'TEST' }
+    let(:parameter_value) { 'TEST' }
+    let(:unknown_parameter_name) { 'NOTEST' }
+    let(:unencryptable_parameter_name) { 'SECRETTEST' }
+
+
+    context 'the parameter is defined' do
+      before do
+        Aws.config[:ssm] = {
+          stub_responses: {
+            get_parameter: {
+              parameter: {
+                name: parameter_name,
+                value: parameter_value,
+                type: "SecureString",
+                version: 1
+              }
+            }
+          }
+        }
+      end
+  
+      it 'should return the parameter value' do
+        expect(resolver.resolve(parameter_name)).to eq parameter_value
+      end
+    end
+
+    context 'the parameter is undefined' do
+      before do
+        Aws.config[:ssm] = {
+          stub_responses: {
+            get_parameter: 
+              Aws::SSM::Errors::ParameterNotFound.new(unknown_parameter_name, "Parameter #{unknown_parameter_name} not found")
+          }
+        }
+      end
+      it 'should raise and error' do
+        expect { resolver.resolve(unknown_parameter_name) }
+            .to raise_error(Aws::SSM::Errors::ParameterNotFound, "Parameter #{unknown_parameter_name} not found")
+      end
+    end
+  end
+end

--- a/spec/stack_master/parameter_resolvers/parameter_store_spec.rb
+++ b/spec/stack_master/parameter_resolvers/parameter_store_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe StackMaster::ParameterResolvers::ParameterStore do
       end
       it 'should raise and error' do
         expect { resolver.resolve(unknown_parameter_name) }
-            .to raise_error(Aws::SSM::Errors::ParameterNotFound, "Parameter #{unknown_parameter_name} not found")
+            .to raise_error(StackMaster::ParameterResolvers::ParameterStore::SecretNotFound, "Unable to find key #{unknown_parameter_name} in Parameter Store")
       end
     end
   end

--- a/spec/stack_master/parameter_resolvers/parameter_store_spec.rb
+++ b/spec/stack_master/parameter_resolvers/parameter_store_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe StackMaster::ParameterResolvers::ParameterStore do
       end
       it 'should raise and error' do
         expect { resolver.resolve(unknown_parameter_name) }
-            .to raise_error(StackMaster::ParameterResolvers::ParameterStore::SecretNotFound, "Unable to find key #{unknown_parameter_name} in Parameter Store")
+            .to raise_error(StackMaster::ParameterResolvers::ParameterStore::ParameterNotFound, "Unable to find #{unknown_parameter_name} in Parameter Store")
       end
     end
   end


### PR DESCRIPTION
Resolves parameters from the AWS SSM parameter store service as alternative
to the dotgpg malarky. (which is great for large teams but is overkill for single
person/small team use)

This is the inital cut, just uses default AWS managed encryption keys.

Format is pretty simple
`parameter.yml`:
```
foo:
  parameter_store: ssm_name
```
Fetches the SecureString parameter ssm_name from the AWS SSM store using the prevailing
aws credentials.

DONE:  
1. Add ability to specify KMS key_id to use to decrypt 
       (to make it useful for storing things like database passwords)  (Can't get_parameter doesn't let you specify the key to use, it's stored with the parameter at encryption time)

1. Add ability to specify version to use to decrypt (Can't retrieve a particular version so of limited utility so not going to do)
1. Make it work with parameter arrays (Not required, 1 parameter 1 value and it can be a comma separated list if required)

TODO:
Nothing

