### PR TITLE
no need for explicit exit since bin/stack_master already handles that

### DIFF
--- a/features/apply.feature
+++ b/features/apply.feature
@@ -147,7 +147,7 @@ Feature: Apply command
   Scenario: Run apply with invalid stack
     When I run `stack_master apply foo bar`
     Then the output should contain "Could not find stack definition bar in region foo"
-    And the exit status should be 1
+    And the exit status should be 0
 
   Scenario: Create stack with --changed
     Given I stub the following stack events:

--- a/features/apply.feature
+++ b/features/apply.feature
@@ -147,7 +147,6 @@ Feature: Apply command
   Scenario: Run apply with invalid stack
     When I run `stack_master apply foo bar`
     Then the output should contain "Could not find stack definition bar in region foo"
-    And the exit status should be 0
 
   Scenario: Create stack with --changed
     Given I stub the following stack events:


### PR DESCRIPTION
followup to https://github.com/envato/stack_master/pull/276 which fixed 1 bug and introduced another 😨 
the cucumber test was misleading since it never executes bin/stack_master and so never gets the actual exit status
also simplifying by converting the array logic to a boolean

replaces https://github.com/envato/stack_master/pull/279
fixes https://github.com/envato/stack_master/issues/277
fixes https://github.com/envato/stack_master/issues/278