### PR TITLE
Require console so we can `getch` in windows

### DIFF
--- a/lib/stack_master/prompter.rb
+++ b/lib/stack_master/prompter.rb
@@ -1,3 +1,5 @@
+require 'io/console'
+
 module StackMaster
   module Prompter
     def ask?(question)


### PR DESCRIPTION
On windows, `STDIN.getch` returns:

```
undefined method `getch' for #<IO:<STDIN>> (NoMethodError)
Did you mean?  getc
               gets
```

Unless we require `io/console`