### PR TITLE
Add 1password secret lookup using the 1password cli (`op`)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .bundle
 .config
 .yardoc
+*.swp
 Gemfile.lock
 InstalledFiles
 _yardoc

--- a/README.md
+++ b/README.md
@@ -253,6 +253,23 @@ you will likely want to set the parameter to NoEcho in your template.
 db_password:
   parameter_store: ssm_parameter_name
 ```
+### 1Password Lookup
+An Alternative to the alternative secret store is accessing 1password secrets using the 1password cli (`op`).
+You declare a 1password lookup with the following parameters in your parameters file:
+
+```
+parameters/database.yml
+database_password:
+  one_password:
+    title: production database
+    vault: Shared
+    type: password
+```
+
+1password stores the name of the secret in the `title`. You can pass the `vault` you expect the secret to be in.
+Currently we support two types of secrets, `password`s and `secureNote`s. All values must be declared, there are no defaults.
+
+For more information on 1password cli please see [here](https://support.1password.com/command-line-getting-started/)
 
 ### Security Group
 

--- a/lib/stack_master.rb
+++ b/lib/stack_master.rb
@@ -62,6 +62,7 @@ module StackMaster
     autoload :LatestAmi, 'stack_master/parameter_resolvers/latest_ami'
     autoload :Env, 'stack_master/parameter_resolvers/env'
     autoload :ParameterStore, 'stack_master/parameter_resolvers/parameter_store'
+    autoload :OnePassword, 'stack_master/parameter_resolvers/one_password'
   end
 
   module AwsDriver

--- a/lib/stack_master/parameter_resolvers/one_password.rb
+++ b/lib/stack_master/parameter_resolvers/one_password.rb
@@ -1,0 +1,48 @@
+module StackMaster
+  module ParameterResolvers
+    class OnePassword < Resolver
+      OnePasswordNotFound = Class.new(StandardError)
+
+      array_resolver
+
+      def initialize(config, stack_definition)
+        @config = config
+        @stack_definition = stack_definition
+      end
+
+      def resolve(params={})
+        raise RuntimeError, "1password requires the `OP_SESSION_<name>` to be set" if ENV.keys.grep(/OP_SESSION_\w+$/).empty?    
+        get_items(params)
+      end
+
+      private
+
+      def op_get_item(item, vault)
+        begin
+          %x(op get item --vault='#{vault}' '#{item}')
+        rescue Errno::ENOENT
+          raise RuntimeError, "The op cli needs to be installed in the PATH"
+        rescue => exception
+          raise RuntimeError, exception
+        end
+      end
+
+      def get_password(title, vault)
+        JSON.parse(op_get_item(title, vault)).dig('details', 'fields').select { |k,v| k.key('password') }[0].values_at('value').first
+      end
+      
+      def get_secure_note(title, vault)
+        JSON.parse(op_get_item(title, vault))['details'].values_at('notesPlain').first
+      end
+
+      def get_items(params)
+        case params['type']
+        when 'password'
+          return get_password(params['title'], params['vault'])
+        when 'secureNote'
+          return get_secure_note(params['title'], params['vault'])
+        end
+      end
+    end
+  end
+end

--- a/lib/stack_master/parameter_resolvers/one_password.rb
+++ b/lib/stack_master/parameter_resolvers/one_password.rb
@@ -35,6 +35,10 @@ module StackMaster
         raise OnePasswordInvalidResponse, "Failed to parse JSON returned, #{item}: #{exception}"
       end
 
+      def is_login_item?(data)
+        data.details.password.nil?
+      end
+
       def op_get_item(item, vault)
         validate_op_installed?
         item = %x(op get item --vault='#{vault}' '#{item}' 2>&1)
@@ -46,9 +50,16 @@ module StackMaster
       end
 
       def get_password(title, vault)
-        create_struct(title, vault).details.fields[1].value
+        # There are two types of password that can be returned.
+        # One is attached to a Login item in 1Password
+        # the other is to a Password item.
+        if is_login_item?(create_struct(title, vault))
+          create_struct(title, vault).details.fields[1].value
+        else
+          create_struct(title, vault).details.password
+        end
       end
-      
+
       def get_secure_note(title, vault)
         create_struct(title, vault).details.notesPlain
       end

--- a/lib/stack_master/parameter_resolvers/one_password.rb
+++ b/lib/stack_master/parameter_resolvers/one_password.rb
@@ -21,8 +21,8 @@ module StackMaster
 
       def validate_op_installed?
         %x(op --version)
-        rescue Errno::ENOENT => exception
-          raise OnePasswordBinaryNotFound, "The op cli needs to be installed and in the PATH, #{exception}"
+      rescue Errno::ENOENT => exception
+        raise OnePasswordBinaryNotFound, "The op cli needs to be installed and in the PATH, #{exception}"
       end
 
       def validate_response?(item)
@@ -30,8 +30,8 @@ module StackMaster
           raise OnePasswordNotFound, "Failed to return item from 1password, #{i['error']}"
         end
         JSON.parse(item)
-        rescue JSON::ParserError => exception
-          raise OnePasswordInvalidResponse, "Failed to parse JSON returned, #{item}: #{exception}"
+      rescue JSON::ParserError => exception
+        raise OnePasswordInvalidResponse, "Failed to parse JSON returned, #{item}: #{exception}"
       end
 
       def op_get_item(item, vault)

--- a/lib/stack_master/parameter_resolvers/one_password.rb
+++ b/lib/stack_master/parameter_resolvers/one_password.rb
@@ -22,7 +22,7 @@ module StackMaster
           item = %x(op get item --vault='#{vault}' '#{item}' 2>&1)
           return item if JSON.parse(item)
         rescue Errno::ENOENT
-          raise RuntimeError, "The op cli needs to be installed in the PATH"
+          raise RuntimeError, "The op cli needs to be installed and in the PATH"
         rescue => exception
           raise RuntimeError, "Failed to return item from 1password, #{item}"
         end

--- a/lib/stack_master/parameter_resolvers/one_password.rb
+++ b/lib/stack_master/parameter_resolvers/one_password.rb
@@ -41,12 +41,16 @@ module StackMaster
         end
       end
 
+      def create_struct(title, vault)
+        JSON.parse(op_get_item(title, vault), object_class: OpenStruct)
+      end
+
       def get_password(title, vault)
-        JSON.parse(op_get_item(title, vault))['details']['fields'].select { |k,v| k.key('password') }[0].values_at('value').first
+        create_struct(title, vault).details.fields[1].value
       end
       
       def get_secure_note(title, vault)
-        JSON.parse(op_get_item(title, vault))['details'].values_at('notesPlain').first
+        create_struct(title, vault).details.notesPlain
       end
 
       def get_items(params)

--- a/lib/stack_master/parameter_resolvers/one_password.rb
+++ b/lib/stack_master/parameter_resolvers/one_password.rb
@@ -2,6 +2,7 @@ module StackMaster
   module ParameterResolvers
     class OnePassword < Resolver
       OnePasswordNotFound = Class.new(StandardError)
+      OnePasswordNotAbleToAuthenticate = Class.new(StandardError)
       OnePasswordBinaryNotFound = Class.new(StandardError)
       OnePasswordInvalidResponse = Class.new(StandardError)
 
@@ -13,7 +14,7 @@ module StackMaster
       end
 
       def resolve(params={})
-        raise RuntimeError, "1password requires the `OP_SESSION_<name>` to be set" if ENV.keys.grep(/OP_SESSION_\w+$/).empty?    
+        raise OnePasswordNotAbleToAuthenticate, "1password requires the `OP_SESSION_<name>` to be set, (remember to sign in?)" if ENV.keys.grep(/OP_SESSION_\w+$/).empty?    
         get_items(params)
       end
 

--- a/lib/stack_master/parameter_resolvers/one_password.rb
+++ b/lib/stack_master/parameter_resolvers/one_password.rb
@@ -19,11 +19,12 @@ module StackMaster
 
       def op_get_item(item, vault)
         begin
-          %x(op get item --vault='#{vault}' '#{item}')
+          item = %x(op get item --vault='#{vault}' '#{item}' 2>&1)
+          return item if JSON.parse(item)
         rescue Errno::ENOENT
           raise RuntimeError, "The op cli needs to be installed in the PATH"
         rescue => exception
-          raise RuntimeError, exception
+          raise RuntimeError, "Failed to return item from 1password, #{item}"
         end
       end
 

--- a/lib/stack_master/parameter_resolvers/one_password.rb
+++ b/lib/stack_master/parameter_resolvers/one_password.rb
@@ -29,7 +29,7 @@ module StackMaster
       end
 
       def get_password(title, vault)
-        JSON.parse(op_get_item(title, vault)).dig('details', 'fields').select { |k,v| k.key('password') }[0].values_at('value').first
+        JSON.parse(op_get_item(title, vault))['details']['fields'].select { |k,v| k.key('password') }[0].values_at('value').first
       end
       
       def get_secure_note(title, vault)

--- a/lib/stack_master/parameter_resolvers/one_password.rb
+++ b/lib/stack_master/parameter_resolvers/one_password.rb
@@ -39,6 +39,14 @@ module StackMaster
         data.details.password.nil?
       end
 
+      def password_item(data)
+        data.details.password 
+      end
+
+      def login_item(data)
+        data.details.fields[1].value
+      end
+
       def op_get_item(item, vault)
         validate_op_installed?
         item = %x(op get item --vault='#{vault}' '#{item}' 2>&1)
@@ -54,9 +62,9 @@ module StackMaster
         # One is attached to a Login item in 1Password
         # the other is to a Password item.
         if is_login_item?(create_struct(title, vault))
-          create_struct(title, vault).details.fields[1].value
+          login_item(create_struct(title, vault))
         else
-          create_struct(title, vault).details.password
+          password_item(create_struct(title, vault))
         end
       end
 

--- a/spec/stack_master/parameter_resolvers/one_password_spec.rb
+++ b/spec/stack_master/parameter_resolvers/one_password_spec.rb
@@ -6,58 +6,58 @@ RSpec.describe StackMaster::ParameterResolvers::OnePassword do
     subject(:resolver) { described_class.new(config, stack_definition) }
     let(:op_env_unset) { ENV['OP_SESSION_something'].clear  }
     let(:secureNote) {{
-      "uuid": "auuid",
-      "vaultUuid": "avaultuuid",
-      "templateUuid": "003",
-      "createdAt": "2018-01-17 07:28:11 +0000 UTC",
-      "updatedAt": "2018-01-17 07:28:11 +0000 UTC",
-      "changerUuid": "anotheruuid",
-      "overview": {
-        "ainfo": "begin message",
-        "ps": 0,
-        "title": "note title"
+      "uuid" => "auuid",
+      "vaultUuid" => "avaultuuid",
+      "templateUuid" => "003",
+      "createdAt" => "2018-01-17 07:28:11 +0000 UTC",
+      "updatedAt" => "2018-01-17 07:28:11 +0000 UTC",
+      "changerUuid" => "anotheruuid",
+      "overview" => {
+        "ainfo" => "begin message",
+        "ps" => 0,
+        "title" => "note title"
       },
-      "details": {
-        "notesPlain": "decrypted note",
-        "sections": [
+      "details" => {
+        "notesPlain" => "decrypted note",
+        "sections" => [
           {
-            "name": "linked items",
-            "title": "Related Items"
+            "name" => "linked items",
+            "title" => "Related Items"
           }
         ]
       }
     }}
     let(:password) {{
-      "uuid": "auuid",
-      "vaultUuid": "avaultuuid",
-      "templateUuid": "001",
-      "createdAt": "2018-03-24 01:55:07 +0000 UTC",
-      "updatedAt": "2018-03-24 01:55:07 +0000 UTC",
-      "changerUuid": "anotheruuid",
-      "overview": {
-        "ainfo": "pi",
-        "ps": 84,
-        "title": "password title"
+      "uuid" => "auuid",
+      "vaultUuid" => "avaultuuid",
+      "templateUuid" => "001",
+      "createdAt" => "2018-03-24 01:55:07 +0000 UTC",
+      "updatedAt" => "2018-03-24 01:55:07 +0000 UTC",
+      "changerUuid" => "anotheruuid",
+      "overview" => {
+        "ainfo" => "pi",
+        "ps" =>  84,
+        "title" => "password title"
       },
-      "details": {
-        "fields": [
+      "details" => {
+        "fields" => [
           {
-            "designation": "username",
-            "name": "username",
-            "type": "T",
-            "value": "theusername"
+            "designation" => "username",
+            "name" => "username",
+            "type" => "T",
+            "value" => "theusername"
           },
           {
-            "designation": "password",
-            "name": "password",
-            "type": "P",
-            "value": "thepassword"
+            "designation" => "password",
+            "name" => "password",
+            "type" => "P",
+            "value" => "thepassword"
           }
         ],
-        "sections": [
+        "sections" => [
           {
-            "name": "linked items",
-            "title": "Related Items"
+            "name" => "linked items",
+            "title" => "Related Items"
           }
         ]
       }

--- a/spec/stack_master/parameter_resolvers/one_password_spec.rb
+++ b/spec/stack_master/parameter_resolvers/one_password_spec.rb
@@ -63,18 +63,14 @@ RSpec.describe StackMaster::ParameterResolvers::OnePassword do
       }
     }}
     let(:the_password) {{
-      one_password: [
-        title: 'password title',
-        type: 'password',
-        vault: 'Shared'
-      ]
+        'title' => 'password title',
+        'type' => 'password',
+        'vault' => 'Shared'
     }}
     let(:the_secureNote) {{
-      one_password: [
-        title: 'note title',
-        type: 'secureNote',
-        vault: 'Shared'
-      ]
+        'title' => 'note title',
+        'type' => 'secureNote',
+        'vault' => 'Shared'
     }}
 
     context 'when we have set OP_SESSION_ environment' do

--- a/spec/stack_master/parameter_resolvers/one_password_spec.rb
+++ b/spec/stack_master/parameter_resolvers/one_password_spec.rb
@@ -63,23 +63,23 @@ RSpec.describe StackMaster::ParameterResolvers::OnePassword do
       }
     }}
     let(:password) {{
-      "uuid": "auuid",
-      "vaultUuid": "avaultuuid",
-      "templateUuid": "005",
-      "createdAt": "2018-04-24 11:07:34 +0000 UTC",
-      "updatedAt": "2018-04-24 11:07:34 +0000 UTC",
-      "changerUuid": "antheruuid",
-      "overview": {
-        "ainfo": "24 Apr 2018, 9:07:34 pm",
-        "ps": 100,
-        "title": "password title"
+      "uuid" => "auuid",
+      "vaultUuid" => "avaultuuid",
+      "templateUuid" => "005",
+      "createdAt" => "2018-04-24 11:07:34 +0000 UTC",
+      "updatedAt" => "2018-04-24 11:07:34 +0000 UTC",
+      "changerUuid" => "antheruuid",
+      "overview" => {
+        "ainfo" => "24 Apr 2018, 9:07:34 pm",
+        "ps" =>  100,
+        "title" => "password title"
       },
-      "details": {
-        "password": "thepassword",
-        "sections": [
+      "details" => {
+        "password" => "thepassword",
+        "sections" => [
           {
-            "name": "linked items",
-            "title": "Related Items"
+            "name" => "linked items",
+            "title" => "Related Items"
           }
         ]
       }

--- a/spec/stack_master/parameter_resolvers/one_password_spec.rb
+++ b/spec/stack_master/parameter_resolvers/one_password_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe StackMaster::ParameterResolvers::OnePassword do
         ]
       }
     }}
-    let(:password) {{
+    let(:login_password) {{
       "uuid" => "auuid",
       "vaultUuid" => "avaultuuid",
       "templateUuid" => "001",
@@ -62,6 +62,28 @@ RSpec.describe StackMaster::ParameterResolvers::OnePassword do
         ]
       }
     }}
+    let(:password) {{
+      "uuid": "auuid",
+      "vaultUuid": "avaultuuid",
+      "templateUuid": "005",
+      "createdAt": "2018-04-24 11:07:34 +0000 UTC",
+      "updatedAt": "2018-04-24 11:07:34 +0000 UTC",
+      "changerUuid": "antheruuid",
+      "overview": {
+        "ainfo": "24 Apr 2018, 9:07:34 pm",
+        "ps": 100,
+        "title": "password title"
+      },
+      "details": {
+        "password": "thepassword",
+        "sections": [
+          {
+            "name": "linked items",
+            "title": "Related Items"
+          }
+        ]
+      }
+    }}
     let(:the_password) {{
         'title' => 'password title',
         'type' => 'password',
@@ -77,12 +99,19 @@ RSpec.describe StackMaster::ParameterResolvers::OnePassword do
       before do
         ENV['OP_SESSION_something'] = 'session'
       end
+      context 'when retrieving a login password' do
+        it 'returns the login password' do
+        allow_any_instance_of(described_class).to receive(:`).with("op --version").and_return(true)
+          allow_any_instance_of(described_class).to receive(:`).with("op get item --vault='Shared' 'password title' 2>&1").and_return(login_password.to_json)
+          expect(resolver.resolve(the_password)).to eq 'thepassword'
+        end
+      end
       context 'when retrieving a password' do
         it 'returns the password' do
         allow_any_instance_of(described_class).to receive(:`).with("op --version").and_return(true)
           allow_any_instance_of(described_class).to receive(:`).with("op get item --vault='Shared' 'password title' 2>&1").and_return(password.to_json)
           expect(resolver.resolve(the_password)).to eq 'thepassword'
-        end      
+        end
       end
       context 'when retrieving a secureNote' do
         it 'returns the secureNote' do

--- a/spec/stack_master/parameter_resolvers/one_password_spec.rb
+++ b/spec/stack_master/parameter_resolvers/one_password_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe StackMaster::ParameterResolvers::OnePassword do
           allow(ENV).to receive_message_chain(:keys, :grep).with(/OP_SESSION_\w+$/).and_return([])
           allow_any_instance_of(described_class).to receive(:`).with("op --version").and_return(true)
           allow_any_instance_of(described_class).to receive(:`).with("op get item --vault='Shared' 'password title' 2>&1").and_return(password.to_json)
-          expect { resolver.resolve(the_password) }.to raise_error(RuntimeError, "1password requires the `OP_SESSION_<name>` to be set")
+          expect { resolver.resolve(the_password) }.to raise_error(StackMaster::ParameterResolvers::OnePassword::OnePasswordNotAbleToAuthenticate, "1password requires the `OP_SESSION_<name>` to be set, (remember to sign in?)")
         end
       end
     end

--- a/spec/stack_master/parameter_resolvers/one_password_spec.rb
+++ b/spec/stack_master/parameter_resolvers/one_password_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe StackMaster::ParameterResolvers::OnePassword do
       it 'we return an error' do
         allow_any_instance_of(described_class).to receive(:`).with("op --version").and_return(true)
         allow_any_instance_of(described_class).to receive(:`).with("op get item --vault='Shared' 'password title' 2>&1").and_return('{key: value }')
-        expect { resolver.resolve(the_password) }.to raise_error(StackMaster::ParameterResolvers::OnePassword::OnePasswordInvalidResponse, "Failed to parse JSON returned, {key: value }: 784: unexpected token at '{key: value }'")
+        expect { resolver.resolve(the_password) }.to raise_error(StackMaster::ParameterResolvers::OnePassword::OnePasswordInvalidResponse, /Failed to parse JSON returned, {key: value }: \d+: unexpected token at '{key: value }'/)
       end
     end
   end

--- a/spec/stack_master/parameter_resolvers/one_password_spec.rb
+++ b/spec/stack_master/parameter_resolvers/one_password_spec.rb
@@ -79,12 +79,14 @@ RSpec.describe StackMaster::ParameterResolvers::OnePassword do
       end
       context 'when retrieving a password' do
         it 'returns the password' do
+        allow_any_instance_of(described_class).to receive(:`).with("op --version").and_return(true)
           allow_any_instance_of(described_class).to receive(:`).with("op get item --vault='Shared' 'password title' 2>&1").and_return(password.to_json)
           expect(resolver.resolve(the_password)).to eq 'thepassword'
         end      
       end
       context 'when retrieving a secureNote' do
         it 'returns the secureNote' do
+        allow_any_instance_of(described_class).to receive(:`).with("op --version").and_return(true)
           allow_any_instance_of(described_class).to receive(:`).with("op get item --vault='Shared' 'note title' 2>&1").and_return(secureNote.to_json)
           expect(resolver.resolve(the_secureNote)).to eq 'decrypted note'
         end
@@ -94,6 +96,7 @@ RSpec.describe StackMaster::ParameterResolvers::OnePassword do
       context 'when retrieving a password' do
         it 'should raise error when ENV not set' do
           allow(ENV).to receive_message_chain(:keys, :grep).with(/OP_SESSION_\w+$/).and_return([])
+          allow_any_instance_of(described_class).to receive(:`).with("op --version").and_return(true)
           allow_any_instance_of(described_class).to receive(:`).with("op get item --vault='Shared' 'password title' 2>&1").and_return(password.to_json)
           expect { resolver.resolve(the_password) }.to raise_error(RuntimeError, "1password requires the `OP_SESSION_<name>` to be set")
         end
@@ -103,9 +106,10 @@ RSpec.describe StackMaster::ParameterResolvers::OnePassword do
       before do
         ENV['OP_SESSION_something'] = 'session'
       end
+      
       it 'we return an error' do
-        allow_any_instance_of(described_class).to receive(:`).with("op get item --vault='Shared' 'password title' 2>&1").and_raise(Errno::ENOENT)
-        expect { resolver.resolve(the_password) }.to raise_error(RuntimeError, "The op cli needs to be installed and in the PATH")
+        allow_any_instance_of(described_class).to receive(:`).with("op --version").and_raise(Errno::ENOENT)
+        expect { resolver.resolve(the_password) }.to raise_error(RuntimeError, "The op cli needs to be installed and in the PATH, No such file or directory")
       end
     end
     context 'when items are not found' do
@@ -113,6 +117,7 @@ RSpec.describe StackMaster::ParameterResolvers::OnePassword do
         ENV['OP_SESSION_something'] = 'session'
       end
       it 'we return an error' do
+        allow_any_instance_of(described_class).to receive(:`).with("op --version").and_return(true)
         allow_any_instance_of(described_class).to receive(:`).with("op get item --vault='Shared' 'password title' 2>&1").and_return('[LOG] 2018/03/26 09:56:02 (ERROR) Vault Shared not found.')
         expect { resolver.resolve(the_password) }.to raise_error(RuntimeError, 'Failed to return item from 1password, [LOG] 2018/03/26 09:56:02 (ERROR) Vault Shared not found.')
       end

--- a/spec/stack_master/parameter_resolvers/one_password_spec.rb
+++ b/spec/stack_master/parameter_resolvers/one_password_spec.rb
@@ -79,13 +79,13 @@ RSpec.describe StackMaster::ParameterResolvers::OnePassword do
       end
       context 'when retrieving a password' do
         it 'returns the password' do
-          allow_any_instance_of(described_class).to receive(:`).with("op get item --vault='Shared' 'password title'").and_return(password.to_json)
+          allow_any_instance_of(described_class).to receive(:`).with("op get item --vault='Shared' 'password title' 2>&1").and_return(password.to_json)
           expect(resolver.resolve(the_password)).to eq 'thepassword'
         end      
       end
       context 'when retrieving a secureNote' do
         it 'returns the secureNote' do
-          allow_any_instance_of(described_class).to receive(:`).with("op get item --vault='Shared' 'note title'").and_return(secureNote.to_json)
+          allow_any_instance_of(described_class).to receive(:`).with("op get item --vault='Shared' 'note title' 2>&1").and_return(secureNote.to_json)
           expect(resolver.resolve(the_secureNote)).to eq 'decrypted note'
         end
       end
@@ -94,7 +94,7 @@ RSpec.describe StackMaster::ParameterResolvers::OnePassword do
       context 'when retrieving a password' do
         it 'should raise error when ENV not set' do
           allow(ENV).to receive_message_chain(:keys, :grep).with(/OP_SESSION_\w+$/).and_return([])
-          allow_any_instance_of(described_class).to receive(:`).with("op get item --vault='Shared' 'password title'").and_return(password.to_json)
+          allow_any_instance_of(described_class).to receive(:`).with("op get item --vault='Shared' 'password title' 2>&1").and_return(password.to_json)
           expect { resolver.resolve(the_password) }.to raise_error(RuntimeError, "1password requires the `OP_SESSION_<name>` to be set")
         end
       end
@@ -103,10 +103,19 @@ RSpec.describe StackMaster::ParameterResolvers::OnePassword do
       before do
         ENV['OP_SESSION_something'] = 'session'
       end
-      it 'gives an error' do
-        allow_any_instance_of(described_class).to receive(:`).with("op get item --vault='Shared' 'password title'").and_raise(Errno::ENOENT)
+      it 'we return an error' do
+        allow_any_instance_of(described_class).to receive(:`).with("op get item --vault='Shared' 'password title' 2>&1").and_raise(Errno::ENOENT)
         expect { resolver.resolve(the_password) }.to raise_error(RuntimeError, "The op cli needs to be installed in the PATH")
-      end   
+      end
+    end
+    context 'when items are not found' do
+      before do
+        ENV['OP_SESSION_something'] = 'session'
+      end
+      it 'we return an error' do
+        allow_any_instance_of(described_class).to receive(:`).with("op get item --vault='Shared' 'password title' 2>&1").and_return('[LOG] 2018/03/26 09:56:02 (ERROR) Vault Shared not found.')
+        expect { resolver.resolve(the_password) }.to raise_error(RuntimeError, 'Failed to return item from 1password, [LOG] 2018/03/26 09:56:02 (ERROR) Vault Shared not found.')
+      end
     end
   end
 end

--- a/spec/stack_master/parameter_resolvers/one_password_spec.rb
+++ b/spec/stack_master/parameter_resolvers/one_password_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe StackMaster::ParameterResolvers::OnePassword do
       end
       it 'we return an error' do
         allow_any_instance_of(described_class).to receive(:`).with("op get item --vault='Shared' 'password title' 2>&1").and_raise(Errno::ENOENT)
-        expect { resolver.resolve(the_password) }.to raise_error(RuntimeError, "The op cli needs to be installed in the PATH")
+        expect { resolver.resolve(the_password) }.to raise_error(RuntimeError, "The op cli needs to be installed and in the PATH")
       end
     end
     context 'when items are not found' do

--- a/spec/stack_master/parameter_resolvers/one_password_spec.rb
+++ b/spec/stack_master/parameter_resolvers/one_password_spec.rb
@@ -1,0 +1,116 @@
+RSpec.describe StackMaster::ParameterResolvers::OnePassword do
+
+  describe '#resolve' do
+    let(:config) { double(base_dir: '/base') }
+    let(:stack_definition) { double(stack_name: 'mystack', region: 'us-east-1') }
+    subject(:resolver) { described_class.new(config, stack_definition) }
+    let(:op_env_unset) { ENV['OP_SESSION_something'].clear  }
+    let(:secureNote) {{
+      "uuid": "auuid",
+      "vaultUuid": "avaultuuid",
+      "templateUuid": "003",
+      "createdAt": "2018-01-17 07:28:11 +0000 UTC",
+      "updatedAt": "2018-01-17 07:28:11 +0000 UTC",
+      "changerUuid": "anotheruuid",
+      "overview": {
+        "ainfo": "begin message",
+        "ps": 0,
+        "title": "note title"
+      },
+      "details": {
+        "notesPlain": "decrypted note",
+        "sections": [
+          {
+            "name": "linked items",
+            "title": "Related Items"
+          }
+        ]
+      }
+    }}
+    let(:password) {{
+      "uuid": "auuid",
+      "vaultUuid": "avaultuuid",
+      "templateUuid": "001",
+      "createdAt": "2018-03-24 01:55:07 +0000 UTC",
+      "updatedAt": "2018-03-24 01:55:07 +0000 UTC",
+      "changerUuid": "anotheruuid",
+      "overview": {
+        "ainfo": "pi",
+        "ps": 84,
+        "title": "password title"
+      },
+      "details": {
+        "fields": [
+          {
+            "designation": "username",
+            "name": "username",
+            "type": "T",
+            "value": "theusername"
+          },
+          {
+            "designation": "password",
+            "name": "password",
+            "type": "P",
+            "value": "thepassword"
+          }
+        ],
+        "sections": [
+          {
+            "name": "linked items",
+            "title": "Related Items"
+          }
+        ]
+      }
+    }}
+    let(:the_password) {{
+      one_password: [
+        title: 'password title',
+        type: 'password',
+        vault: 'Shared'
+      ]
+    }}
+    let(:the_secureNote) {{
+      one_password: [
+        title: 'note title',
+        type: 'secureNote',
+        vault: 'Shared'
+      ]
+    }}
+
+    context 'when we have set OP_SESSION_ environment' do
+      before do
+        ENV['OP_SESSION_something'] = 'session'
+      end
+      context 'when retrieving a password' do
+        it 'returns the password' do
+          allow_any_instance_of(described_class).to receive(:`).with("op get item --vault='Shared' 'password title'").and_return(password.to_json)
+          expect(resolver.resolve(the_password)).to eq 'thepassword'
+        end      
+      end
+      context 'when retrieving a secureNote' do
+        it 'returns the secureNote' do
+          allow_any_instance_of(described_class).to receive(:`).with("op get item --vault='Shared' 'note title'").and_return(secureNote.to_json)
+          expect(resolver.resolve(the_secureNote)).to eq 'decrypted note'
+        end
+      end
+    end
+    context 'when we have not set OP_SESSION_ environment' do
+      context 'when retrieving a password' do
+        it 'should raise error when ENV not set' do
+          allow(ENV).to receive_message_chain(:keys, :grep).with(/OP_SESSION_\w+$/).and_return([])
+          allow_any_instance_of(described_class).to receive(:`).with("op get item --vault='Shared' 'password title'").and_return(password.to_json)
+          expect { resolver.resolve(the_password) }.to raise_error(RuntimeError, "1password requires the `OP_SESSION_<name>` to be set")
+        end
+      end
+    end
+    context 'when we op cli is not installed' do
+      before do
+        ENV['OP_SESSION_something'] = 'session'
+      end
+      it 'gives an error' do
+        allow_any_instance_of(described_class).to receive(:`).with("op get item --vault='Shared' 'password title'").and_raise(Errno::ENOENT)
+        expect { resolver.resolve(the_password) }.to raise_error(RuntimeError, "The op cli needs to be installed in the PATH")
+      end   
+    end
+  end
+end


### PR DESCRIPTION
This adds 1password lookups using the 1password cli `op`.

You declare your parameters like so:

```
parameters/database.yml
database_password:
  one_password:
    title: production database
    vault: Shared
    type: password
```

Currently we support two types of secrets, `password`s and `secureNote`s.

You must sign in before being able to resolve secrets:
`eval $(op signin <url> <email> <SECRET>)`
see [here](https://support.1password.com/command-line-getting-started/) for more detail