### PR TITLE
support multiple aliases for a single region

### DIFF
--- a/lib/stack_master/config.rb
+++ b/lib/stack_master/config.rb
@@ -96,7 +96,8 @@ module StackMaster
 
     def resolve_region_aliases(stacks)
       stacks.inject({}) do |hash, (region, attributes)|
-        hash[unalias_region(region)] = attributes
+        hash[unalias_region(region)] ||= {}
+        hash[unalias_region(region)].merge!(attributes)
         hash
       end
     end


### PR DESCRIPTION
Related to https://github.com/envato/stack_master/pull/115 and https://github.com/envato/stack_master/issues/180 I have hit an issue where only the last region alias defined is actually honored. This simple patch allows for multiple aliases in a single region, but does not set any precedence for parameter resolution. E.g. consider the following:
```
region_aliases:
  foo: us-east-1
  bar: us-east-1

stacks:
  foo:
    foo-stack:
      template: foo.rb
  bar:
    bar-stack:
      template: bar.rb
```
Parameters for both stacks will look in `parameters/foo` and `parameters/bar`. Since one cannot have duplicate stack names in a region IMO this is not a huge issue. This patch will at least allow the option for logical `stack_master.yml` layout and ordering for parameter files.