### PR TITLE
Fix S3 url for China region

### DIFF
--- a/lib/stack_master/aws_driver/s3.rb
+++ b/lib/stack_master/aws_driver/s3.rb
@@ -51,6 +51,8 @@ module StackMaster
       def url(bucket:, prefix:, region:, template:)
         if region == 'us-east-1'
           ["https://s3.amazonaws.com", bucket, prefix, template].compact.join('/')
+        elsif region.start_with? "cn-"
+          ["https://s3.#{region}.amazonaws.com.cn", bucket, prefix, template].compact.join('/')
         else
           ["https://s3-#{region}.amazonaws.com", bucket, prefix, template].compact.join('/')
         end


### PR DESCRIPTION
There is slightly different AWS S3 url for China region.