### PR TITLE
Bugfix: display changeset before asking for confirmation

### DIFF
--- a/lib/stack_master/commands/apply.rb
+++ b/lib/stack_master/commands/apply.rb
@@ -130,12 +130,12 @@ module StackMaster
           halt!(@change_set.status_reason)
         end
 
+        @change_set.display(StackMaster.stdout)
         if differ.single_param_update?(@options.yes_param)
           StackMaster.stdout.puts("Auto-approving update to single parameter #{@options.yes_param}")
         else
           ask_update_confirmation!
         end
-        @change_set.display(StackMaster.stdout)
         execute_change_set
       end
 


### PR DESCRIPTION
A stack update should display the changeset first before asking for confirmation. This bug was introduced in https://github.com/envato/stack_master/pull/252/files#diff-cf22d74c8f612a3282d758a02c9d21e7R138 and results in the changeset being displayed after a confirmation has been entered.