### PR TITLE
Adds a check for REVIEW_IN_PROGRESS on CF stack.

### DIFF
--- a/lib/stack_master/commands/apply.rb
+++ b/lib/stack_master/commands/apply.rb
@@ -46,11 +46,20 @@ module StackMaster
         !stack.nil?
       end
 
+      def stack_in_review?
+        return false if stack.nil?
+        if stack.stack_status == "REVIEW_IN_PROGRESS"
+          StackMaster.stderr.puts "Stack currently exists and is in #{stack.stack_status}"
+          failed! "You will need to delete the stack (#{stack.stack_name}) before continuing"
+        end
+      end
+
       def use_s3?
         !@s3_config.empty?
       end
 
       def diff_stacks
+        stack_in_review?
         StackDiffer.new(proposed_stack, stack).output_diff
       end
 

--- a/lib/stack_master/commands/apply.rb
+++ b/lib/stack_master/commands/apply.rb
@@ -46,9 +46,8 @@ module StackMaster
         !stack.nil?
       end
 
-      def stack_in_review?
-        return false if stack.nil?
-        if stack.stack_status == "REVIEW_IN_PROGRESS"
+      def abort_if_review_in_progress
+        if stack_exists? && stack.stack_status == "REVIEW_IN_PROGRESS"
           StackMaster.stderr.puts "Stack currently exists and is in #{stack.stack_status}"
           failed! "You will need to delete the stack (#{stack.stack_name}) before continuing"
         end
@@ -59,7 +58,7 @@ module StackMaster
       end
 
       def diff_stacks
-        stack_in_review?
+        abort_if_review_in_progress
         StackDiffer.new(proposed_stack, stack).output_diff
       end
 

--- a/spec/stack_master/commands/apply_spec.rb
+++ b/spec/stack_master/commands/apply_spec.rb
@@ -238,6 +238,15 @@ RSpec.describe StackMaster::Commands::Apply do
     end
   end
 
+  context 'stack is in review_in_progress' do
+    
+    let(:stack) { StackMaster::Stack.new(stack_id: '1', stack_name: 'mistack', stack_status: 'REVIEW_IN_PROGRESS')}
+
+    it 'fails with error' do
+      expect{ apply }.to output("Stack currently exists and is in REVIEW_IN_PROGRESS\nYou will need to delete the stack (mistack) before continuing\n").to_stderr
+    end
+  end
+
   context 'one or more parameters are empty' do
     let(:stack) { StackMaster::Stack.new(stack_id: '1', parameters: parameters) }
     let(:parameters) { { 'param_1' => nil } }

--- a/spec/stack_master/commands/apply_spec.rb
+++ b/spec/stack_master/commands/apply_spec.rb
@@ -239,10 +239,9 @@ RSpec.describe StackMaster::Commands::Apply do
   end
 
   context 'stack is in review_in_progress' do
-    
     let(:stack) { StackMaster::Stack.new(stack_id: '1', stack_name: 'mistack', stack_status: 'REVIEW_IN_PROGRESS')}
 
-    it 'fails with error' do
+    it 'abort and fails with error' do
       expect{ apply }.to output("Stack currently exists and is in REVIEW_IN_PROGRESS\nYou will need to delete the stack (mistack) before continuing\n").to_stderr
     end
   end


### PR DESCRIPTION
relates to issue https://github.com/envato/stack_master/issues/232

Adds a check on `REVIEW_IN_PROGRESS` status in the Cloudformation stack which can be left if that state by a user or someone else.