### PR TITLE
Include stacktemplates in gem package

### DIFF
--- a/stack_master.gemspec
+++ b/stack_master.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/envato/stack_master"
   spec.license       = "MIT"
 
-  spec.files         = Dir.glob("{bin,lib}/**/*") + %w(README.md)
+  spec.files         = Dir.glob("{bin,lib,stacktemplates}/**/*") + %w(README.md)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]


### PR DESCRIPTION
Fixes #246

Without this PR `stack_master init` fails with:

```
error: No such file or directory @ rb_sysopen - /Users/patrickrobinson/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/stack_master-1.8.0/stacktemplates/stack_master.yml.erb. Use --trace to view backtrace
```