### PR TITLE
Better error when no container

### DIFF
--- a/lib/stack_master/parameter_resolvers/latest_container.rb
+++ b/lib/stack_master/parameter_resolvers/latest_container.rb
@@ -17,12 +17,14 @@ module StackMaster
         ecr_client = Aws::ECR::Client.new(region: @region)
 
         images = fetch_images(parameters['repository_name'], parameters['registry_id'], ecr_client)
-        return nil if images.empty?
 
-        if !parameters['tag'].nil?
+        unless parameters['tag'].nil?
           images.select! { |image| image.image_tags.any? { |tag| tag == parameters['tag'] } }
         end
         images.sort! { |image_x, image_y| image_y.image_pushed_at <=> image_x.image_pushed_at }
+
+        return nil if images.empty?
+
         latest_image = images.first
 
         # aws_account_id.dkr.ecr.region.amazonaws.com/repository@sha256:digest

--- a/spec/stack_master/parameter_resolvers/latest_container_spec.rb
+++ b/spec/stack_master/parameter_resolvers/latest_container_spec.rb
@@ -38,9 +38,17 @@ RSpec.describe StackMaster::ParameterResolvers::LatestContainer do
         { registry_id: '012345678910', image_digest: 'sha256:deadbeef', image_pushed_at: Time.utc(2015,1,3,0,0), image_tags: ['v2'] }
       ])
     end
+  
+    context 'when image exists' do
+      it 'returns the image with the production tag' do
+        expect(resolver.resolve({'repository_name' => 'foo', 'tag' => 'production'})).to eq '012345678910.dkr.ecr.us-east-1.amazonaws.com/foo@sha256:decafc0ffee'
+      end
+    end
 
-    it 'returns the image with the production tag' do
-      expect(resolver.resolve({'repository_name' => 'foo', 'tag' => 'production'})).to eq '012345678910.dkr.ecr.us-east-1.amazonaws.com/foo@sha256:decafc0ffee'
+    context 'when no image exists for this tag' do
+      it 'returns nil' do
+        expect(resolver.resolve({'repository_name' => 'foo', 'tag' => 'nosuchtag'})).to be_nil
+      end
     end
   end
 


### PR DESCRIPTION
## Context

If you provide a tag and there are some images in ECR, but none that match your tag, then StackMaster supplies an unhelpful error message:

```
error: undefined method `registry_id' for nil:NilClass. Use --trace to view backtrace
```

## Changes

Ensure it returns a helpful error by returning `nil`, which will result in the "no value provided for parameter" message.