### PR TITLE
return non-zero exit status when command fails

### DIFF
--- a/features/apply.feature
+++ b/features/apply.feature
@@ -144,6 +144,11 @@ Feature: Apply command
     And the output should match /2020-10-29 00:00:00 (\+|\-)[0-9]{4} myapp-web AWS::CloudFormation::Stack CREATE_COMPLETE/
     Then the exit status should be 0
 
+  Scenario: Run apply with invalid stack
+    When I run `stack_master apply foo bar`
+    Then the output should contain "Could not find stack definition bar in region foo"
+    And the exit status should be 1
+
   Scenario: Create stack with --changed
     Given I stub the following stack events:
       | stack_id | event_id | stack_name | logical_resource_id | resource_status | resource_type              | timestamp           |

--- a/lib/stack_master/cli.rb
+++ b/lib/stack_master/cli.rb
@@ -13,10 +13,6 @@ module StackMaster
       TablePrint::Config.io = StackMaster.stdout
     end
 
-    def default_config_file
-      "stack_master.yml"
-    end
-
     def execute!
       program :name, 'StackMaster'
       program :version, StackMaster::VERSION
@@ -200,6 +196,12 @@ module StackMaster
       run!
     end
 
+    private
+
+    def default_config_file
+      "stack_master.yml"
+    end
+
     def load_config(file)
       stack_file = file || default_config_file
       StackMaster::Config.load!(stack_file)
@@ -218,6 +220,7 @@ module StackMaster
         stack_definitions = config.filter(region, stack_name)
         if stack_definitions.empty?
           StackMaster.stdout.puts "Could not find stack definition #{stack_name} in region #{region}"
+          command_results.push false
         end
         stack_definitions = stack_definitions.select do |stack_definition|
           StackStatus.new(config, stack_definition).changed?
@@ -229,8 +232,8 @@ module StackMaster
         end
       end
 
-      # Return success/failure
-      command_results.all?
+      # fail command execution if something went wrong
+      @kernel.exit 1 unless command_results.all?
     end
   end
 end


### PR DESCRIPTION
 - the return value of execute_stacks_command is not getting used for anything by commander see https://github.com/commander-rb/commander/issues/78
 - a missing stack did not cause an error

If it were not for https://github.com/cucumber/aruba/issues/592 it could be simplified to `@kernel.exit command_results.all?`