### PR TITLE
add resolver for acm certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,15 @@ db_username:
   env: DB_USERNAME
 ```
 
+### ACM Certificates
+
+Find an ACM certificate by domain name:
+
+```yaml
+cert:
+  acm_certificate: www.example.com
+```
+
 ### Custom parameter resolvers
 
 New parameter resolvers can be created in a separate gem.

--- a/lib/stack_master.rb
+++ b/lib/stack_master.rb
@@ -1,11 +1,12 @@
 require 'commander'
 require 'yaml'
-require "aws-sdk-cloudformation"
-require "aws-sdk-ec2"
-require "aws-sdk-s3"
-require "aws-sdk-sns"
-require "aws-sdk-ssm"
-require "colorize"
+require 'aws-sdk-acm'
+require 'aws-sdk-cloudformation'
+require 'aws-sdk-ec2'
+require 'aws-sdk-s3'
+require 'aws-sdk-sns'
+require 'aws-sdk-ssm'
+require 'colorize'
 require 'active_support/core_ext/string'
 require 'multi_json'
 
@@ -60,6 +61,7 @@ module StackMaster
   end
 
   module ParameterResolvers
+    autoload :AcmCertificate, 'stack_master/parameter_resolvers/acm_certificate'
     autoload :AmiFinder, 'stack_master/parameter_resolvers/ami_finder'
     autoload :StackOutput, 'stack_master/parameter_resolvers/stack_output'
     autoload :Secret, 'stack_master/parameter_resolvers/secret'

--- a/lib/stack_master/parameter_resolvers/acm_certificate.rb
+++ b/lib/stack_master/parameter_resolvers/acm_certificate.rb
@@ -1,0 +1,37 @@
+module StackMaster
+  module ParameterResolvers
+    class AcmCertificate < Resolver
+      CertificateNotFound = Class.new(StandardError)
+
+      def initialize(config, stack_definition)
+        @config = config
+        @stack_definition = stack_definition
+      end
+
+      def resolve(domain_name)
+        cert_arn = find_cert_arn_by_domain_name(domain_name)
+        raise CertificateNotFound, "Could not find certificate #{domain_name} in #{@stack_definition.region}" unless cert_arn
+        cert_arn
+      end
+
+      private
+
+      def all_certs
+        certs = []
+        next_token = nil
+        client = Aws::ACM::Client.new(region: @stack_definition.region)
+        loop do
+          resp = client.list_certificates(certificate_statuses: ['ISSUED'], next_token: next_token)
+          certs << resp.certificate_summary_list
+          next_token = resp.next_token
+          break if next_token.nil?
+        end
+        certs.flatten
+      end
+
+      def find_cert_arn_by_domain_name(domain_name)
+        all_certs.map { |c| c.certificate_arn if c.domain_name == domain_name }.compact.first
+      end
+    end
+  end
+end

--- a/spec/stack_master/parameter_resolvers/acm_certificate_spec.rb
+++ b/spec/stack_master/parameter_resolvers/acm_certificate_spec.rb
@@ -1,0 +1,36 @@
+RSpec.describe StackMaster::ParameterResolvers::AcmCertificate do
+  let(:config) { double(base_dir: '/base') }
+  let(:stack_definition) { double(stack_name: 'mystack', region: 'us-east-1') }
+  subject(:resolver) { described_class.new(config, stack_definition) }
+  let(:acm) { Aws::ACM::Client.new }
+
+  before do
+    allow(Aws::ACM::Client).to receive(:new).and_return(acm)
+  end
+
+  context 'when a certificate is found' do
+    before do
+      acm.stub_responses(:list_certificates, certificate_summary_list: [
+        { certificate_arn: 'arn:aws:acm:us-east-1:12345:certificate/abc', domain_name: 'abc' },
+        { certificate_arn: 'arn:aws:acm:us-east-1:12345:certificate/def', domain_name: 'def' }
+      ])
+    end
+
+    it 'returns the certificate' do
+      expect(resolver.resolve('def')).to eq 'arn:aws:acm:us-east-1:12345:certificate/def'
+    end
+  end
+
+  context 'when no certificate is found' do
+    before do
+      acm.stub_responses(:list_certificates, certificate_summary_list: [])
+    end
+
+    it 'raises an error' do
+      expect { resolver.resolve('def') }.to raise_error(
+        StackMaster::ParameterResolvers::AcmCertificate::CertificateNotFound,
+        'Could not find certificate def in us-east-1'
+      )
+    end
+  end
+end

--- a/stack_master.gemspec
+++ b/stack_master.gemspec
@@ -40,6 +40,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "os"
   spec.add_dependency "ruby-progressbar"
   spec.add_dependency "commander"
+  spec.add_dependency "aws-sdk-acm", "~> 1"
   spec.add_dependency "aws-sdk-cloudformation", "~> 1"
   spec.add_dependency "aws-sdk-ec2", "~> 1"
   spec.add_dependency "aws-sdk-s3", "~> 1"


### PR DESCRIPTION
Partially addresses https://github.com/envato/stack_master/issues/92

@stevehodgkiss I'm not sure what you're looking for wrt EC2 KeyPairs or EIP allocation IDs.

EC2 key pairs are specified by key name in Cloudformation so I'm not certain how useful a resolver would be or what it would resolve.

EIP associations are done on the EIP resource (not the instance itself) so not sure what to resolve here either. Is the use case that given `x` allocation ID just return the public IP? What's the use case?

Happy to add more with clarification 😄 