### PR TITLE
pass compile-time-params through to cfndsl

### DIFF
--- a/lib/stack_master/template_compilers/cfndsl.rb
+++ b/lib/stack_master/template_compilers/cfndsl.rb
@@ -6,6 +6,7 @@ module StackMaster::TemplateCompilers
 
     def self.compile(template_file_path, compile_time_parameters, _compiler_options = {})
       CfnDsl.disable_binding
+      CfnDsl::ExternalParameters.defaults.clear # Ensure there's no leakage across invocations
       CfnDsl::ExternalParameters.defaults(compile_time_parameters.symbolize_keys)
       ::CfnDsl.eval_file_with_extras(template_file_path).to_json
     end

--- a/lib/stack_master/template_compilers/cfndsl.rb
+++ b/lib/stack_master/template_compilers/cfndsl.rb
@@ -4,9 +4,9 @@ module StackMaster::TemplateCompilers
       require 'cfndsl'
     end
 
-    def self.compile(template_file_path, _compile_time_parameters, _compiler_options = {})
+    def self.compile(template_file_path, compile_time_parameters, _compiler_options = {})
       CfnDsl.disable_binding
-      CfnDsl::ExternalParameters.defaults(_compile_time_parameters.symbolize_keys)
+      CfnDsl::ExternalParameters.defaults(compile_time_parameters.symbolize_keys)
       ::CfnDsl.eval_file_with_extras(template_file_path).to_json
     end
 

--- a/lib/stack_master/template_compilers/cfndsl.rb
+++ b/lib/stack_master/template_compilers/cfndsl.rb
@@ -5,6 +5,8 @@ module StackMaster::TemplateCompilers
     end
 
     def self.compile(template_file_path, _compile_time_parameters, _compiler_options = {})
+      CfnDsl.disable_binding
+      CfnDsl::ExternalParameters.defaults(_compile_time_parameters.symbolize_keys)
       ::CfnDsl.eval_file_with_extras(template_file_path).to_json
     end
 

--- a/spec/fixtures/templates/rb/cfndsl/sample-ctp-repeated.rb
+++ b/spec/fixtures/templates/rb/cfndsl/sample-ctp-repeated.rb
@@ -1,0 +1,18 @@
+CloudFormation {
+  Description "Test"
+
+  Parameter("One") {
+    String
+    Default "Test"
+    MaxLength 15
+  }
+
+  Output(:One,FnBase64( Ref("One")))
+
+  EC2_Instance(:MyInstance) {
+    DisableApiTermination external_parameters["DisableApiTermination"]
+    InstanceType external_parameters["InstanceType"]
+    ImageId "ami-12345678"
+  }
+
+}

--- a/spec/fixtures/templates/rb/cfndsl/sample-ctp.json
+++ b/spec/fixtures/templates/rb/cfndsl/sample-ctp.json
@@ -10,6 +10,7 @@
     "MyInstance" : {
       "Type" : "AWS::EC2::Instance",
       "Properties" : {
+        "InstanceType": "t2.medium",
         "ImageId" : "ami-12345678"
       }
     }

--- a/spec/fixtures/templates/rb/cfndsl/sample-ctp.rb
+++ b/spec/fixtures/templates/rb/cfndsl/sample-ctp.rb
@@ -10,6 +10,7 @@ CloudFormation {
   Output(:One,FnBase64( Ref("One")))
 
   EC2_Instance(:MyInstance) {
+    InstanceType external_parameters["InstanceType"]
     ImageId "ami-12345678"
   }
 

--- a/spec/fixtures/templates/rb/cfndsl/sample.json
+++ b/spec/fixtures/templates/rb/cfndsl/sample.json
@@ -10,6 +10,7 @@
     "MyInstance" : {
       "Type" : "AWS::EC2::Instance",
       "Properties" : {
+        "InstanceType": "t2.medium",
         "ImageId" : "ami-12345678"
       }
     }

--- a/spec/fixtures/templates/rb/cfndsl/sample.rb
+++ b/spec/fixtures/templates/rb/cfndsl/sample.rb
@@ -10,6 +10,7 @@ CloudFormation {
   Output(:One,FnBase64( Ref("One")))
 
   EC2_Instance(:MyInstance) {
+    InstanceType external_parameters["InstanceType"]
     ImageId "ami-12345678"
   }
 

--- a/spec/stack_master/template_compilers/cfndsl_spec.rb
+++ b/spec/stack_master/template_compilers/cfndsl_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe StackMaster::TemplateCompilers::Cfndsl do
   before(:all) { described_class.require_dependencies }
 
   describe '.compile' do
-    def compile
-      described_class.compile(template_file_path, compile_time_parameters)
+    def compile(ctps = compile_time_parameters)
+      described_class.compile(template_file_path, ctps)
     end
 
     context 'valid cfndsl template' do
@@ -26,6 +26,18 @@ RSpec.describe StackMaster::TemplateCompilers::Cfndsl do
       it 'produces valid JSON' do
         valid_compiled_json = File.read(valid_compiled_json_path)
         expect(JSON.parse(compile)).to eq(JSON.parse(valid_compiled_json))
+      end
+
+      context 'compiling multiple times' do
+        let(:compile_time_parameters) { {'InstanceType' => 't2.medium', 'DisableApiTermination' => 'true'} }
+        let(:template_file_path) { 'spec/fixtures/templates/rb/cfndsl/sample-ctp-repeated.rb' }
+
+        it 'does not leak compile time params across invocations' do
+          #expect(JSON.parse(compile)["Resources"]["MyInstance"]["Properties"]["DisableApiTermination"]).to eq(compile_time_parameters['DisableApiTermination'])
+          expect {
+            compile_time_parameters.delete("DisableApiTermination")
+          }.to change { JSON.parse(compile)["Resources"]["MyInstance"]["Properties"]["DisableApiTermination"] }.from('true').to(nil)
+        end
       end
     end
   end

--- a/spec/stack_master/template_compilers/cfndsl_spec.rb
+++ b/spec/stack_master/template_compilers/cfndsl_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe StackMaster::TemplateCompilers::Cfndsl do
   before(:all) { described_class.require_dependencies }
 
   describe '.compile' do
-    def compile(ctps = compile_time_parameters)
-      described_class.compile(template_file_path, ctps)
+    def compile
+      described_class.compile(template_file_path, compile_time_parameters)
     end
 
     context 'valid cfndsl template' do
@@ -33,7 +33,6 @@ RSpec.describe StackMaster::TemplateCompilers::Cfndsl do
         let(:template_file_path) { 'spec/fixtures/templates/rb/cfndsl/sample-ctp-repeated.rb' }
 
         it 'does not leak compile time params across invocations' do
-          #expect(JSON.parse(compile)["Resources"]["MyInstance"]["Properties"]["DisableApiTermination"]).to eq(compile_time_parameters['DisableApiTermination'])
           expect {
             compile_time_parameters.delete("DisableApiTermination")
           }.to change { JSON.parse(compile)["Resources"]["MyInstance"]["Properties"]["DisableApiTermination"] }.from('true').to(nil)

--- a/spec/stack_master/template_compilers/cfndsl_spec.rb
+++ b/spec/stack_master/template_compilers/cfndsl_spec.rb
@@ -18,5 +18,15 @@ RSpec.describe StackMaster::TemplateCompilers::Cfndsl do
         expect(JSON.parse(compile)).to eq(JSON.parse(valid_compiled_json))
       end
     end
+
+    context 'with compile time parameters' do
+      let(:template_file_path) { 'spec/fixtures/templates/rb/cfndsl/sample-ctp.rb' }
+      let(:valid_compiled_json_path) { 'spec/fixtures/templates/rb/cfndsl/sample-ctp.json' }
+
+      it 'produces valid JSON' do
+        valid_compiled_json = File.read(valid_compiled_json_path)
+        expect(JSON.parse(compile)).to eq(JSON.parse(valid_compiled_json))
+      end
+    end
   end
 end


### PR DESCRIPTION
This is a pretty simple PR that just does the bare minimum to wire-up CTP's to cfndsl.

A few points:

* CfnDsl, unlike Sparkle, [doesn't currently support direct ruby access](https://github.com/cfndsl/cfndsl/issues/255) to the template (e.g. to add a `CompileState` output).  So I haven't added that, though I could modify the output json if that was seen as a hard requirement.
* CfnDsl doesn't natively support any form of parameter validation - its expected that you're giving cfndsl valid yaml/json/ruby as input and they just expose those to the template.  Hence I haven't added any validation.
* CfnDsl [has a pending PR to support passing a hash for compile-time-params](https://github.com/cfndsl/cfndsl/pull/365) (as of today!  by me!).  The current requirement to serialize CTP's as `:raw` parameter types is awkward at best.

Feedback welcome, but hopefully this gets the ball rolling.