### PR TITLE
Install ldiff binary on windows, so diffy can make it purty

### DIFF
--- a/stack_master.gemspec
+++ b/stack_master.gemspec
@@ -55,4 +55,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "cfndsl"
   spec.add_dependency "multi_json"
   spec.add_dependency "dotgpg" unless windows_build
+  spec.add_dependency "diff-lcs" if windows_build
 end


### PR DESCRIPTION
By default Windows does not have a diff executable. diff-lcs provides one that diffy can use