### PR TITLE
Test on Ruby 2.6 (and not on 2.1 and 2.2)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: ruby
 matrix:
   include:
-    - rvm: 2.2
-    - rvm: 2.2
-      os: osx
     - rvm: 2.3
     - rvm: 2.3
       os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: ruby
 matrix:
   include:
-    - rvm: 2.1
-      gemfile: spec/support/gemfiles/Gemfile.activesupport-4.0.0
     - rvm: 2.2
     - rvm: 2.2
       os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ matrix:
     - rvm: 2.5
     - rvm: 2.5
       os: osx
+    - rvm: 2.6
+    - rvm: 2.6
+      os: osx
 sudo: false
 script:
   - bundle exec rake spec features

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,11 @@
 language: ruby
-matrix:
-  include:
-    - rvm: 2.3
-    - rvm: 2.3
-      os: osx
-    - rvm: 2.4
-    - rvm: 2.4
-      os: osx
-    - rvm: 2.5
-    - rvm: 2.5
-      os: osx
-    - rvm: 2.6
-    - rvm: 2.6
-      os: osx
+os:
+- linux
+- osx
+rvm:
+- 2.3
+- 2.4
+- 2.5
+- 2.6
+script: bundle exec rake spec features
 sudo: false
-script:
-  - bundle exec rake spec features

--- a/spec/support/gemfiles/Gemfile.activesupport-4.0.0
+++ b/spec/support/gemfiles/Gemfile.activesupport-4.0.0
@@ -1,5 +1,0 @@
-source 'https://rubygems.org'
-
-gemspec :path => '../../../'
-
-gem 'activesupport', '4.0.0'


### PR DESCRIPTION
Ruby 2.6 has been [released](https://www.ruby-lang.org/en/news/2018/12/25/ruby-2-6-0-released/)! Let's add it to the test matrix.

![image](https://user-images.githubusercontent.com/497874/50583347-baac3800-0ebc-11e9-8419-5174aa0ec220.png)
