### PR TITLE
Add `--yes-param` option for single-param update auto-confim on `apply`

### DIFF
--- a/lib/stack_master/cli.rb
+++ b/lib/stack_master/cli.rb
@@ -42,6 +42,7 @@ module StackMaster
         c.description = "Creates or updates a stack. Shows a diff of the proposed stack's template and parameters. Tails stack events until CloudFormation has completed."
         c.example 'update a stack named myapp-vpc in us-east-1', 'stack_master apply us-east-1 myapp-vpc'
         c.option '--on-failure ACTION', String, "Action to take on CREATE_FAILURE. Valid Values: [ DO_NOTHING | ROLLBACK | DELETE ]. Default: ROLLBACK\nNote: You cannot use this option with Serverless Application Model (SAM) templates."
+        c.option '--yes-param PARAM_NAME', String, "Auto-approve stack updates when only parameter PARAM_NAME changes"
         c.action do |args, options|
           options.defaults config: default_config_file
           execute_stacks_command(StackMaster::Commands::Apply, args, options)

--- a/lib/stack_master/stack_differ.rb
+++ b/lib/stack_master/stack_differ.rb
@@ -1,4 +1,5 @@
 require "diffy"
+require "hashdiff"
 
 module StackMaster
   class StackDiffer
@@ -70,6 +71,14 @@ module StackMaster
       else
         []
       end
+    end
+
+    def single_param_update?(param_name)
+      return false if param_name.blank? || @current_stack.blank? || body_different?
+      differences = HashDiff.diff(@current_stack.parameters_with_defaults, @proposed_stack.parameters_with_defaults)
+      return false if differences.count != 1
+      diff = differences[0]
+      diff[0] == "~" && diff[1] == param_name
     end
 
     private

--- a/spec/stack_master/stack_differ_spec.rb
+++ b/spec/stack_master/stack_differ_spec.rb
@@ -1,17 +1,19 @@
 RSpec.describe StackMaster::StackDiffer do
   subject(:differ) { described_class.new(proposed_stack, stack) }
+  let(:current_body) { '{}' }
+  let(:proposed_body) { "{\"a\": 1}" }
   let(:current_params) { Hash.new }
   let(:proposed_params) { { 'param1' => 'hello'} }
   let(:stack) { StackMaster::Stack.new(stack_name: stack_name,
                                        region: region,
                                        stack_id: 123,
-                                       template_body: '{}',
+                                       template_body: current_body,
                                        template_format: :json,
                                        parameters: current_params) }
   let(:proposed_stack) { StackMaster::Stack.new(stack_name: stack_name,
                                                 region: region,
                                                 parameters: proposed_params,
-                                                template_body: "{\"a\": 1}",
+                                                template_body: proposed_body,
                                                 template_format: :json) }
   let(:stack_name) { 'myapp-vpc' }
   let(:region) { 'us-east-1' }
@@ -41,6 +43,52 @@ RSpec.describe StackMaster::StackDiffer do
         expect { differ.output_diff }.to output(/param1\: hello/).to_stdout
         expect { differ.output_diff }.to_not output(/No stack found/).to_stdout
       end
+    end
+  end
+
+  describe "#single_param_update?" do
+    let(:yes_param) { 'YesParam' }
+    let(:old_value) { 'old' }
+    let(:new_value) { 'new' }
+    let(:current_params) { { yes_param => old_value } }
+    let(:proposed_params) { { yes_param => new_value } }
+    let(:current_body) { proposed_body }
+
+    subject(:result) { differ.single_param_update?(yes_param) }
+
+    context "when only param changes" do
+      it { is_expected.to be_truthy }
+    end
+
+    context "when new stack" do
+      let(:stack) { nil }
+      it { is_expected.to be_falsey }
+    end
+
+    context "when no changes" do
+      let(:current_params) { proposed_params }
+      it { is_expected.to be_falsey }
+    end
+
+    context "when body changes" do
+      let(:current_body) { '{}' }
+      it { is_expected.to be_falsey }
+    end
+
+    context "on param removal" do
+      let(:proposed_params) { {} }
+      it { is_expected.to be_falsey }
+    end
+
+    context "on param first addition" do
+      let(:current_params) { {} }
+      it { is_expected.to be_falsey }
+    end
+
+    context "when another param also changes" do
+      let(:current_params) { { yes_param => old_value, 'other' => 'old' } }
+      let(:proposed_params) { { yes_param => new_value, 'other' => 'new' } }
+      it { is_expected.to be_falsey }
     end
   end
 end

--- a/stack_master.gemspec
+++ b/stack_master.gemspec
@@ -56,6 +56,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "deep_merge"
   spec.add_dependency "cfndsl"
   spec.add_dependency "multi_json"
+  spec.add_dependency "hashdiff"
   spec.add_dependency "dotgpg" unless windows_build
   spec.add_dependency "diff-lcs" if windows_build
 end


### PR DESCRIPTION
My team's most common use-case for Stack Master is updating the AMI ID when a new AMI shared by a few different stacks is released.

The process can be pretty tedious, as it requires manual approval for each stack, and at each step the most common happy path scenario is the human just checks that only the AMI param is getting updated and presses `y`

This change adds a `--yes-param PARAM_NAME` option to the `apply` command that skips the confirmation step whenever the only change on a stack an update to a single param `PARAM_NAME` (in the case I have in mind, that param would be `Ami`, but it could be called anything).

Unlike `--yes`, it retains a safeguard against unexpected changes sneaking in, but it's a big time and distraction gain when just rolling AMIs on up-to-date stacks.