### PR TITLE
Add a parameter resolver for EJSON wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,11 @@ my_param:
   ejson: "my_secret"
 ```
 
+Additional configuration options:
+
+- `ejson_file_region` The AWS region to attempt to decrypt private key with
+- `ejson_file_kms` Default: true. Set to false to use ejson without KMS.
+
 ### Security Group
 
 Looks up a security group by name and returns the ARN.

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ key_name: myapp-us-east-1
 
 ### Compile Time Parameters
 
-Compile time parameters can be used for [SparkleFormation](http://www.sparkleformation.io) templates. It conforms and 
+Compile time parameters can be used for [SparkleFormation](http://www.sparkleformation.io) templates. It conforms and
 allows you to use the [Compile Time Parameters](http://www.sparkleformation.io/docs/sparkle_formation/compile-time-parameters.html) feature.
 
 A simple example looks like this
@@ -289,9 +289,21 @@ For more information on 1password cli please see [here](https://support.1passwor
 
 ### EJSON Store
 
-[ejson](https://github.com/Shopify/ejson) is a tool for managing asymmetrically encrypted values in JSON format. This allows you to keep secrets securely in git/Github and give anyone the ability the capability to add new secrets without requiring access to the private key.
+[ejson](https://github.com/Shopify/ejson) is a tool to manage asymmetrically encrypted values in JSON format.
+This allows you to keep secrets securely in git/Github and gives anyone the ability the capability to add new
+secrets without requiring access to the private key. [ejson_wrapper](https://github.com/envato/ejson_wrapper)
+encrypts the underlying EJSON private key with KMS and stores it in the ejson file as `_private_key_enc`. Each
+time an ejson secret is required, the underlying EJSON private key is first decrypted before passing it onto
+ejson to decrypt the file.
 
-First create the `production.ejson` file and store the secret value in it, then call `ejson encrypt secrets.ejson`. Then add the `ejson_file` argument to your stack in stack_master.yml:
+First, generate an ejson file with ejson_wrapper, specifying the KMS key ID to be used:
+
+```shell
+gem install ejson_wrapper
+ejson_wrapper generate --region us-east-1 --kms-key-id [key_id] --file secrets/production.ejson
+```
+
+Then, add the `ejson_file` argument to your stack in stack_master.yml:
 
 ```yaml
 stacks:
@@ -307,8 +319,6 @@ finally refer to the secret key in the parameter file, i.e. parameters/my_app.ym
 my_param:
   ejson: "my_secret"
 ```
-
-You can also use [EJSON Wrapper](https://github.com/envato/ejson_wrapper) to encrypt the private key with KMS and store it in the ejson file.
 
 ### Security Group
 

--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ you will likely want to set the parameter to NoEcho in your template.
 db_password:
   parameter_store: ssm_parameter_name
 ```
+
 ### 1Password Lookup
 An Alternative to the alternative secret store is accessing 1password secrets using the 1password cli (`op`).
 You declare a 1password lookup with the following parameters in your parameters file:
@@ -273,6 +274,29 @@ database_password:
 Currently we support two types of secrets, `password`s and `secureNote`s. All values must be declared, there are no defaults.
 
 For more information on 1password cli please see [here](https://support.1password.com/command-line-getting-started/)
+
+### EJSON Store
+
+[ejson](https://github.com/Shopify/ejson) is a tool for managing asymmetrically encrypted values in JSON format. This allows you to keep secrets securely in git/Github and give anyone the ability the capability to add new secrets without requiring access to the private key.
+
+First create the `production.ejson` file and store the secret value in it, then call `ejson encrypt secrets.ejson`. Then add the `ejson_file` argument to your stack in stack_master.yml:
+
+```yaml
+stacks:
+  us-east-1:
+    my_app:
+      template: my_app.json
+      ejson_file: production.ejson
+```
+
+finally refer to the secret key in the parameter file, i.e. parameters/my_app.yml:
+
+```yaml
+my_param:
+  ejson: "my_secret"
+```
+
+You can also use [EJSON Wrapper](https://github.com/envato/ejson_wrapper) to encrypt the private key with KMS and store it in the ejson file.
 
 ### Security Group
 

--- a/lib/stack_master.rb
+++ b/lib/stack_master.rb
@@ -67,7 +67,7 @@ module StackMaster
     autoload :AcmCertificate, 'stack_master/parameter_resolvers/acm_certificate'
     autoload :AmiFinder, 'stack_master/parameter_resolvers/ami_finder'
     autoload :StackOutput, 'stack_master/parameter_resolvers/stack_output'
-    autoload :EJSON, 'stack_master/parameter_resolvers/ejson'
+    autoload :Ejson, 'stack_master/parameter_resolvers/ejson'
     autoload :Secret, 'stack_master/parameter_resolvers/secret'
     autoload :SnsTopicName, 'stack_master/parameter_resolvers/sns_topic_name'
     autoload :SecurityGroup, 'stack_master/parameter_resolvers/security_group'

--- a/lib/stack_master.rb
+++ b/lib/stack_master.rb
@@ -67,6 +67,7 @@ module StackMaster
     autoload :AcmCertificate, 'stack_master/parameter_resolvers/acm_certificate'
     autoload :AmiFinder, 'stack_master/parameter_resolvers/ami_finder'
     autoload :StackOutput, 'stack_master/parameter_resolvers/stack_output'
+    autoload :EJSON, 'stack_master/parameter_resolvers/ejson'
     autoload :Secret, 'stack_master/parameter_resolvers/secret'
     autoload :SnsTopicName, 'stack_master/parameter_resolvers/sns_topic_name'
     autoload :SecurityGroup, 'stack_master/parameter_resolvers/security_group'

--- a/lib/stack_master/parameter_resolvers/ejson.rb
+++ b/lib/stack_master/parameter_resolvers/ejson.rb
@@ -2,7 +2,7 @@ require 'ejson_wrapper'
 
 module StackMaster
   module ParameterResolvers
-    class EJSON < Resolver
+    class Ejson < Resolver
       SecretNotFound = Class.new(StandardError)
 
       def initialize(config, stack_definition)

--- a/lib/stack_master/parameter_resolvers/ejson.rb
+++ b/lib/stack_master/parameter_resolvers/ejson.rb
@@ -28,7 +28,7 @@ module StackMaster
 
       def decrypt_ejson_file
         @decrypt_ejson_file ||= EJSONWrapper.decrypt(ejson_file_path,
-                                                     use_kms: true,
+                                                     use_kms: @stack_definition.ejson_file_kms,
                                                      region: ejson_file_region)
       end
 

--- a/lib/stack_master/parameter_resolvers/ejson.rb
+++ b/lib/stack_master/parameter_resolvers/ejson.rb
@@ -21,17 +21,13 @@ module StackMaster
       private
 
       def validate_ejson_file_specified
-        if ejson_file.nil?
+        if @stack_definition.ejson_file.nil?
           raise ArgumentError, "No ejson_file defined for stack definition #{@stack_definition.stack_name} in #{@stack_definition.region}"
         end
       end
 
       def decrypt_ejson_file
-        EJSONWrapper.decrypt(@stack_definition.ejson_file, use_kms: true, region: StackMaster.cloud_formation_driver.region)
-      end
-
-      def ejson_file
-        @stack_definition.ejson_file
+        EJSONWrapper.decrypt(ejson_file_path, use_kms: true, region: StackMaster.cloud_formation_driver.region)
       end
 
       def ejson_file_path
@@ -39,7 +35,7 @@ module StackMaster
       end
 
       def secret_path_relative_to_base
-        @secret_path_relative_to_base ||= File.join('secrets', ejson_file)
+        @secret_path_relative_to_base ||= File.join('secrets', @stack_definition.ejson_file)
       end
     end
   end

--- a/lib/stack_master/parameter_resolvers/ejson.rb
+++ b/lib/stack_master/parameter_resolvers/ejson.rb
@@ -27,7 +27,11 @@ module StackMaster
       end
 
       def decrypt_ejson_file
-        EJSONWrapper.decrypt(ejson_file_path, use_kms: true, region: StackMaster.cloud_formation_driver.region)
+        EJSONWrapper.decrypt(ejson_file_path, use_kms: true, region: ejson_file_region)
+      end
+
+      def ejson_file_region
+        @stack_definition.ejson_file_region || StackMaster.cloud_formation_driver.region
       end
 
       def ejson_file_path

--- a/lib/stack_master/parameter_resolvers/ejson.rb
+++ b/lib/stack_master/parameter_resolvers/ejson.rb
@@ -27,7 +27,9 @@ module StackMaster
       end
 
       def decrypt_ejson_file
-        EJSONWrapper.decrypt(ejson_file_path, use_kms: true, region: ejson_file_region)
+        @decrypt_ejson_file ||= EJSONWrapper.decrypt(ejson_file_path,
+                                                     use_kms: true,
+                                                     region: ejson_file_region)
       end
 
       def ejson_file_region

--- a/lib/stack_master/parameter_resolvers/ejson.rb
+++ b/lib/stack_master/parameter_resolvers/ejson.rb
@@ -1,0 +1,46 @@
+require 'ejson_wrapper'
+
+module StackMaster
+  module ParameterResolvers
+    class EJSON < Resolver
+      SecretNotFound = Class.new(StandardError)
+
+      def initialize(config, stack_definition)
+        @config = config
+        @stack_definition = stack_definition
+      end
+
+      def resolve(secret_key)
+        validate_ejson_file_specified
+        secrets = decrypt_ejson_file
+        secrets.fetch(secret_key.to_sym) do
+          raise SecretNotFound, "Unable to find key #{secret_key} in file #{ejson_file}"
+        end
+      end
+
+      private
+
+      def validate_ejson_file_specified
+        if ejson_file.nil?
+          raise ArgumentError, "No ejson_file defined for stack definition #{@stack_definition.stack_name} in #{@stack_definition.region}"
+        end
+      end
+
+      def decrypt_ejson_file
+        EJSONWrapper.decrypt(@stack_definition.ejson_file, use_kms: true, region: StackMaster.cloud_formation_driver.region)
+      end
+
+      def ejson_file
+        @stack_definition.ejson_file
+      end
+
+      def ejson_file_path
+        @ejson_file_path ||= File.join(@config.base_dir, secret_path_relative_to_base)
+      end
+
+      def secret_path_relative_to_base
+        @secret_path_relative_to_base ||= File.join('secrets', ejson_file)
+      end
+    end
+  end
+end

--- a/lib/stack_master/stack_definition.rb
+++ b/lib/stack_master/stack_definition.rb
@@ -9,6 +9,7 @@ module StackMaster
                   :base_dir,
                   :template_dir,
                   :secret_file,
+                  :ejson_file,
                   :stack_policy_file,
                   :additional_parameter_lookup_dirs,
                   :s3,
@@ -37,6 +38,7 @@ module StackMaster
         @notification_arns == other.notification_arns &&
         @base_dir == other.base_dir &&
         @secret_file == other.secret_file &&
+        @ejson_file == other.ejson_file &&
         @stack_policy_file == other.stack_policy_file &&
         @additional_parameter_lookup_dirs == other.additional_parameter_lookup_dirs &&
         @s3 == other.s3 &&

--- a/lib/stack_master/stack_definition.rb
+++ b/lib/stack_master/stack_definition.rb
@@ -11,6 +11,7 @@ module StackMaster
                   :template_dir,
                   :secret_file,
                   :ejson_file,
+                  :ejson_file_region,
                   :stack_policy_file,
                   :additional_parameter_lookup_dirs,
                   :s3,
@@ -43,6 +44,7 @@ module StackMaster
         @base_dir == other.base_dir &&
         @secret_file == other.secret_file &&
         @ejson_file == other.ejson_file &&
+        @ejson_file_region == other.ejson_file_region &&
         @stack_policy_file == other.stack_policy_file &&
         @additional_parameter_lookup_dirs == other.additional_parameter_lookup_dirs &&
         @s3 == other.s3 &&

--- a/lib/stack_master/stack_definition.rb
+++ b/lib/stack_master/stack_definition.rb
@@ -12,6 +12,7 @@ module StackMaster
                   :secret_file,
                   :ejson_file,
                   :ejson_file_region,
+                  :ejson_file_kms,
                   :stack_policy_file,
                   :additional_parameter_lookup_dirs,
                   :s3,
@@ -27,6 +28,7 @@ module StackMaster
       @s3 = {}
       @files = []
       @allowed_accounts = nil
+      @ejson_file_kms = true
       super
       @template_dir ||= File.join(@base_dir, 'templates')
       @allowed_accounts = Array(@allowed_accounts)
@@ -45,6 +47,7 @@ module StackMaster
         @secret_file == other.secret_file &&
         @ejson_file == other.ejson_file &&
         @ejson_file_region == other.ejson_file_region &&
+        @ejson_file_kms == other.ejson_file_kms &&
         @stack_policy_file == other.stack_policy_file &&
         @additional_parameter_lookup_dirs == other.additional_parameter_lookup_dirs &&
         @s3 == other.s3 &&

--- a/spec/stack_master/parameter_resolvers/ejson_spec.rb
+++ b/spec/stack_master/parameter_resolvers/ejson_spec.rb
@@ -1,0 +1,34 @@
+RSpec.describe StackMaster::ParameterResolvers::EJSON do
+  let(:base_dir) { '/base_dir' }
+  let(:config) { double(base_dir: base_dir) }
+  let(:ejson_file) { 'staging.ejson' }
+  let(:stack_definition) { double(ejson_file: ejson_file, stack_name: 'mystack', region: 'us-east-1') }
+  subject(:ejson) { described_class.new(config, stack_definition) }
+  let(:secrets) { { secret_a: 'value_a' } }
+
+  before do
+    allow(EJSONWrapper).to receive(:decrypt).and_return(secrets)
+  end
+
+  it 'returns secrets' do
+    expect(ejson.resolve('secret_a')).to eq('value_a')
+  end
+
+  context 'when decryption fails' do
+    before do
+      allow(EJSONWrapper).to receive(:decrypt).and_raise(EJSONWrapper::DecryptionFailed)
+    end
+
+    it 'bubbles the error up' do
+      expect { ejson.resolve('test') }.to raise_error(EJSONWrapper::DecryptionFailed)
+    end
+  end
+
+  context 'when ejson_file not specified' do
+    let(:ejson_file) { nil }
+
+    it 'raises an error' do
+      expect { ejson.resolve('test') }.to raise_error(ArgumentError, /No ejson_file defined/)
+    end
+  end
+end

--- a/spec/stack_master/parameter_resolvers/ejson_spec.rb
+++ b/spec/stack_master/parameter_resolvers/ejson_spec.rb
@@ -2,7 +2,8 @@ RSpec.describe StackMaster::ParameterResolvers::Ejson do
   let(:base_dir) { '/base_dir' }
   let(:config) { double(base_dir: base_dir) }
   let(:ejson_file) { 'staging.ejson' }
-  let(:stack_definition) { double(ejson_file: ejson_file, stack_name: 'mystack', region: 'us-east-1') }
+  let(:ejson_file_region) { 'ap-southeast-2' }
+  let(:stack_definition) { double(ejson_file: ejson_file, ejson_file_region: ejson_file_region, stack_name: 'mystack', region: 'us-east-1') }
   subject(:ejson) { described_class.new(config, stack_definition) }
   let(:secrets) { { secret_a: 'value_a' } }
 
@@ -14,9 +15,22 @@ RSpec.describe StackMaster::ParameterResolvers::Ejson do
     expect(ejson.resolve('secret_a')).to eq('value_a')
   end
 
-  it 'decrypts with the correct file path' do
-    ejson.resolve('secret_a')
-    expect(EJSONWrapper).to have_received(:decrypt).with('/base_dir/secrets/staging.ejson', use_kms: true, region: StackMaster.cloud_formation_driver.region)
+  context 'when ejson_file_region is unspecified' do
+    let(:ejson_file_region) { nil }
+
+    it 'decrypts with the correct file path' do
+      ejson.resolve('secret_a')
+      expect(EJSONWrapper).to have_received(:decrypt).with('/base_dir/secrets/staging.ejson', use_kms: true, region: StackMaster.cloud_formation_driver.region)
+    end
+  end
+
+  context 'when ejson_file_region is unspecified' do
+    let(:ejson_file_region) { 'ap-southeast-2' }
+
+    it 'decrypts with the correct file path' do
+      ejson.resolve('secret_a')
+      expect(EJSONWrapper).to have_received(:decrypt).with('/base_dir/secrets/staging.ejson', use_kms: true, region: 'ap-southeast-2')
+    end
   end
 
   context 'when decryption fails' do

--- a/spec/stack_master/parameter_resolvers/ejson_spec.rb
+++ b/spec/stack_master/parameter_resolvers/ejson_spec.rb
@@ -14,6 +14,11 @@ RSpec.describe StackMaster::ParameterResolvers::Ejson do
     expect(ejson.resolve('secret_a')).to eq('value_a')
   end
 
+  it 'decrypts with the correct file path' do
+    ejson.resolve('secret_a')
+    expect(EJSONWrapper).to have_received(:decrypt).with('/base_dir/secrets/staging.ejson', use_kms: true, region: StackMaster.cloud_formation_driver.region)
+  end
+
   context 'when decryption fails' do
     before do
       allow(EJSONWrapper).to receive(:decrypt).and_raise(EJSONWrapper::DecryptionFailed)

--- a/spec/stack_master/parameter_resolvers/ejson_spec.rb
+++ b/spec/stack_master/parameter_resolvers/ejson_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe StackMaster::ParameterResolvers::EJSON do
+RSpec.describe StackMaster::ParameterResolvers::Ejson do
   let(:base_dir) { '/base_dir' }
   let(:config) { double(base_dir: base_dir) }
   let(:ejson_file) { 'staging.ejson' }

--- a/spec/stack_master/parameter_resolvers/ejson_spec.rb
+++ b/spec/stack_master/parameter_resolvers/ejson_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe StackMaster::ParameterResolvers::Ejson do
   let(:config) { double(base_dir: base_dir) }
   let(:ejson_file) { 'staging.ejson' }
   let(:ejson_file_region) { 'ap-southeast-2' }
-  let(:stack_definition) { double(ejson_file: ejson_file, ejson_file_region: ejson_file_region, stack_name: 'mystack', region: 'us-east-1') }
+  let(:stack_definition) { double(ejson_file: ejson_file, ejson_file_region: ejson_file_region, stack_name: 'mystack', region: 'us-east-1', ejson_file_kms: true) }
   subject(:ejson) { described_class.new(config, stack_definition) }
   let(:secrets) { { secret_a: 'value_a' } }
 

--- a/spec/stack_master/stack_definition_spec.rb
+++ b/spec/stack_master/stack_definition_spec.rb
@@ -67,4 +67,8 @@ RSpec.describe StackMaster::StackDefinition do
       ])
     end
   end
+
+  it 'defaults ejson_file_kms to true' do
+    expect(stack_definition.ejson_file_kms).to eq true
+  end
 end

--- a/stack_master.gemspec
+++ b/stack_master.gemspec
@@ -57,6 +57,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "cfndsl"
   spec.add_dependency "multi_json"
   spec.add_dependency "hashdiff"
+  spec.add_dependency "ejson_wrapper"
   spec.add_dependency "dotgpg" unless windows_build
   spec.add_dependency "diff-lcs" if windows_build
 end


### PR DESCRIPTION
An EJSON file that uses KMS can be generated with EJSON Wrapper:

```
ejson_wrapper generate --region ap-southeast-2 --kms-key-id [key_id] --file secrets/staging.ejson
```

Secrets are then added as usual with EJSON. Add the plaintext then:

```
ejson encrypt secrets.ejson
```

Set `ejson_file` in the stack definition to `staging.ejson`. Then secrets can be referenced in parameter files:

```
my_param:
  ejson: "my_secret"
```

TODO:

- [x] Update Readme.