### PR TITLE
Create latest_container resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,8 +333,8 @@ Any value can be an array of possible matches.
 
 ### Latest Container from Repository
 
-Looks up the latest Container Image from an ECR repository. We use this instead of a "latest" tag, because if the tag is latest a CloudFormation update will not trigger a deployment of the container, since nothing has changed.
-As such this resolver will never return the latest tag for a container.
+Looks up the latest Container Image from an ECR repository. We use this instead of a "latest" tag, because if the tag is "latest" a CloudFormation update will not trigger a deployment of the container, since nothing has changed.
+As such this resolver will never return the tag "latest". If no other tag exists on the most recent container, it will return nil.
 
 ```yaml
 container_image_id:

--- a/README.md
+++ b/README.md
@@ -333,10 +333,12 @@ Any value can be an array of possible matches.
 
 ### Latest Container from Repository
 
-Looks up the latest Container Image from an ECR repository. We use this instead of a "latest" tag, because if the tag is "latest" a CloudFormation update will not trigger a deployment of the container, since nothing has changed.
-As such this resolver will never return the tag "latest". If no other tag exists on the most recent container, it will return nil.
+Looks up the a Container Image from an ECR repository. By default this will return the latest container in a repository.
+If `tag` is specified we return the sha digest of the image with this tag.
+This avoids the issue where CloudFormation won't update a Task Definition if we use a tag such as `latest`, because it only updates resources if a parameter has changed.
+This allows us to tag an image and deploy the latest version of that image via CloudFormation and avoids versioning our tags and having to store the metadata about the latest tag version somewhere.
 
-Returns the docker repository URI, i.e. `aws_account_id.dkr.ecr.region.amazonaws.com/container:tag`
+Returns the docker repository URI, i.e. `aws_account_id.dkr.ecr.region.amazonaws.com/container@sha256:digest`
 
 ```yaml
 container_image_id:
@@ -344,6 +346,7 @@ container_image_id:
     repository_name: nginx # Required. The name of the repository
     registry_id: 012345678910 # The AWS Account ID the repository is located in. Defaults to the current account's default registry
     region: us-east-1 # Defaults to the region the stack is located in
+    tag: production # By default we'll find the latest image pushed to the repository. If tag is specified we return the sha digest of the image with this tag
 ```
 
 ### Environment Variable

--- a/README.md
+++ b/README.md
@@ -331,6 +331,19 @@ A set of possible attributes is available in the [AWS documentation](https://doc
 
 Any value can be an array of possible matches.
 
+### Latest Container from Repository
+
+Looks up the latest Container Image from an ECR repository. We use this instead of a "latest" tag, because if the tag is latest a CloudFormation update will not trigger a deployment of the container, since nothing has changed.
+As such this resolver will never return the latest tag for a container.
+
+```yaml
+container_image_id:
+  latest_container:
+    repository_name: nginx # Required. The name of the repository
+    registry_id: 012345678910 # The AWS Account ID the repository is located in. Defaults to the current account's default registry
+    region: us-east-1 # Defaults to the region the stack is located in
+```
+
 ### Environment Variable
 
 Lookup an environment variable:

--- a/README.md
+++ b/README.md
@@ -336,6 +336,8 @@ Any value can be an array of possible matches.
 Looks up the latest Container Image from an ECR repository. We use this instead of a "latest" tag, because if the tag is "latest" a CloudFormation update will not trigger a deployment of the container, since nothing has changed.
 As such this resolver will never return the tag "latest". If no other tag exists on the most recent container, it will return nil.
 
+Returns the docker repository URI, i.e. `aws_account_id.dkr.ecr.region.amazonaws.com/container:tag`
+
 ```yaml
 container_image_id:
   latest_container:

--- a/lib/stack_master.rb
+++ b/lib/stack_master.rb
@@ -3,6 +3,7 @@ require 'yaml'
 require 'aws-sdk-acm'
 require 'aws-sdk-cloudformation'
 require 'aws-sdk-ec2'
+require 'aws-sdk-ecr'
 require 'aws-sdk-s3'
 require 'aws-sdk-sns'
 require 'aws-sdk-ssm'
@@ -74,6 +75,7 @@ module StackMaster
     autoload :Env, 'stack_master/parameter_resolvers/env'
     autoload :ParameterStore, 'stack_master/parameter_resolvers/parameter_store'
     autoload :OnePassword, 'stack_master/parameter_resolvers/one_password'
+    autoload :LatestContainer, 'stack_master/parameter_resolvers/latest_container'
   end
 
   module AwsDriver

--- a/lib/stack_master/parameter_resolvers/latest_container.rb
+++ b/lib/stack_master/parameter_resolvers/latest_container.rb
@@ -35,6 +35,9 @@ module StackMaster
             repository_name: repository_name,
             registry_id: registry_id,
             next_token: next_token,
+            filter: {
+              tag_status: "TAGGED",
+            },
           })
 
           images += resp.image_details

--- a/lib/stack_master/parameter_resolvers/latest_container.rb
+++ b/lib/stack_master/parameter_resolvers/latest_container.rb
@@ -9,20 +9,24 @@ module StackMaster
       end
 
       def resolve(parameters)
-        @region = parameters['region'] || @stack_definition.region
-        ecr_client = Aws::ECR::Client.new(region: @region)
         if parameters['repository_name'].nil?
           raise ArgumentError, "repository_name parameter is required but was not supplied"
         end
+
+        @region = parameters['region'] || @stack_definition.region
+        ecr_client = Aws::ECR::Client.new(region: @region)
+
         images = fetch_images(parameters['repository_name'], parameters['registry_id'], ecr_client)
         return nil if images.empty?
+
         if !parameters['tag'].nil?
           images.select! { |image| image.image_tags.any? { |tag| tag == parameters['tag'] } }
         end
         images.sort! { |image_x, image_y| image_y.image_pushed_at <=> image_x.image_pushed_at }
         latest_image = images.first
+
         # aws_account_id.dkr.ecr.region.amazonaws.com/repository@sha256:digest
-        return  "#{latest_image.registry_id}.dkr.ecr.#{@region}.amazonaws.com/#{parameters['repository_name']}@#{latest_image.image_digest}"
+        "#{latest_image.registry_id}.dkr.ecr.#{@region}.amazonaws.com/#{parameters['repository_name']}@#{latest_image.image_digest}"
       end
 
       private

--- a/lib/stack_master/parameter_resolvers/latest_container.rb
+++ b/lib/stack_master/parameter_resolvers/latest_container.rb
@@ -16,11 +16,13 @@ module StackMaster
         end
         images = fetch_images(parameters['repository_name'], parameters['registry_id'], ecr_client)
         return nil if images.empty?
+        if !parameters['tag'].nil?
+          images.select! { |image| image.image_tags.any? { |tag| tag == parameters['tag'] } }
+        end
         images.sort! { |image_x, image_y| image_y.image_pushed_at <=> image_x.image_pushed_at }
         latest_image = images.first
-        latest_tag = latest_image.image_tags.delete_if { |tag| tag == "latest" }.first
-        # aws_account_id.dkr.ecr.region.amazonaws.com
-        return  "#{latest_image.registry_id}.dkr.ecr.#{@region}.amazonaws.com/#{parameters['repository_name']}:#{latest_tag}"
+        # aws_account_id.dkr.ecr.region.amazonaws.com/repository@sha256:digest
+        return  "#{latest_image.registry_id}.dkr.ecr.#{@region}.amazonaws.com/#{parameters['repository_name']}@sha256:#{latest_image.image_digest}"
       end
 
       private

--- a/lib/stack_master/parameter_resolvers/latest_container.rb
+++ b/lib/stack_master/parameter_resolvers/latest_container.rb
@@ -1,0 +1,49 @@
+module StackMaster
+  module ParameterResolvers
+    class LatestContainer < Resolver
+      array_resolver class_name: 'LatestContainers'
+
+      def initialize(config, stack_definition)
+        @config = config
+        @stack_definition = stack_definition
+      end
+
+      def resolve(parameters)
+        @region = parameters['region'] || @stack_definition.region
+        ecr_client = Aws::ECR::Client.new(region: @region)
+        if parameters['repository_name'].nil?
+          raise ArgumentError, "repository_name parameter is required but was not supplied"
+        end
+        images = fetch_images(parameters['repository_name'], parameters['registry_id'], ecr_client)
+        return nil if images.empty?
+        images.sort! { |image_x, image_y| image_y.image_pushed_at <=> image_x.image_pushed_at }
+        latest_image = images.first
+        latest_tag = latest_image.image_tags.delete_if { |tag| tag == "latest" }.first
+        # aws_account_id.dkr.ecr.region.amazonaws.com
+        return  "#{latest_image.registry_id}.dkr.ecr.#{@region}.amazonaws.com/#{parameters['repository_name']}:#{latest_tag}"
+      end
+
+      private
+
+      def fetch_images(repository_name, registry_id, ecr)
+        images = []
+        next_token = nil
+        while
+          resp = ecr.describe_images({
+            repository_name: repository_name,
+            registry_id: registry_id,
+            next_token: next_token,
+          })
+
+          images.push(resp.image_details)
+          next_token = resp.next_token
+
+          if resp.next_token.nil?
+            break
+          end
+        end
+        images.flatten
+      end
+    end
+  end
+end

--- a/lib/stack_master/parameter_resolvers/latest_container.rb
+++ b/lib/stack_master/parameter_resolvers/latest_container.rb
@@ -22,7 +22,7 @@ module StackMaster
         images.sort! { |image_x, image_y| image_y.image_pushed_at <=> image_x.image_pushed_at }
         latest_image = images.first
         # aws_account_id.dkr.ecr.region.amazonaws.com/repository@sha256:digest
-        return  "#{latest_image.registry_id}.dkr.ecr.#{@region}.amazonaws.com/#{parameters['repository_name']}@sha256:#{latest_image.image_digest}"
+        return  "#{latest_image.registry_id}.dkr.ecr.#{@region}.amazonaws.com/#{parameters['repository_name']}@#{latest_image.image_digest}"
       end
 
       private

--- a/lib/stack_master/parameter_resolvers/latest_container.rb
+++ b/lib/stack_master/parameter_resolvers/latest_container.rb
@@ -35,14 +35,11 @@ module StackMaster
             next_token: next_token,
           })
 
-          images.push(resp.image_details)
+          images += resp.image_details
           next_token = resp.next_token
-
-          if resp.next_token.nil?
-            break
-          end
+          break if next_token.nil?
         end
-        images.flatten
+        images
       end
     end
   end

--- a/spec/stack_master/parameter_resolvers/latest_container_spec.rb
+++ b/spec/stack_master/parameter_resolvers/latest_container_spec.rb
@@ -1,0 +1,59 @@
+RSpec.describe StackMaster::ParameterResolvers::LatestContainer do
+  let(:config) { double(base_dir: '/base') }
+  let(:stack_definition) { double(stack_name: 'mystack', region: 'us-east-1') }
+  subject(:resolver) { described_class.new(config, stack_definition) }
+  let(:ecr) { Aws::ECR::Client.new(stub_responses: true) }
+
+  before do
+    allow(Aws::ECR::Client).to receive(:new).and_return(ecr)
+  end
+
+  context 'when matches are found' do
+    before do
+      ecr.stub_responses(:describe_images, image_details: [
+        { registry_id: '012345678910', image_digest: 'decafc0ffee', image_pushed_at: Time.utc(2015,1,2,0,0), image_tags: ['v1'] },
+        { registry_id: '012345678910', image_digest: 'deadbeef', image_pushed_at: Time.utc(2015,1,3,0,0), image_tags: ['v2'] }
+      ])
+    end
+
+    it 'returns the latest one' do
+      expect(resolver.resolve({'repository_name' => 'foo'})).to eq '012345678910.dkr.ecr.us-east-1.amazonaws.com/foo:v2'
+    end
+  end
+
+  context 'when there are multiple tags including latest' do
+    before do
+      ecr.stub_responses(:describe_images, image_details: [
+        { registry_id: '012345678910', image_digest: 'decafc0ffee', image_pushed_at: Time.utc(2015,1,2,0,0), image_tags: ['v1'] },
+        { registry_id: '012345678910', image_digest: 'deadbeef', image_pushed_at: Time.utc(2015,1,3,0,0), image_tags: ['latest', 'v2'] }
+      ])
+    end
+
+    it 'does not return the latest tag' do
+      expect(resolver.resolve({'repository_name' => 'foo'})).to eq '012345678910.dkr.ecr.us-east-1.amazonaws.com/foo:v2'
+    end
+  end
+
+  context 'when no matches are found' do
+    before do
+      ecr.stub_responses(:describe_images, image_details: [])
+    end
+
+    it 'returns nil' do
+      expect(resolver.resolve({'repository_name' => 'foo'})).to be_nil
+    end
+  end
+
+  context 'when registry_id is passed in' do
+    before do
+      ecr.stub_responses(:describe_images, image_details: [
+        { registry_id: '012345678910', image_digest: 'decafc0ffee', image_pushed_at: Time.utc(2015,1,2,0,0), image_tags: ['v1'] },
+      ])
+    end
+
+    it 'passes registry_id to describe_images' do
+      expect(ecr).to receive(:describe_images).with(repository_name: "foo", registry_id: "012345678910", next_token: nil)
+      resolver.resolve({'repository_name' => 'foo', 'registry_id' => "012345678910"})
+    end
+  end
+end

--- a/spec/stack_master/parameter_resolvers/latest_container_spec.rb
+++ b/spec/stack_master/parameter_resolvers/latest_container_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe StackMaster::ParameterResolvers::LatestContainer do
     end
 
     it 'passes registry_id to describe_images' do
-      expect(ecr).to receive(:describe_images).with(repository_name: "foo", registry_id: "012345678910", next_token: nil)
+      expect(ecr).to receive(:describe_images).with(repository_name: "foo", registry_id: "012345678910", next_token: nil, filter: {:tag_status=>"TAGGED"})
       resolver.resolve({'repository_name' => 'foo', 'registry_id' => '012345678910'})
     end
   end

--- a/spec/stack_master/parameter_resolvers/latest_container_spec.rb
+++ b/spec/stack_master/parameter_resolvers/latest_container_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe StackMaster::ParameterResolvers::LatestContainer do
   context 'when matches are found' do
     before do
       ecr.stub_responses(:describe_images, next_token: nil, image_details: [
-        { registry_id: '012345678910', image_digest: 'decafc0ffee', image_pushed_at: Time.utc(2015,1,2,0,0), image_tags: ['v1'] },
-        { registry_id: '012345678910', image_digest: 'deadbeef', image_pushed_at: Time.utc(2015,1,3,0,0), image_tags: ['v2'] }
+        { registry_id: '012345678910', image_digest: 'sha256:decafc0ffee', image_pushed_at: Time.utc(2015,1,2,0,0), image_tags: ['v1'] },
+        { registry_id: '012345678910', image_digest: 'sha256:deadbeef', image_pushed_at: Time.utc(2015,1,3,0,0), image_tags: ['v2'] }
       ])
     end
 
@@ -34,8 +34,8 @@ RSpec.describe StackMaster::ParameterResolvers::LatestContainer do
   context 'when a tag is passed in' do
     before do
       ecr.stub_responses(:describe_images, next_token: nil, image_details: [
-        { registry_id: '012345678910', image_digest: 'decafc0ffee', image_pushed_at: Time.utc(2015,1,2,0,0), image_tags: ['v1', 'production'] },
-        { registry_id: '012345678910', image_digest: 'deadbeef', image_pushed_at: Time.utc(2015,1,3,0,0), image_tags: ['v2'] }
+        { registry_id: '012345678910', image_digest: 'sha256:decafc0ffee', image_pushed_at: Time.utc(2015,1,2,0,0), image_tags: ['v1', 'production'] },
+        { registry_id: '012345678910', image_digest: 'sha256:deadbeef', image_pushed_at: Time.utc(2015,1,3,0,0), image_tags: ['v2'] }
       ])
     end
 
@@ -47,7 +47,7 @@ RSpec.describe StackMaster::ParameterResolvers::LatestContainer do
   context 'when registry_id is passed in' do
     before do
       ecr.stub_responses(:describe_images, next_token: nil, image_details: [
-        { registry_id: '012345678910', image_digest: 'decafc0ffee', image_pushed_at: Time.utc(2015,1,2,0,0), image_tags: ['v1'] },
+        { registry_id: '012345678910', image_digest: 'sha256:decafc0ffee', image_pushed_at: Time.utc(2015,1,2,0,0), image_tags: ['v1'] },
       ])
     end
 
@@ -61,12 +61,12 @@ RSpec.describe StackMaster::ParameterResolvers::LatestContainer do
     before do
       ecr.stub_responses(:describe_images, [
         { next_token: '1', image_details: [
-          { registry_id: '012345678910', image_digest: 'decafc0ffee', image_pushed_at: Time.utc(2015,1,2,0,0), image_tags: ['v1'] },
-          { registry_id: '012345678910', image_digest: 'deadbeef', image_pushed_at: Time.utc(2015,1,3,0,0), image_tags: ['latest', 'v2'] }
+          { registry_id: '012345678910', image_digest: 'sha256:decafc0ffee', image_pushed_at: Time.utc(2015,1,2,0,0), image_tags: ['v1'] },
+          { registry_id: '012345678910', image_digest: 'sha256:deadbeef', image_pushed_at: Time.utc(2015,1,3,0,0), image_tags: ['latest', 'v2'] }
         ]},
         { next_token: nil, image_details: [
-          { registry_id: '012345678910', image_digest: 'badf00d', image_pushed_at: Time.utc(2015,1,4,0,0), image_tags: ['v3'] },
-          { registry_id: '012345678910', image_digest: 'd15ea5e', image_pushed_at: Time.utc(2015,1,5,0,0), image_tags: ['v4'] }
+          { registry_id: '012345678910', image_digest: 'sha256:badf00d', image_pushed_at: Time.utc(2015,1,4,0,0), image_tags: ['v3'] },
+          { registry_id: '012345678910', image_digest: 'sha256:d15ea5e', image_pushed_at: Time.utc(2015,1,5,0,0), image_tags: ['v4'] }
         ]}
       ])
     end

--- a/spec/stack_master/parameter_resolvers/latest_container_spec.rb
+++ b/spec/stack_master/parameter_resolvers/latest_container_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe StackMaster::ParameterResolvers::LatestContainer do
 
   context 'when matches are found' do
     before do
-      ecr.stub_responses(:describe_images, image_details: [
+      ecr.stub_responses(:describe_images, next_token: nil, image_details: [
         { registry_id: '012345678910', image_digest: 'decafc0ffee', image_pushed_at: Time.utc(2015,1,2,0,0), image_tags: ['v1'] },
         { registry_id: '012345678910', image_digest: 'deadbeef', image_pushed_at: Time.utc(2015,1,3,0,0), image_tags: ['v2'] }
       ])
@@ -23,7 +23,7 @@ RSpec.describe StackMaster::ParameterResolvers::LatestContainer do
 
   context 'when there are multiple tags including latest' do
     before do
-      ecr.stub_responses(:describe_images, image_details: [
+      ecr.stub_responses(:describe_images, next_token: nil, image_details: [
         { registry_id: '012345678910', image_digest: 'decafc0ffee', image_pushed_at: Time.utc(2015,1,2,0,0), image_tags: ['v1'] },
         { registry_id: '012345678910', image_digest: 'deadbeef', image_pushed_at: Time.utc(2015,1,3,0,0), image_tags: ['latest', 'v2'] }
       ])
@@ -36,7 +36,7 @@ RSpec.describe StackMaster::ParameterResolvers::LatestContainer do
 
   context 'when no matches are found' do
     before do
-      ecr.stub_responses(:describe_images, image_details: [])
+      ecr.stub_responses(:describe_images, next_token: nil, image_details: [])
     end
 
     it 'returns nil' do
@@ -46,14 +46,33 @@ RSpec.describe StackMaster::ParameterResolvers::LatestContainer do
 
   context 'when registry_id is passed in' do
     before do
-      ecr.stub_responses(:describe_images, image_details: [
+      ecr.stub_responses(:describe_images, next_token: nil, image_details: [
         { registry_id: '012345678910', image_digest: 'decafc0ffee', image_pushed_at: Time.utc(2015,1,2,0,0), image_tags: ['v1'] },
       ])
     end
 
     it 'passes registry_id to describe_images' do
       expect(ecr).to receive(:describe_images).with(repository_name: "foo", registry_id: "012345678910", next_token: nil)
-      resolver.resolve({'repository_name' => 'foo', 'registry_id' => "012345678910"})
+      resolver.resolve({'repository_name' => 'foo', 'registry_id' => '012345678910'})
+    end
+  end
+
+  context 'when there are multiple pages' do
+    before do
+      ecr.stub_responses(:describe_images, [
+        { next_token: '1', image_details: [
+          { registry_id: '012345678910', image_digest: 'decafc0ffee', image_pushed_at: Time.utc(2015,1,2,0,0), image_tags: ['v1'] },
+          { registry_id: '012345678910', image_digest: 'deadbeef', image_pushed_at: Time.utc(2015,1,3,0,0), image_tags: ['latest', 'v2'] }
+        ]},
+        { next_token: nil, image_details: [
+          { registry_id: '012345678910', image_digest: 'decafc0ffee', image_pushed_at: Time.utc(2015,1,4,0,0), image_tags: ['v3'] },
+          { registry_id: '012345678910', image_digest: 'deadbeef', image_pushed_at: Time.utc(2015,1,5,0,0), image_tags: ['v4'] }
+        ]}
+      ])
+    end
+
+    it 'takes all pages into account' do
+      expect(resolver.resolve({'repository_name' => 'foo'})).to eq '012345678910.dkr.ecr.us-east-1.amazonaws.com/foo:v4'
     end
   end
 end

--- a/stack_master.gemspec
+++ b/stack_master.gemspec
@@ -46,6 +46,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "aws-sdk-s3", "~> 1"
   spec.add_dependency "aws-sdk-sns", "~> 1"
   spec.add_dependency "aws-sdk-ssm", "~> 1"
+  spec.add_dependency "aws-sdk-ecr", "~> 1"
   spec.add_dependency "diffy"
   spec.add_dependency "erubis"
   spec.add_dependency "colorize"


### PR DESCRIPTION
While we generally don't recommend deploying containers with CloudFormation, see #237, it can sometimes be useful.

This PR creates a parameter resolver that finds the latest image in an ECR repository and returns the full image path to that image.