### PR TITLE
Add call to Utils.underscore_to_hyphen for stack_name in delete command

### DIFF
--- a/lib/stack_master/cli.rb
+++ b/lib/stack_master/cli.rb
@@ -187,8 +187,10 @@ module StackMaster
             region = args[0]
           end
 
+          stack_name = Utils.underscore_to_hyphen(args[1])
+
           StackMaster.cloud_formation_driver.set_region(region)
-          StackMaster::Commands::Delete.perform(region, args[1])
+          StackMaster::Commands::Delete.perform(region, stack_name)
         end
       end
 


### PR DESCRIPTION
This change just makes the behavior of the cli more consistent.

When you apply a stack any underscores in the stack name argument will be converted to hyphens, using the Utils.underscore_to_hyphen method, before actually being created - but this conversion is not performed on the stack name argument when trying to delete the same stack.

E.g. `stack_master apply [region] my_stack_name` will create a cloudformation stack called `my-stack-name`.  If you then try to do `stack_master delete [region] my_stack_name` stack master will not convert the underscores before trying to delete it, which results in a `Stack does not exist` error.

There's a comment in the source which indicates that the delete command is intended to work without stack_master.yml - this should still be the case, however with this change you won't be able to delete a stack with underscores in the name that was created via some other tool, as they will now be converted to hyphens, and result in a `Stack does not exist` error.