### PR TITLE
Deprecate dotpg

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,13 +56,11 @@ stack_defaults:
   role_arn: service_role_arn
 region_defaults:
   us-east-1:
-    secret_file: production.yml.gpg
     tags:
       environment: production
     notification_arns:
       - test_arn
   ap-southeast-2:
-    secret_file: staging.yml.gpg
     tags:
       environment: staging
 stacks:
@@ -211,7 +209,9 @@ into parameters of dependent stacks.
 
 ### Secret
 
-Note: This resolver is not supported on Windows, you can instead use the [Parameter Store](#parameter-store).
+**DEPRECATED**: This parameters resolver is deprecated and will be removed in version 2.0. Refer to [Parameter Store](#parameter-store) and [1Password](#1password-lookup) for alternatives for handling secrets.
+
+Note: This resolver is not supported on Windows.
 
 The secret parameters resolver expects a `secret_file` to be defined in the
 stack definition which is a GPG encrypted YAML file. Once decrypted and parsed,
@@ -256,7 +256,9 @@ you will likely want to set the parameter to NoEcho in your template.
 db_password:
   parameter_store: ssm_parameter_name
 ```
+
 ### 1Password Lookup
+
 An Alternative to the alternative secret store is accessing 1password secrets using the 1password cli (`op`).
 You declare a 1password lookup with the following parameters in your parameters file:
 

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ into parameters of dependent stacks.
 
 ### Secret
 
-**DEPRECATED**: This parameters resolver is deprecated and will be removed in version 2.0. Refer to [Parameter Store](#parameter-store) and [1Password](#1password-lookup) for alternatives for handling secrets.
+**DEPRECATED**: This parameters resolver is deprecated and will be removed in version 2.0. You may install the [seperate gem](https://github.com/envato/stack_master-gpg_parameter_resolver) or use [Parameter Store](#parameter-store) or [1Password](#1password-lookup).
 
 Note: This resolver is not supported on Windows.
 

--- a/features/apply_with_secret_parameters.feature
+++ b/features/apply_with_secret_parameters.feature
@@ -1,0 +1,51 @@
+Feature: Apply command with parameter_store parameter
+
+  Background:
+    Given a file named "stack_master.yml" with:
+      """
+      stacks:
+        us-east-2:
+          vpc:
+            template: vpc.rb
+            secret_file: production.yml.gpg
+      """
+    And a directory named "parameters"
+    And a file named "parameters/vpc.yml" with:
+      """
+      vpc_cidr:
+        secrets: "cucumber-test-vpc-cidr"
+      """
+    And a directory named "secrets"
+    And a file named "secrets/production.yml.gpg" with ""
+    And a directory named "templates"
+    And a file named "templates/vpc.rb" with:
+      """
+      SparkleFormation.new(:vpc) do
+
+        parameters.vpc_cidr do
+          type 'String'
+        end
+
+        resources.vpc do
+          type 'AWS::EC2::VPC'
+          properties do
+            cidr_block ref!(:vpc_cidr)
+          end
+        end
+
+      end
+      """
+
+  Scenario: Run apply and create a new stack
+    Given I stub the following stack events:
+      | stack_id | event_id | stack_name | logical_resource_id | resource_status | resource_type              | timestamp           |
+      | 1        | 1        | vpc        | Vpc                 | CREATE_COMPLETE | AWS::EC2::VPC              | 2020-10-29 00:00:00 |
+      | 1        | 1        | vpc        | vpc                 | CREATE_COMPLETE | AWS::CloudFormation::Stack | 2020-10-29 00:00:00 |
+    And I stub DotGPG calls to return a secret for "cucumber-test-vpc-cidr"
+    When I run `stack_master apply -y us-east-2 vpc`
+    Then the stderr should contain:
+    """
+    [DEPRECATION WARNING] The GPG Parameter Resolver is being deprecated in favour of the Parameter Store and 1Password resolvers.
+    Support for GPG encrypted secrets will be removed in StackMaster 2.0
+    """
+    And the exit status should be 0

--- a/features/step_definitions/stack_steps.rb
+++ b/features/step_definitions/stack_steps.rb
@@ -1,3 +1,5 @@
+require 'dotgpg'
+
 Before do
   StackMaster.non_interactive_answer = 'y'
 end
@@ -63,6 +65,14 @@ end
 
 Given(/^I stub CloudFormation validate calls to fail validation with message "([^"]*)"$/) do |message|
   allow(StackMaster.cloud_formation_driver).to receive(:validate_template).and_raise(Aws::CloudFormation::Errors::ValidationError.new('', message))
+end
+
+Given(/^I stub DotGPG calls to return a secret for "([^"]*)"$/) do |secret_key|
+  dotgpg_double = double()
+  allow(Dotgpg::Dir).to receive(:closest).and_return(dotgpg_double)
+  expect(dotgpg_double).to receive(:decrypt) do |_, string_io|
+    string_io.write("#{secret_key}: too many secrets")
+  end
 end
 
 When(/^an S3 file in bucket "([^"]*)" with key "([^"]*)" exists with content:$/) do |bucket, key, body|

--- a/lib/stack_master/parameter_resolvers/secret.rb
+++ b/lib/stack_master/parameter_resolvers/secret.rb
@@ -21,7 +21,7 @@ module StackMaster
         secret_key = value
         raise ArgumentError, "No secret_file defined for stack definition #{@stack_definition.stack_name} in #{@stack_definition.region}" unless !@stack_definition.secret_file.nil?
         raise ArgumentError, "Could not find secret file at #{secret_file_path}" unless File.exist?(secret_file_path)
-        StackMaster.stderr.puts """[DEPRECATION WARNING] The GPG Parameter Resolver is being deprecated in favour of the Parameter Store and 1Password resolvers.
+        StackMaster.stderr.puts """[DEPRECATION WARNING] The GPG Parameter Resolver is being deprecated and migrated to https://github.com/envato/stack_master-gpg_parameter_resolver.
 Support for GPG encrypted secrets will be removed in StackMaster 2.0"""
         secrets_hash.fetch(secret_key) do
           raise SecretNotFound, "Unable to find key #{secret_key} in file #{secret_file_path}"

--- a/lib/stack_master/parameter_resolvers/secret.rb
+++ b/lib/stack_master/parameter_resolvers/secret.rb
@@ -21,6 +21,8 @@ module StackMaster
         secret_key = value
         raise ArgumentError, "No secret_file defined for stack definition #{@stack_definition.stack_name} in #{@stack_definition.region}" unless !@stack_definition.secret_file.nil?
         raise ArgumentError, "Could not find secret file at #{secret_file_path}" unless File.exist?(secret_file_path)
+        StackMaster.stderr.puts """[DEPRECATION WARNING] The GPG Parameter Resolver is being deprecated in favour of the Parameter Store and 1Password resolvers.
+Support for GPG encrypted secrets will be removed in StackMaster 2.0"""
         secrets_hash.fetch(secret_key) do
           raise SecretNotFound, "Unable to find key #{secret_key} in file #{secret_file_path}"
         end


### PR DESCRIPTION
This is both a proposal and pull request. I propose that for version 2 of StackMaster we should remove dotgpg support. Dotgpg is difficult to use for a couple of reasons, firstly anytime someone joins or leaves our team we have to re-encrypt our secrets. Secondly there's a [long running issue](https://github.com/ConradIrwin/dotgpg/issues/20) where dotgpg will fail if there's an expired key.

Also removing Dotgpg will simplify our release process, which at the moment requires that we build two seperate versions one of which has to be built on a Windows machine.

This PR prints a deprecation warning when the secrets parameter resolver is used and updates the documentation.