### PR TITLE
Print backtrace when compilation fails

### DIFF
--- a/lib/stack_master/template_compiler.rb
+++ b/lib/stack_master/template_compiler.rb
@@ -6,8 +6,8 @@ module StackMaster
       compiler = template_compiler_for_file(template_file_path, config)
       compiler.require_dependencies
       compiler.compile(template_file_path, compile_time_parameters, compiler_options)
-    rescue
-      raise TemplateCompilationFailed.new("Failed to compile #{template_file_path}.")
+    rescue StandardError => e
+      raise TemplateCompilationFailed.new("Failed to compile #{template_file_path} with error #{e}.\n#{e.backtrace}")
     end
 
     def self.register(name, klass)

--- a/spec/stack_master/template_compiler_spec.rb
+++ b/spec/stack_master/template_compiler_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe StackMaster::TemplateCompiler do
         it 'raise TemplateCompilationFailed exception' do
           expect{ StackMaster::TemplateCompiler.compile(config, template_file_path, compile_time_parameters, compile_time_parameters)
           }.to raise_error(
-                 StackMaster::TemplateCompiler::TemplateCompilationFailed,"Failed to compile #{template_file_path}.")
+                 StackMaster::TemplateCompiler::TemplateCompilationFailed, /^Failed to compile #{template_file_path}/)
         end
       end
     end


### PR DESCRIPTION
When a template fails to compile it's common to get an error like:

```
Executing apply on samson-db in us-east-1
StackMaster::TemplateCompiler::TemplateCompilationFailed Failed to compile /Users/matt/Documents/GitHub/our-samson/aws/templates/samson_db.rb.
 Caused by: NameError uninitialized constant #<Class:0x007f850a560748>::Sparkleformation 
```

Which is quite unhelpful to understand where the error occurs. This PR makes two changes to combat this:

- When we do catch an exception, print the error and backtrace.