### PR TITLE
Allow loading of sparkle packs

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,6 +481,16 @@ stacks:
           vpc-sparkle-pack: vpc-sparkle-pack
 ```
 
+The template can then simply load a dynamic from the sparkle pack like so:
+
+```ruby
+SparkleFormation.new(:my_stack_with_dynamic) do
+   dynamic!(:sparkle_pack_dynamic)
+end
+```
+
+Note though that if a dynamic with the same name exists in your `templates/dynamics/` directory it will get loaded since it has higher precedence.
+
 ## Commands
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -477,7 +477,7 @@ stacks:
     my-stack:
       template: my-stack-with-dynamic.rb
       compiler_options:
-        sparkle_pack:
+        sparkle_packs:
           vpc-sparkle-pack: vpc-sparkle-pack
 ```
 

--- a/README.md
+++ b/README.md
@@ -467,6 +467,20 @@ stacks:
       template: my-stack.rb
 ```
 
+### Loading SparklePacks
+
+[SparklePacks](http://www.sparkleformation.io/docs/sparkle_formation/sparkle-packs.html) can be pre-loaded using compiler options. This requires the name of a rubygem to `require` followed by the name of the SparklePack, which is usually the same name as the Gem.
+
+```yaml
+stacks:
+  us-east-1
+    my-stack:
+      template: my-stack-with-dynamic.rb
+      compiler_options:
+        sparkle_pack:
+          vpc-sparkle-pack: vpc-sparkle-pack
+```
+
 ## Commands
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -478,7 +478,7 @@ stacks:
       template: my-stack-with-dynamic.rb
       compiler_options:
         sparkle_packs:
-          vpc-sparkle-pack: vpc-sparkle-pack
+          - vpc-sparkle-pack
 ```
 
 The template can then simply load a dynamic from the sparkle pack like so:

--- a/lib/stack_master/stack.rb
+++ b/lib/stack_master/stack.rb
@@ -65,7 +65,7 @@ module StackMaster
       parameter_hash = ParameterLoader.load(stack_definition.parameter_files)
       template_parameters = ParameterResolver.resolve(config, stack_definition, parameter_hash[:template_parameters])
       compile_time_parameters = ParameterResolver.resolve(config, stack_definition, parameter_hash[:compile_time_parameters])
-      template_body = TemplateCompiler.compile(config, stack_definition.template_file_path, compile_time_parameters,stack_definition.compiler_options)
+      template_body = TemplateCompiler.compile(config, stack_definition.template_file_path, compile_time_parameters, stack_definition.compiler_options)
       template_format = TemplateUtils.identify_template_format(template_body)
       stack_policy_body = if stack_definition.stack_policy_file_path
                             File.read(stack_definition.stack_policy_file_path)

--- a/lib/stack_master/template_compilers/sparkle_formation.rb
+++ b/lib/stack_master/template_compilers/sparkle_formation.rb
@@ -32,11 +32,11 @@ module StackMaster::TemplateCompilers
                         File.expand_path(compiler_options['sparkle_path']) : File.dirname(template_file_path)
 
       collection = ::SparkleFormation::SparkleCollection.new
+      root_pack = ::SparkleFormation::Sparkle.new(
+        :root => sparkle_path,
+      )
+      collection.set_root(root_pack)
       if compiler_options['sparkle_packs']
-        root_pack = ::SparkleFormation::Sparkle.new(
-          :root => sparkle_path,
-        )
-        collection.set_root(root_pack)
         compiler_options['sparkle_packs'].each_pair do |gem_name, pack_name|
           require gem_name
           pack = ::SparkleFormation::SparklePack.new(:name => pack_name)

--- a/lib/stack_master/template_compilers/sparkle_formation.rb
+++ b/lib/stack_master/template_compilers/sparkle_formation.rb
@@ -13,12 +13,7 @@ module StackMaster::TemplateCompilers
     end
 
     def self.compile(template_file_path, compile_time_parameters, compiler_options = {})
-      if compiler_options['sparkle_path']
-        ::SparkleFormation.sparkle_path = File.expand_path(compiler_options['sparkle_path'])
-      else
-        ::SparkleFormation.sparkle_path = File.dirname(template_file_path)
-      end
-      sparkle_template = ::SparkleFormation.compile(template_file_path, :sparkle)
+      sparkle_template = compile_sparkle_template(template_file_path, compiler_options)
       definitions = sparkle_template.parameters
       validate_definitions(definitions)
       validate_parameters(definitions, compile_time_parameters)
@@ -31,6 +26,15 @@ module StackMaster::TemplateCompilers
     end
 
     private
+
+    def self.compile_sparkle_template(template_file_path, compiler_options)
+      if compiler_options['sparkle_path']
+        ::SparkleFormation.sparkle_path = File.expand_path(compiler_options['sparkle_path'])
+      else
+        ::SparkleFormation.sparkle_path = File.dirname(template_file_path)
+      end
+      ::SparkleFormation.compile(template_file_path, :sparkle)
+    end
 
     def self.validate_definitions(definitions)
       CompileTime::DefinitionsValidator.new(definitions).validate

--- a/lib/stack_master/template_compilers/sparkle_formation.rb
+++ b/lib/stack_master/template_compilers/sparkle_formation.rb
@@ -37,8 +37,8 @@ module StackMaster::TemplateCompilers
       )
       collection.set_root(root_pack)
       if compiler_options['sparkle_packs']
-        compiler_options['sparkle_packs'].each_pair do |gem_name, pack_name|
-          require gem_name
+        compiler_options['sparkle_packs'].each do |pack_name|
+          require pack_name
           pack = ::SparkleFormation::SparklePack.new(:name => pack_name)
           collection.add_sparkle(pack)
         end

--- a/spec/fixtures/sparkle_pack_integration/my_sparkle_pack/lib/my_sparkle_pack.rb
+++ b/spec/fixtures/sparkle_pack_integration/my_sparkle_pack/lib/my_sparkle_pack.rb
@@ -1,0 +1,1 @@
+::SparkleFormation::SparklePack.register!

--- a/spec/fixtures/sparkle_pack_integration/my_sparkle_pack/lib/sparkleformation/dynamics/my_dynamic.rb
+++ b/spec/fixtures/sparkle_pack_integration/my_sparkle_pack/lib/sparkleformation/dynamics/my_dynamic.rb
@@ -1,0 +1,5 @@
+SparkleFormation.dynamic(:my_dynamic) do
+  outputs.foo do
+    value "bar"
+  end
+end

--- a/spec/fixtures/sparkle_pack_integration/templates/dynamics/local_dynamic.rb
+++ b/spec/fixtures/sparkle_pack_integration/templates/dynamics/local_dynamic.rb
@@ -1,0 +1,5 @@
+SparkleFormation.dynamic(:local_dynamic) do
+  outputs.bar do
+    value "local_dynamic"
+  end
+end

--- a/spec/fixtures/sparkle_pack_integration/templates/template_with_dynamic.rb
+++ b/spec/fixtures/sparkle_pack_integration/templates/template_with_dynamic.rb
@@ -1,0 +1,3 @@
+SparkleFormation.new(:template_with_dynamic) do
+  dynamic!(:local_dynamic)
+end

--- a/spec/fixtures/sparkle_pack_integration/templates/template_with_dynamic_from_pack.rb
+++ b/spec/fixtures/sparkle_pack_integration/templates/template_with_dynamic_from_pack.rb
@@ -1,0 +1,3 @@
+SparkleFormation.new(:template_with_dynamic_from_pack) do
+  dynamic!(:my_dynamic)
+end

--- a/spec/stack_master/template_compilers/sparkle_formation_spec.rb
+++ b/spec/stack_master/template_compilers/sparkle_formation_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe StackMaster::TemplateCompilers::SparkleFormation do
 
     context 'with a sparkle_pack loaded' do
       let(:template_file_path) { File.join(File.dirname(__FILE__), "..", "..", "fixtures", "sparkle_pack_integration", "templates", "template_with_dynamic_from_pack.rb")}
-      let(:compiler_options) { {"sparkle_packs" => {"my_sparkle_pack" => "my_sparkle_pack"}} }
+      let(:compiler_options) { {"sparkle_packs" => ["my_sparkle_pack"]} }
 
       before do
         lib =  File.join(File.dirname(__FILE__), "..", "..", "fixtures", "sparkle_pack_integration", "my_sparkle_pack", "lib")

--- a/spec/stack_master/template_compilers/sparkle_formation_spec.rb
+++ b/spec/stack_master/template_compilers/sparkle_formation_spec.rb
@@ -19,13 +19,16 @@ RSpec.describe StackMaster::TemplateCompilers::SparkleFormation do
 
     before do
       allow(::SparkleFormation).to receive(:compile).with(template_file_path, :sparkle).and_return(sparkle_template)
+      allow(::SparkleFormation::Sparkle).to receive(:new)
       allow(StackMaster::SparkleFormation::CompileTime::DefinitionsValidator).to receive(:new).and_return(definitions_validator)
       allow(StackMaster::SparkleFormation::CompileTime::ParametersValidator).to receive(:new).and_return(parameters_validator)
       allow(StackMaster::SparkleFormation::CompileTime::StateBuilder).to receive(:new).and_return(state_builder)
+      allow(::SparkleFormation::SparkleCollection).to receive(:new).and_return(sparkle_double)
 
       allow(sparkle_template).to receive(:parameters).and_return(compile_time_parameter_definitions)
       allow(sparkle_template).to receive(:sparkle).and_return(sparkle_double)
       allow(sparkle_double).to receive(:apply)
+      allow(sparkle_double).to receive(:set_root)
       allow(definitions_validator).to receive(:validate)
       allow(parameters_validator).to receive(:validate)
       allow(state_builder).to receive(:build).and_return({})
@@ -83,19 +86,31 @@ RSpec.describe StackMaster::TemplateCompilers::SparkleFormation do
   end
 
   describe '.compile with sparkle packs' do
-    let(:template_file_path) { File.join(File.dirname(__FILE__), "..", "..", "fixtures", "sparkle_pack_integration", "templates", "template_with_dynamic_from_pack.rb")}
     let(:compile_time_parameters) { {} }
-    let(:compiler_options) { {"sparkle_packs" => {"my_sparkle_pack" => "my_sparkle_pack"}} }
     subject(:compile) { described_class.compile(template_file_path, compile_time_parameters, compiler_options)}
 
-    before do
-      lib =  File.join(File.dirname(__FILE__), "..", "..", "fixtures", "sparkle_pack_integration", "my_sparkle_pack", "lib")
-      puts "Loading from #{lib}"
-      $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+    context 'with a sparkle_pack loaded' do
+      let(:template_file_path) { File.join(File.dirname(__FILE__), "..", "..", "fixtures", "sparkle_pack_integration", "templates", "template_with_dynamic_from_pack.rb")}
+      let(:compiler_options) { {"sparkle_packs" => {"my_sparkle_pack" => "my_sparkle_pack"}} }
+
+      before do
+        lib =  File.join(File.dirname(__FILE__), "..", "..", "fixtures", "sparkle_pack_integration", "my_sparkle_pack", "lib")
+        puts "Loading from #{lib}"
+        $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+      end
+
+      it 'pulls the dynamic from the sparkle pack' do
+        expect(compile).to eq(%Q({\n  \"Outputs\": {\n    \"Foo\": {\n      \"Value\": \"bar\"\n    }\n  }\n}))
+      end
     end
 
-    it 'pulls the dynamic from the sparkle pack' do
-      expect(compile).to eq(%Q({\n  \"Outputs\": {\n    \"Foo\": {\n      \"Value\": \"bar\"\n    }\n  }\n}))
+    context 'without a sparkle_pack loaded' do
+      let(:template_file_path) { File.join(File.dirname(__FILE__), "..", "..", "fixtures", "sparkle_pack_integration", "templates", "template_with_dynamic.rb")}
+      let(:compiler_options) { {} }
+
+      it 'pulls the dynamic from the local path' do
+        expect(compile).to eq(%Q({\n  \"Outputs\": {\n    \"Bar\": {\n      \"Value\": \"local_dynamic\"\n    }\n  }\n}))
+      end
     end
   end
 end


### PR DESCRIPTION
SparkleFormation supports the concept of a [SparklePack](http://www.sparkleformation.io/docs/sparkle_formation/sparkle-packs.html) which can be packaged as a RubyGem and required inside the template that utilises it. This allows re-usable dynamics to be shared very simply.

Unfortunately the implementation is [fundamentally](https://github.com/sparkleformation/sparkle_formation/pull/239) [broken](https://github.com/sparkleformation/sparkle_formation/pull/240). Such that requiring a sparkle pack inside a template like so (which is what the documentation suggests):

```
require 'vpc_sparkle_pack'
pack = ::SparkleFormation::SparklePack.new(:name => 'vpc_sparkle_pack')
SparkleFormation.new(:util_vpc, sparkle: pack) do
...
end
```

results in a race condition, dependent on the file load order which is not deterministic.

This bug occurs when SparkleFormation tries to load a SparklePack while it's still loading `templates/`. Therefore the easiest workaround is to pre-load the SparklePack from StackMaster.

I would've liked to have fixed this in SparkleFormation, but after spending 3 days on the problem I feel I am no closer to a solution.