### PR TITLE
Return true if nothing has failed in cli

### DIFF
--- a/lib/stack_master/cli.rb
+++ b/lib/stack_master/cli.rb
@@ -234,6 +234,8 @@ module StackMaster
 
       # fail command execution if something went wrong
       @kernel.exit 1 unless command_results.all?
+
+      true
     end
   end
 end


### PR DESCRIPTION
We should ensure that we return true,
otherwise changes introduced in #276 will cause stack_master to always
exit with code 1, which breaks integration tests.

Addresses issues opened in #277.

cc: @grosser 
