### PR TITLE
Remove region from stack_master.yml

### DIFF
--- a/features/apply.feature
+++ b/features/apply.feature
@@ -4,11 +4,10 @@ Feature: Apply command
     Given a file named "stack_master.yml" with:
       """
       stacks:
-        us_east_1:
-          myapp_vpc:
-            template: myapp_vpc.rb
-          myapp_web:
-            template: myapp_web.rb
+        myapp_vpc:
+          template: myapp_vpc.rb
+        myapp_web:
+          template: myapp_web.rb
       """
     And a directory named "parameters"
     And a file named "parameters/myapp_vpc.yml" with:
@@ -332,12 +331,11 @@ Feature: Apply command
     Given a file named "stack_master.yml" with:
       """
       stacks:
-        us_east_1:
-          myapp_vpc:
-            template: myapp_vpc.rb
-            notification_arns:
-              - test_arn
-            stack_policy_file: no_rds_replacement.json
+        myapp_vpc:
+          template: myapp_vpc.rb
+          notification_arns:
+            - test_arn
+          stack_policy_file: no_rds_replacement.json
       """
     And a file named "policies/no_rds_replacement.json" with:
       """

--- a/features/apply_with_compile_time_parameters.feature
+++ b/features/apply_with_compile_time_parameters.feature
@@ -4,9 +4,8 @@ Feature: Apply command with compile time parameters
     Given a file named "stack_master.yml" with:
     """
           stacks:
-            us-east-1:
-              vpc:
-                template: vpc.rb
+            vpc:
+              template: vpc.rb
           """
     And a directory named "parameters"
     And a file named "parameters/vpc.yml" with:

--- a/features/apply_with_env_parameters.feature
+++ b/features/apply_with_env_parameters.feature
@@ -4,9 +4,8 @@ Feature: Apply command with environment parameter
     Given a file named "stack_master.yml" with:
       """
       stacks:
-        us-east-2:
-          vpc:
-            template: vpc.rb
+        vpc:
+          template: vpc.rb
       """
     And a directory named "parameters"
     And a file named "parameters/vpc.yml" with:

--- a/features/apply_with_parameter_store_parameters.feature
+++ b/features/apply_with_parameter_store_parameters.feature
@@ -4,9 +4,8 @@ Feature: Apply command with parameter_store parameter
     Given a file named "stack_master.yml" with:
       """
       stacks:
-        us-east-2:
-          vpc:
-            template: vpc.rb
+        vpc:
+          template: vpc.rb
       """
     And a directory named "parameters"
     And a file named "parameters/vpc.yml" with:

--- a/features/apply_with_s3.feature
+++ b/features/apply_with_s3.feature
@@ -9,11 +9,10 @@ Feature: Apply command
           region: us-east-1
           prefix: cfn_templates/my-app
       stacks:
-        us_east_1:
-          myapp_vpc:
-            template: myapp_vpc.rb
-            files:
-              - user_data.sh
+        myapp_vpc:
+          template: myapp_vpc.rb
+          files:
+            - user_data.sh
       """
     And a directory named "parameters"
     And a file named "parameters/myapp_vpc.yml" with:

--- a/features/diff.feature
+++ b/features/diff.feature
@@ -4,9 +4,8 @@ Feature: Diff command
     Given a file named "stack_master.yml" with:
       """
       stacks:
-        us_east_1:
-          myapp_vpc:
-            template: myapp_vpc.json
+        myapp_vpc:
+          template: myapp_vpc.json
       """
     And a directory named "parameters"
     And a file named "parameters/myapp_vpc.yml" with:

--- a/features/events.feature
+++ b/features/events.feature
@@ -4,9 +4,8 @@ Feature: Events command
     Given a file named "stack_master.yml" with:
       """
       stacks:
-        us_east_1:
-          myapp_vpc:
-            template: myapp_vpc.rb
+        myapp_vpc:
+          template: myapp_vpc.rb
       """
     And a directory named "templates"
     And a file named "templates/myapp_vpc.rb" with:

--- a/features/init.feature
+++ b/features/init.feature
@@ -2,5 +2,4 @@ Feature: init project
 
   Scenario: Run init
     When I run `stack_master init us-east-1 my-app`
-    # TODO flesh this out
     Then the exit status should be 0

--- a/features/outputs.feature
+++ b/features/outputs.feature
@@ -4,9 +4,8 @@ Feature: Outputs command
     Given a file named "stack_master.yml" with:
       """
       stacks:
-        us_east_1:
-          myapp_vpc:
-            template: myapp_vpc.rb
+        myapp_vpc:
+          template: myapp_vpc.rb
       """
     And a directory named "templates"
     And a file named "templates/myapp_vpc.rb" with:

--- a/features/region_aliases.feature
+++ b/features/region_aliases.feature
@@ -7,12 +7,8 @@ Feature: Region aliases
         staging: ap-southeast-2
         production: us_east_1
       stacks:
-        staging:
-          myapp_vpc:
-            template: myapp_vpc.rb
-        production:
-          myapp_vpc:
-            template: myapp_vpc.rb
+        myapp_vpc:
+          template: myapp_vpc.rb
       """
     And a directory named "templates"
     And a directory named "parameters"

--- a/features/resources.feature
+++ b/features/resources.feature
@@ -4,9 +4,8 @@ Feature: Resources command
     Given a file named "stack_master.yml" with:
       """
       stacks:
-        us_east_1:
-          myapp_vpc:
-            template: myapp_vpc.rb
+        myapp_vpc:
+          template: myapp_vpc.rb
       """
     And a directory named "templates"
     And a file named "templates/myapp_vpc.rb" with:

--- a/features/stack_defaults.feature
+++ b/features/stack_defaults.feature
@@ -21,18 +21,16 @@ Feature: Stack defaults
           tags:
             environment: production
       stacks:
-        ap_southeast_2:
-          myapp_vpc:
-            template: myapp_vpc.rb
-            tags:
-              role: network
-            notification_arns:
-              - test_arn_3
-        us_east_1:
-          myapp_vpc:
-            template: myapp_vpc.rb
-            tags:
-              role: network
+        myapp_vpc:
+          template: myapp_vpc.rb
+          tags:
+            role: network
+          notification_arns:
+            - test_arn_3
+        myotherapp_vpc:
+          template: myapp_vpc.rb
+          tags:
+            role: network
       """
     And a directory named "templates"
     And a directory named "policies"

--- a/features/status.feature
+++ b/features/status.feature
@@ -4,13 +4,12 @@ Feature: Status command
     Given a file named "stack_master.yml" with:
       """
       stacks:
-        us_east_1:
-          stack1:
-            template: stack1.json
-          stack2:
-            template: stack2.json
-          stack3:
-            template: stack3.json
+        stack1:
+          template: stack1.json
+        stack2:
+          template: stack2.json
+        stack3:
+          template: stack3.json
       """
     And a directory named "parameters"
     And a file named "parameters/stack1.yml" with:
@@ -106,7 +105,7 @@ Feature: Status command
 }
       """
 
-    When I run `stack_master status --trace`
+    When I run `stack_master status us-east-1 --trace`
     And the output should contain all of these lines:
       | REGION    \| STACK_NAME \| STACK_STATUS    \| DIFFERENT |
       | ----------\|------------\|-----------------\|---------- |

--- a/features/validate.feature
+++ b/features/validate.feature
@@ -4,9 +4,8 @@ Feature: Validate command
     Given a file named "stack_master.yml" with:
       """
       stacks:
-        us_east_1:
-          stack1:
-            template: stack1.json
+        stack1:
+          template: stack1.json
       """
     And a directory named "parameters"
     And a file named "parameters/stack1.yml" with:

--- a/lib/stack_master/commands/compile.rb
+++ b/lib/stack_master/commands/compile.rb
@@ -16,7 +16,7 @@ module StackMaster
       private
 
       def stack_definition
-        @stack_definition ||= @config.find_stack(@region, @stack_name)
+        @stack_definition ||= @config.find_stack(@stack_name)
       end
 
       def proposed_stack

--- a/lib/stack_master/commands/diff.rb
+++ b/lib/stack_master/commands/diff.rb
@@ -16,7 +16,7 @@ module StackMaster
       private
 
       def stack_definition
-        @stack_definition ||= @config.find_stack(@region, @stack_name)
+        @stack_definition ||= @config.find_stack(@stack_name)
       end
 
       def stack

--- a/lib/stack_master/commands/lint.rb
+++ b/lib/stack_master/commands/lint.rb
@@ -27,7 +27,7 @@ module StackMaster
       private
 
       def stack_definition
-        @stack_definition ||= @config.find_stack(@region, @stack_name)
+        @stack_definition ||= @config.find_stack(@stack_name)
       end
 
       def proposed_stack

--- a/lib/stack_master/utils.rb
+++ b/lib/stack_master/utils.rb
@@ -22,9 +22,9 @@ module StackMaster
     end
 
     def hash_to_aws_parameters(params)
-      params.inject([]) do |params, (key, value)|
-        params << { parameter_key: key, parameter_value: value }
-        params
+      params.inject([]) do |aws_params, (key, value)|
+        aws_params << { parameter_key: key, parameter_value: value }
+        aws_params
       end
     end
 
@@ -41,9 +41,9 @@ module StackMaster
     end
 
     def underscore_keys_to_hyphen(hash)
-      hash.inject({}) do |hash, (key, value)|
-        hash[underscore_to_hyphen(key)] = value
-        hash
+      hash.inject({}) do |hash_with_underscore_keys, (key, value)|
+        hash_with_underscore_keys[underscore_to_hyphen(key)] = value
+        hash_with_underscore_keys
       end
     end
   end

--- a/spec/fixtures/stack_master.yml
+++ b/spec/fixtures/stack_master.yml
@@ -4,9 +4,6 @@ region_aliases:
 stack_defaults:
   tags:
     application: my-awesome-blog
-  s3:
-    bucket: my-bucket
-    region: us-east-1
 template_compilers:
   rb: ruby_dsl
 region_defaults:
@@ -18,6 +15,9 @@ region_defaults:
     role_arn: test_service_role_arn
     secret_file: production.yml.gpg
     stack_policy_file: my_policy.json
+    s3:
+      bucket: my-bucket
+      region: us-east-1
   staging:
     tags:
       environment: staging
@@ -26,24 +26,25 @@ region_defaults:
       - test_arn_3
     role_arn: test_service_role_arn3
     secret_file: staging.yml.gpg
+    s3:
+      bucket: my-bucket
+      region: ap-southeast-2
 stacks:
-  us-east-1:
-    myapp_vpc:
-      template: myapp_vpc.json
-      notification_arns:
-        - test_arn_2
-      role_arn: test_service_role_arn2
-    myapp_web:
-      template: myapp_web.rb
-    myapp_vpc_with_secrets:
-      template: myapp_vpc.json
-  ap-southeast-2:
-    myapp_vpc:
-      template: myapp_vpc.rb
-      notification_arns:
-        - test_arn_4
-      role_arn: test_service_role_arn4
-    myapp_web:
-      template: myapp_web
-      tags:
-        test_override: 2
+  myapp_vpc:
+    template: myapp_vpc.json
+    notification_arns:
+      - test_arn_2
+    role_arn: test_service_role_arn2
+  myapp_web:
+    template: myapp_web.rb
+  myapp_vpc_with_secrets:
+    template: myapp_vpc.json
+  myotherapp_vpc:
+    template: myapp_vpc.rb
+    notification_arns:
+      - test_arn_4
+    role_arn: test_service_role_arn4
+  myotherapp_web:
+    template: myapp_web
+    tags:
+      test_override: 2

--- a/spec/stack_master/stack_spec.rb
+++ b/spec/stack_master/stack_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe StackMaster::Stack do
   describe '.generate' do
     let(:tags) { {'tag1' => 'value1'} }
     let(:stack_definition) { StackMaster::StackDefinition.new(region: region, stack_name: stack_name, tags: tags, base_dir: '/base_dir', template: template_file_name, notification_arns: ['test_arn'], role_arn: 'test_service_role_arn', stack_policy_file: 'no_replace_rds.json') }
-    let(:config) { StackMaster::Config.new({'stacks' => {}}, '/base_dir') }
+    let(:config) { StackMaster::Config.new({'stacks' => {}}, '/base_dir', region) }
     subject(:stack) { StackMaster::Stack.generate(stack_definition, config) }
     let(:parameter_hash) { {template_parameters: {'DbPassword' => {'secret' => 'db_password'}}, compile_time_parameters: {}} }
     let(:resolved_template_parameters) { {'DbPassword' => 'sdfgjkdhlfjkghdflkjghdflkjg', 'InstanceType' => 't2.medium'} }

--- a/spec/stack_master/validator_spec.rb
+++ b/spec/stack_master/validator_spec.rb
@@ -1,11 +1,12 @@
 RSpec.describe StackMaster::Validator do
 
   subject(:validator) { described_class.new(stack_definition, config) }
-  let(:config) { StackMaster::Config.new({'stacks' => {}}, '/base_dir') }
+  let(:region) { 'us-east-1' }
+  let(:config) { StackMaster::Config.new({'stacks' => {}}, '/base_dir', region) }
   let(:stack_name) { 'myapp_vpc' }
   let(:stack_definition) do
     StackMaster::StackDefinition.new(
-        region: 'us-east-1',
+        region: region,
         stack_name: stack_name,
         template: 'myapp_vpc.json',
         tags: {'environment' => 'production'},


### PR DESCRIPTION
This is a Proposal for the direction of 2.0 of StackMaster. The proposal started [here](https://docs.google.com/document/d/1OhiyLps8SjO8cLyObm6sl-DxDKC9ROvsn-yLlCIZkmM/edit?usp=sharing) and given there wasn't a great deal of discussion on this I thought I'd throw it up.

I often find the duplication of stacks in stack_master.yml to be tedious and unnecessary. We often duplicate stack configuration many times, especially when we are building multiple environments and multi-region deployments.

Essentially we are duplicating the region parameter twice, once in `stack_master.yml` and once on the command line. We can remove it from the config file, but it does have some draw backs:
- The need for a migration "tool" to upgrade existing configurations to 2.0. I'll add this as part of a future PR
- We can no longer have per region per stack configurations for notification_arns, s3_buckets and files. The configuration must be for an entire region or an entire stack. For 2.0 we also plan on supporting per account settings called "environments", so this will likely also become a place to configure these settings (and probably per region per environment).
- It breaks existing CI workflows we use where we just run `stack_master validate` to validate all our stacks. `validate`, `status` and `diff` now must be passed a region.

Alternatively we could move these configurations into the parameter files, but that doesn't feel like where it should go. Other proposals for where this configuration might live are welcome.

Ultimately I think this proposal moves us closer to a _better_ experience for StackMaster users, by making it simpler to manage multiple stacks deployed to multiple regions and environments with little heavy lifting. Eventually we want stack_master.yml file to look something like this:

```
---
environments:
  production: 012345678910
  staging: 109876543210
bundles:
  my-web-app:
    vpc:
      template: vpc.rb
    web:
      template: asg.rb
    db:
      template: rds.rb
    redis:
      template: redis.rb
stacks:
  my-bastion:
    template: bastion.rb
```

Where I can `stack_master apply us-east-1 my-web-app` and have it come up cleanly.


This PR is to be merged into the `version-2.0` branch, which will act as our develop branch until 2.0 is considered ready for a release.