### PR TITLE
Ensure Global Options take effect

### DIFF
--- a/stack_master.gemspec
+++ b/stack_master.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "timecop"
   spec.add_dependency "os"
   spec.add_dependency "ruby-progressbar"
-  spec.add_dependency "commander"
+  spec.add_dependency "commander", "<= 4.4.5"
   spec.add_dependency "aws-sdk-acm", "~> 1"
   spec.add_dependency "aws-sdk-cloudformation", "~> 1"
   spec.add_dependency "aws-sdk-ec2", "~> 1"


### PR DESCRIPTION
Downgrade Commander to fix apparent bug in the parsing of Global Options when arguments are passed in.

Fixes #248

Without this PR the following feature test fails:

```
    And the output should not contain all of these lines:                 # aruba-0.14.6/lib/aruba/cucumber/command.rb:356
      | Stack diff:                 |
      | -    "TestSg2": {           |
      | Parameters diff: No changes |
      expected [#<Aruba::Command(#<Aruba::Processes::InProcess:70193980971960 commandline="stack_master --changed apply us-east-1 myapp-vpc --trace": output="Executing apply on myapp-vpc in us-east-1
      Stack diff: No changes
      Parameters ...">)>] not to include an object have output: string includes: "Stack diff:" (RSpec::Expectations::ExpectationNotMetError)
      features/apply.feature:303:in `And the output should not contain all of these lines:'
    Then the exit status should be 0                                      # aruba-0.14.6/lib/aruba/cucumber/command.rb:277
```

When I invested this a while ago I came to the (incorrect) conclusion that the test was badly written and not indicative of actual behaviour. I think we need a better test to ensure global options are respected. I'm not entirely sure what this test is actually doing, since the README says changed should be used without a stack argument (i.e. `stack_master --changed apply`)

We also should raise this upstream to the Commander repository.