### PR TITLE
Update Config.rb to raise error on badly formatted yaml

### DIFF
--- a/lib/stack_master/config.rb
+++ b/lib/stack_master/config.rb
@@ -3,11 +3,15 @@ require 'active_support/core_ext/object/deep_dup'
 
 module StackMaster
   class Config
+    ConfigParseError = Class.new(StandardError)
+
     def self.load!(config_file = 'stack_master.yml')
       resolved_config_file = search_up_and_chdir(config_file)
       config = YAML.load(File.read(resolved_config_file))
       base_dir = File.dirname(File.expand_path(resolved_config_file))
       new(config, base_dir)
+    rescue Psych::SyntaxError => error
+      raise ConfigParseError, "Unable to parse stack_master.yml: #{error}"
     end
 
     attr_accessor :stacks,

--- a/lib/stack_master/config.rb
+++ b/lib/stack_master/config.rb
@@ -11,7 +11,7 @@ module StackMaster
       base_dir = File.dirname(File.expand_path(resolved_config_file))
       new(config, base_dir)
     rescue Psych::SyntaxError => error
-      raise ConfigParseError, "Unable to parse stack_master.yml: #{error}"
+      raise ConfigParseError, "Unable to parse #{resolved_config_file}: #{error}"
     end
 
     attr_accessor :stacks,

--- a/spec/stack_master/config_spec.rb
+++ b/spec/stack_master/config_spec.rb
@@ -17,10 +17,22 @@ RSpec.describe StackMaster::Config do
       additional_parameter_lookup_dirs: ['production']
     )
   }
+  let(:bad_yaml) { "a: b\n- c" }
 
   describe ".load!" do
     it "fails to load the config if no stack_master.yml in parent directories" do
       expect { StackMaster::Config.load!('stack_master.yml') }.to raise_error Errno::ENOENT
+    end
+
+    it "raises exception on invalid yaml" do
+      begin
+        orig_dir = Dir.pwd
+        Dir.chdir './spec/fixtures/'
+        allow(File).to receive(:read).and_return(bad_yaml)
+        expect { StackMaster::Config.load!('stack_master.yml') }.to raise_error StackMaster::Config::ConfigParseError
+      ensure
+        Dir.chdir orig_dir
+      end
     end
 
     it "searches up the tree for stack master yaml" do


### PR DESCRIPTION
With badly formatted yaml I get this error message, which usually takes some time for me to remember what the problem is.

```
stack_master validate
error: (<unknown>): mapping values are not allowed in this context at line 19 column 19. Use --trace to view backtrace
```

Now, this helps me remember in a 🔦 :
```
stack_master validate
error: Unable to parse <path-to-stack_master.yml>: (<unknown>): mapping values are not allowed in this context at line 19 column 19. Use --trace to view backtrace
```