### PR TITLE
Add lint and compile commands

### DIFF
--- a/lib/stack_master.rb
+++ b/lib/stack_master.rb
@@ -54,6 +54,7 @@ module StackMaster
     autoload :Diff, 'stack_master/commands/diff'
     autoload :ListStacks, 'stack_master/commands/list_stacks'
     autoload :Validate, 'stack_master/commands/validate'
+    autoload :Lint, 'stack_master/commands/lint'
     autoload :Resources, 'stack_master/commands/resources'
     autoload :Delete, 'stack_master/commands/delete'
     autoload :Status, 'stack_master/commands/status'

--- a/lib/stack_master.rb
+++ b/lib/stack_master.rb
@@ -55,6 +55,7 @@ module StackMaster
     autoload :ListStacks, 'stack_master/commands/list_stacks'
     autoload :Validate, 'stack_master/commands/validate'
     autoload :Lint, 'stack_master/commands/lint'
+    autoload :Compile, 'stack_master/commands/compile'
     autoload :Resources, 'stack_master/commands/resources'
     autoload :Delete, 'stack_master/commands/delete'
     autoload :Status, 'stack_master/commands/status'

--- a/lib/stack_master/cli.rb
+++ b/lib/stack_master/cli.rb
@@ -142,6 +142,17 @@ module StackMaster
         end
       end
 
+      command :compile do |c|
+        c.syntax = 'stack_master compile [region_or_alias] [stack_name]'
+        c.summary = "Print the compiled version of a given stack"
+        c.description = "Processes the stack and prints out a compiled version - same we'd send to AWS"
+        c.example 'print compiled stack myapp-vpc with us-east-1 settings', 'stack_master compile us-east-1 myapp-vpc'
+        c.action do |args, options|
+          options.defaults config: default_config_file
+          execute_stacks_command(StackMaster::Commands::Compile, args, options)
+        end
+      end
+
       command :status do |c|
         c.syntax = 'stack_master status'
         c.summary = 'Check the current status stacks.'

--- a/lib/stack_master/cli.rb
+++ b/lib/stack_master/cli.rb
@@ -131,6 +131,17 @@ module StackMaster
         end
       end
 
+      command :lint do |c|
+        c.syntax = 'stack_master lint [region_or_alias] [stack_name]'
+        c.summary = "Check the stack definition locally"
+        c.description = "Runs cfn-lint on the template which would be sent to AWS on apply"
+        c.example 'run cfn-lint on stack myapp-vpc with us-east-1 settings', 'stack_master lint us-east-1 myapp-vpc'
+        c.action do |args, options|
+          options.defaults config: default_config_file
+          execute_stacks_command(StackMaster::Commands::Lint, args, options)
+        end
+      end
+
       command :status do |c|
         c.syntax = 'stack_master status'
         c.summary = 'Check the current status stacks.'

--- a/lib/stack_master/commands/compile.rb
+++ b/lib/stack_master/commands/compile.rb
@@ -1,0 +1,27 @@
+module StackMaster
+  module Commands
+    class Compile
+      include Command
+      include Commander::UI
+
+      def initialize(config, stack_definition, options = {})
+        @config = config
+        @stack_definition = stack_definition
+      end
+
+      def perform
+        puts(proposed_stack.template_body)
+      end
+
+      private
+
+      def stack_definition
+        @stack_definition ||= @config.find_stack(@region, @stack_name)
+      end
+
+      def proposed_stack
+        @proposed_stack ||= Stack.generate(stack_definition, @config)
+      end
+    end
+  end
+end

--- a/lib/stack_master/commands/lint.rb
+++ b/lib/stack_master/commands/lint.rb
@@ -19,6 +19,7 @@ module StackMaster
 
         Tempfile.open(['stack', ".#{proposed_stack.template_format}"]) do |f|
           f.write(proposed_stack.template_body)
+          f.flush
           system('cfn-lint', f.path).nil?
           puts "cfn-lint run complete"
         end

--- a/lib/stack_master/commands/lint.rb
+++ b/lib/stack_master/commands/lint.rb
@@ -1,0 +1,42 @@
+require 'tempfile'
+
+module StackMaster
+  module Commands
+    class Lint
+      include Command
+      include Commander::UI
+
+      def initialize(config, stack_definition, options = {})
+        @config = config
+        @stack_definition = stack_definition
+      end
+
+      def perform
+        unless cfn_lint_available
+          puts "Failed to run cfn-lint, do you have it installed and available in $PATH?"
+          return
+        end
+
+        Tempfile.open(['stack', '.json']) do |f|
+          f.write(proposed_stack.template_body)
+          system('cfn-lint', f.path).nil?
+          puts "cfn-lint run complete"
+        end
+      end
+
+      private
+
+      def stack_definition
+        @stack_definition ||= @config.find_stack(@region, @stack_name)
+      end
+
+      def proposed_stack
+        @proposed_stack ||= Stack.generate(stack_definition, @config)
+      end
+
+      def cfn_lint_available
+        !system('cfn-lint', '--version').nil?
+      end
+    end
+  end
+end

--- a/lib/stack_master/commands/lint.rb
+++ b/lib/stack_master/commands/lint.rb
@@ -20,7 +20,7 @@ module StackMaster
         Tempfile.open(['stack', ".#{proposed_stack.template_format}"]) do |f|
           f.write(proposed_stack.template_body)
           f.flush
-          system('cfn-lint', f.path).nil?
+          system('cfn-lint', f.path)
           puts "cfn-lint run complete"
         end
       end

--- a/lib/stack_master/commands/lint.rb
+++ b/lib/stack_master/commands/lint.rb
@@ -17,7 +17,7 @@ module StackMaster
           return
         end
 
-        Tempfile.open(['stack', '.json']) do |f|
+        Tempfile.open(['stack', ".#{proposed_stack.template_format}"]) do |f|
           f.write(proposed_stack.template_body)
           system('cfn-lint', f.path).nil?
           puts "cfn-lint run complete"

--- a/lib/stack_master/commands/lint.rb
+++ b/lib/stack_master/commands/lint.rb
@@ -13,8 +13,7 @@ module StackMaster
 
       def perform
         unless cfn_lint_available
-          puts "Failed to run cfn-lint, do you have it installed and available in $PATH?"
-          return
+          failed! "Failed to run cfn-lint, do you have it installed and available in $PATH?"
         end
 
         Tempfile.open(['stack', ".#{proposed_stack.template_format}"]) do |f|

--- a/spec/stack_master/commands/compile_spec.rb
+++ b/spec/stack_master/commands/compile_spec.rb
@@ -1,0 +1,39 @@
+RSpec.describe StackMaster::Commands::Compile do
+  let(:region) { 'us-east-1' }
+  let(:stack_name) { 'myapp-vpc' }
+  let(:stack_definition) { StackMaster::StackDefinition.new(base_dir: '/base_dir', region: region, stack_name: stack_name) }
+  let(:config) { double(find_stack: stack_definition) }
+  let(:parameters) { {} }
+  let(:proposed_stack) {
+    StackMaster::Stack.new(
+      template_body: template_body,
+      template_format: template_format,
+      parameters: parameters)
+  }
+
+  let(:template_body) { '{}' }
+  let(:template_format) { :json }
+
+  before do
+    allow(StackMaster::Stack).to receive(:generate).with(stack_definition, config).and_return(proposed_stack)
+  end
+
+  def run
+    described_class.perform(config, stack_definition)
+  end
+
+  context "with a json stack" do
+    it 'outputs the template' do
+      expect { run }.to output(template_body + "\n").to_stdout
+    end
+  end
+
+  context "with a yaml stack" do
+    let(:template_body) { '---' }
+    let(:template_format) { :yaml }
+
+    it 'outputs the template' do
+      expect { run }.to output(template_body + "\n").to_stdout
+    end
+  end
+end

--- a/spec/stack_master/commands/lint_spec.rb
+++ b/spec/stack_master/commands/lint_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe StackMaster::Commands::Lint do
 
     it 'outputs a warning' do
       expect_any_instance_of(described_class).to receive(:system).once.with('cfn-lint', '--version').and_return(nil)
-      expect { run }.to output(/Failed to run cfn-lint/).to_stdout
+      expect { run }.to output(/Failed to run cfn-lint/).to_stderr
     end
   end
 end

--- a/spec/stack_master/commands/lint_spec.rb
+++ b/spec/stack_master/commands/lint_spec.rb
@@ -1,0 +1,59 @@
+RSpec.describe StackMaster::Commands::Lint do
+  let(:region) { 'us-east-1' }
+  let(:stack_name) { 'myapp-vpc' }
+  let(:stack_definition) { StackMaster::StackDefinition.new(base_dir: '/base_dir', region: region, stack_name: stack_name) }
+  let(:config) { double(find_stack: stack_definition) }
+  let(:parameters) { {} }
+  let(:proposed_stack) {
+    StackMaster::Stack.new(
+      template_body: template_body,
+      template_format: template_format,
+      parameters: parameters)
+  }
+  let(:tempfile) { double(:tempfile) }
+  let(:path) { double(:path) }
+
+  before do
+    allow(StackMaster::Stack).to receive(:generate).with(stack_definition, config).and_return(proposed_stack)
+  end
+
+  def run 
+    described_class.perform(config, stack_definition)
+  end
+
+  context "when cfn-lint is installed" do
+    before do
+      expect_any_instance_of(described_class).to receive(:system).once.with('cfn-lint', '--version').and_return(0)
+    end
+
+    context "with a json stack" do
+      let(:template_body) { '{}' }
+      let(:template_format) { :json }
+
+      it 'outputs the template' do
+        expect_any_instance_of(described_class).to receive(:system).once.with('cfn-lint', /.*\.json/)
+        run
+      end
+    end
+
+    context "with a yaml stack" do
+      let(:template_body) { '---' }
+      let(:template_format) { :yaml }
+
+      it 'outputs the template' do
+        expect_any_instance_of(described_class).to receive(:system).once.with('cfn-lint', /.*\.yaml/)
+        run
+      end
+    end
+  end
+
+  context "when cfn-lint is missing" do
+    let(:template_body) { '' }
+    let(:template_format) { :json}
+
+    it 'outputs a warning' do
+      expect_any_instance_of(described_class).to receive(:system).once.with('cfn-lint', '--version').and_return(nil)
+      expect { run }.to output(/Failed to run cfn-lint/).to_stdout
+    end
+  end
+end


### PR DESCRIPTION
Make it easy to use cfn-lint on the templated stacks. The templated
stack is written to a temporary file which cfn-lint is run on. Since
the error messages contain the path to the json node, it's not that
important to preserve the rendered json with matching lines.

Unfortunately there's no special error code for success/failure. We can
just forward the original output.

Having cfn-lint is not a requirement for stack_master and the missing
binary is handled without exploding.

Also add a `compile` command which outputs the processed stack
template for use in other tools.