### PR TITLE
Add ability to restrict which accounts can work with stacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -551,7 +551,7 @@ Note though that if a dynamic with the same name exists in your `templates/dynam
 
 ## Allowed accounts
 
-The AWS account the command is executing in can be restricted to a specific list of allowed account. This is useful in reduicing the possibility of applying non-production changes in a production account. Each stack definition can specify the `allowed_accounts` property with an array of AWS account IDs the stack is allowed to work with.
+The AWS account the command is executing in can be restricted to a specific list of allowed accounts. This is useful in reducing the possibility of applying non-production changes in a production account. Each stack definition can specify the `allowed_accounts` property with an array of AWS account IDs the stack is allowed to work with.
 
 This is an opt-in feature which is enabled by specifying at least one account to allow.
 

--- a/README.md
+++ b/README.md
@@ -555,32 +555,32 @@ The AWS account the command is executing in can be restricted to a specific list
 
 This is an opt-in feature which is enabled by specifying at least one account to allow.
 
-Unlike other stack defaults, `allowed_accounts` values specified in the stack definition override values in the stack defaults instead of merging them together. This allows specifying allowed accounts in the stack defaults for all stacks and still have different values for specific stacks. See below example config for an example.
+Unlike other stack defaults, the `allowed_accounts` property values specified in the stack definition override values specified in the stack defaults (i.e., other stack property values are merged together with those specified in the stack defaults). This allows specifying allowed accounts in the stack defaults (inherited by all stacks) and override them for specific stacks. See below example config for an example.
 
 ```yaml
 stack_defaults:
   allowed_accounts: '555555555'
 stacks:
   us-east-1:
-    myapp-vpc: # inherits allowed account 555555555
+    myapp-vpc: # only allow account 555555555 (inherited from the stack defaults)
       template: myapp_vpc.rb
       tags:
         purpose: front-end
     myapp-db:
       template: myapp_db.rb
-      allowed_accounts: # only these accounts
+      allowed_accounts: # only allow these accounts (overrides the stack defaults)
         - '1234567890'
         - '9876543210'
       tags:
         purpose: back-end
     myapp-web:
       template: myapp_web.rb
-      allowed_accounts: [] # allow all accounts by overriding stack defaults
+      allowed_accounts: [] # allow all accounts (overrides the stack defaults)
       tags:
         purpose: front-end
     myapp-redis:
       template: myapp_redis.rb
-      allowed_accounts: '888888888' # only this account
+      allowed_accounts: '888888888' # only allow this account (overrides the stack defaults)
       tags:
         purpose: back-end
 ```

--- a/README.md
+++ b/README.md
@@ -91,10 +91,14 @@ stacks:
   staging:
     myapp-vpc:
       template: myapp_vpc.rb
+      allowed_accounts: '123456789'
       tags:
         purpose: front-end
     myapp-db:
       template: myapp_db.rb
+      allowed_accounts:
+        - '1234567890'
+        - '9876543210'
       tags:
         purpose: back-end
     myapp-web:
@@ -544,6 +548,44 @@ end
 ```
 
 Note though that if a dynamic with the same name exists in your `templates/dynamics/` directory it will get loaded since it has higher precedence.
+
+## Allowed accounts
+
+The AWS account the command is executing in can be restricted to a specific list of allowed account. This is useful in reduicing the possibility of applying non-production changes in a production account. Each stack definition can specify the `allowed_accounts` property with an array of AWS account IDs the stack is allowed to work with.
+
+This is an opt-in feature which is enabled by specifying at least one account to allow.
+
+Unlike other stack defaults, `allowed_accounts` values specified in the stack definition override values in the stack defaults instead of merging them together. This allows specifying allowed accounts in the stack defaults for all stacks and still have different values for specific stacks. See below example config for an example.
+
+```yaml
+stack_defaults:
+  allowed_accounts: '555555555'
+stacks:
+  us-east-1:
+    myapp-vpc: # inherits allowed account 555555555
+      template: myapp_vpc.rb
+      tags:
+        purpose: front-end
+    myapp-db:
+      template: myapp_db.rb
+      allowed_accounts: # only these accounts
+        - '1234567890'
+        - '9876543210'
+      tags:
+        purpose: back-end
+    myapp-web:
+      template: myapp_web.rb
+      allowed_accounts: [] # allow all accounts by overriding stack defaults
+      tags:
+        purpose: front-end
+    myapp-redis:
+      template: myapp_redis.rb
+      allowed_accounts: '888888888' # only this account
+      tags:
+        purpose: back-end
+```
+
+In the cases where you want to bypass the account check, there is StackMaster flag `--skip-account-check` that can be used.
 
 ## Commands
 

--- a/features/apply_with_allowed_accounts.feature
+++ b/features/apply_with_allowed_accounts.feature
@@ -1,0 +1,55 @@
+Feature: Apply command with allowed accounts
+
+  Background:
+    Given a file named "stack_master.yml" with:
+      """
+      stack_defaults:
+        allowed_accounts:
+          - '11111111'
+      stacks:
+        us_east_1:
+          myapp_vpc:
+            template: myapp.rb
+          myapp_db:
+            template: myapp.rb
+            allowed_accounts: '22222222'
+          myapp_web:
+            template: myapp.rb
+            allowed_accounts: []
+      """
+    And a directory named "templates"
+    And a file named "templates/myapp.rb" with:
+      """
+      SparkleFormation.new(:myapp) do
+        description "Test template"
+        set!('AWSTemplateFormatVersion', '2010-09-09')
+      end
+      """
+
+  Scenario: Run apply with stack inheriting allowed accounts from stack defaults
+    Given I stub the following stack events:
+      | stack_id | event_id | stack_name | logical_resource_id | resource_status | resource_type              | timestamp           |
+      | 1        | 1        | myapp-vpc  | myapp-vpc           | CREATE_COMPLETE | AWS::CloudFormation::Stack | 2020-10-29 00:00:00 |
+    When I use the account "11111111"
+    And I run `stack_master apply us-east-1 myapp-vpc`
+    And the output should match /2020-10-29 00:00:00 (\+|\-)[0-9]{4} myapp-vpc AWS::CloudFormation::Stack CREATE_COMPLETE/
+    Then the exit status should be 0
+
+  Scenario: Run apply with stack overriding allowed accounts with its own list
+    Given I stub the following stack events:
+      | stack_id | event_id | stack_name | logical_resource_id | resource_status | resource_type              | timestamp           |
+      | 1        | 1        | myapp-db   | myapp-db            | CREATE_COMPLETE | AWS::CloudFormation::Stack | 2020-10-29 00:00:00 |
+    When I use the account "11111111"
+    And I run `stack_master apply us-east-1 myapp-db`
+    And the output should contain all of these lines:
+      | Account '11111111' is not an allowed account. Allowed accounts are ["22222222"].|
+    Then the exit status should be 0
+
+  Scenario: Run apply with stack overriding allowed accounts to allow all accounts
+    Given I stub the following stack events:
+      | stack_id | event_id | stack_name | logical_resource_id | resource_status | resource_type              | timestamp           |
+      | 1        | 1        | myapp-web  | myapp-web           | CREATE_COMPLETE | AWS::CloudFormation::Stack | 2020-10-29 00:00:00 |
+    When I use the account "33333333"
+    And I run `stack_master apply us-east-1 myapp-web`
+    And the output should match /2020-10-29 00:00:00 (\+|\-)[0-9]{4} myapp-web AWS::CloudFormation::Stack CREATE_COMPLETE/
+    Then the exit status should be 0

--- a/features/step_definitions/identity_steps.rb
+++ b/features/step_definitions/identity_steps.rb
@@ -1,0 +1,11 @@
+Given(/^I use the account "([^"]*)"$/) do |account_id|
+  Aws.config[:sts] = {
+    stub_responses: {
+      get_caller_identity: {
+        account: account_id,
+        arn: 'an-arn',
+        user_id: 'a-user-id'
+      }
+    }
+  }
+end

--- a/lib/stack_master.rb
+++ b/lib/stack_master.rb
@@ -38,6 +38,7 @@ module StackMaster
   autoload :PagedResponseAccumulator, 'stack_master/paged_response_accumulator'
   autoload :StackDefinition, 'stack_master/stack_definition'
   autoload :TemplateCompiler, 'stack_master/template_compiler'
+  autoload :Identity, 'stack_master/identity'
 
   autoload :StackDiffer, 'stack_master/stack_differ'
   autoload :Validator, 'stack_master/validator'

--- a/lib/stack_master.rb
+++ b/lib/stack_master.rb
@@ -98,6 +98,7 @@ module StackMaster
   NON_INTERACTIVE_DEFAULT = false
   DEBUG_DEFAULT = false
   QUIET_DEFAULT = false
+  SKIP_ACCOUNT_CHECK_DEFAULT = false
 
   def interactive?
     !non_interactive?
@@ -137,6 +138,16 @@ module StackMaster
 
   def reset_flags
     @quiet = QUIET_DEFAULT
+    @skip_account_check = SKIP_ACCOUNT_CHECK_DEFAULT
+  end
+
+  def skip_account_check!
+    @skip_account_check = true
+  end
+  @skip_account_check = SKIP_ACCOUNT_CHECK_DEFAULT
+
+  def skip_account_check?
+    @skip_account_check
   end
 
   attr_accessor :non_interactive_answer

--- a/lib/stack_master/cli.rb
+++ b/lib/stack_master/cli.rb
@@ -34,6 +34,9 @@ module StackMaster
       global_option '-q', '--quiet', 'Do not output the resulting Stack Events, just return immediately' do
         StackMaster.quiet!
       end
+      global_option '--skip-account-check', 'Do not check if command is allowed to execute in account' do
+        StackMaster.skip_account_check!
+      end
 
       command :apply do |c|
         c.syntax = 'stack_master apply [region_or_alias] [stack_name]'
@@ -251,7 +254,7 @@ module StackMaster
     end
 
     def running_in_allowed_account?(allowed_accounts)
-      identity.running_in_allowed_account?(allowed_accounts)
+      StackMaster.skip_account_check? || identity.running_in_allowed_account?(allowed_accounts)
     end
 
     def identity

--- a/lib/stack_master/cli.rb
+++ b/lib/stack_master/cli.rb
@@ -223,12 +223,14 @@ module StackMaster
           success = false
         end
         stack_definitions = stack_definitions.select do |stack_definition|
-          StackStatus.new(config, stack_definition).changed?
+          running_in_allowed_account?(stack_definition.allowed_accounts) && StackStatus.new(config, stack_definition).changed?
         end if options.changed
         stack_definitions.each do |stack_definition|
           StackMaster.cloud_formation_driver.set_region(stack_definition.region)
           StackMaster.stdout.puts "Executing #{command.command_name} on #{stack_definition.stack_name} in #{stack_definition.region}"
-          success = false unless command.perform(config, stack_definition, options).success?
+          success = execute_if_allowed_account(stack_definition.allowed_accounts) do
+            command.perform(config, stack_definition, options).success?
+          end
         end
       end
       success

--- a/lib/stack_master/cli.rb
+++ b/lib/stack_master/cli.rb
@@ -258,7 +258,7 @@ module StackMaster
     end
 
     def identity
-      @account ||= StackMaster::Identity.new
+      @identity ||= StackMaster::Identity.new
     end
   end
 end

--- a/lib/stack_master/commands/status.rb
+++ b/lib/stack_master/commands/status.rb
@@ -16,12 +16,13 @@ module StackMaster
         progress if @show_progress
         status = @config.stacks.map do |stack_definition|
           stack_status = StackStatus.new(@config, stack_definition)
+          allowed_accounts = stack_definition.allowed_accounts
           progress.increment if @show_progress
           {
             region: stack_definition.region,
             stack_name: stack_definition.stack_name,
-            stack_status: stack_status.status,
-            different: stack_status.changed_message,
+            stack_status: running_in_allowed_account?(allowed_accounts) ? stack_status.status : "Disallowed account",
+            different: running_in_allowed_account?(allowed_accounts) ? stack_status.changed_message : "N/A",
           }
         end
         tp.set :max_width, self.window_size
@@ -40,6 +41,14 @@ module StackMaster
 
       def sort_params(hash)
         hash.sort.to_h
+      end
+
+      def running_in_allowed_account?(allowed_accounts)
+        identity.running_in_allowed_account?(allowed_accounts)
+      end
+
+      def identity
+        @identity ||= StackMaster::Identity.new
       end
     end
   end

--- a/lib/stack_master/commands/status.rb
+++ b/lib/stack_master/commands/status.rb
@@ -44,7 +44,7 @@ module StackMaster
       end
 
       def running_in_allowed_account?(allowed_accounts)
-        identity.running_in_allowed_account?(allowed_accounts)
+        StackMaster.skip_account_check? || identity.running_in_allowed_account?(allowed_accounts)
       end
 
       def identity

--- a/lib/stack_master/config.rb
+++ b/lib/stack_master/config.rb
@@ -116,6 +116,7 @@ module StackMaster
             'base_dir' => @base_dir,
             'template_dir' => @template_dir,
             'additional_parameter_lookup_dirs' => @region_to_aliases[region])
+          stack_attributes['allowed_accounts'] = attributes['allowed_accounts'] if attributes['allowed_accounts']
           @stacks << StackDefinition.new(stack_attributes)
         end
       end

--- a/lib/stack_master/identity.rb
+++ b/lib/stack_master/identity.rb
@@ -1,0 +1,23 @@
+module StackMaster
+  class Identity
+    def running_in_allowed_account?(allowed_accounts)
+      allowed_accounts.nil? || allowed_accounts.empty? || allowed_accounts.include?(account)
+    end
+
+    def account
+      @account ||= sts.get_caller_identity.account
+    end
+
+    private
+
+    attr_reader :sts
+
+    def region
+      @region ||= ENV['AWS_REGION'] || Aws.config[:region] || Aws.shared_config.region || 'us-east-1'
+    end
+
+    def sts
+      @sts ||= Aws::STS::Client.new(region: region)
+    end
+  end
+end

--- a/lib/stack_master/stack_definition.rb
+++ b/lib/stack_master/stack_definition.rb
@@ -24,7 +24,7 @@ module StackMaster
       @notification_arns = []
       @s3 = {}
       @files = []
-      @allowed_accounts = []
+      @allowed_accounts = nil
       super
       @template_dir ||= File.join(@base_dir, 'templates')
       @allowed_accounts = Array(@allowed_accounts)

--- a/lib/stack_master/stack_definition.rb
+++ b/lib/stack_master/stack_definition.rb
@@ -5,6 +5,7 @@ module StackMaster
                   :template,
                   :tags,
                   :role_arn,
+                  :allowed_accounts,
                   :notification_arns,
                   :base_dir,
                   :template_dir,
@@ -23,8 +24,10 @@ module StackMaster
       @notification_arns = []
       @s3 = {}
       @files = []
+      @allowed_accounts = []
       super
       @template_dir ||= File.join(@base_dir, 'templates')
+      @allowed_accounts = Array(@allowed_accounts)
     end
 
     def ==(other)
@@ -34,6 +37,7 @@ module StackMaster
         @template == other.template &&
         @tags == other.tags &&
         @role_arn == other.role_arn &&
+        @allowed_accounts == other.allowed_accounts &&
         @notification_arns == other.notification_arns &&
         @base_dir == other.base_dir &&
         @secret_file == other.secret_file &&

--- a/spec/fixtures/stack_master.yml
+++ b/spec/fixtures/stack_master.yml
@@ -2,6 +2,8 @@ region_aliases:
   production: us-east-1
   staging: ap-southeast-2
 stack_defaults:
+  allowed_accounts:
+    - '555555555'
   tags:
     application: my-awesome-blog
   s3:

--- a/spec/fixtures/stack_master.yml
+++ b/spec/fixtures/stack_master.yml
@@ -35,6 +35,7 @@ stacks:
       role_arn: test_service_role_arn2
     myapp_web:
       template: myapp_web.rb
+      allowed_accounts: '1234567890'
     myapp_vpc_with_secrets:
       template: myapp_vpc.json
   ap-southeast-2:
@@ -45,5 +46,8 @@ stacks:
       role_arn: test_service_role_arn4
     myapp_web:
       template: myapp_web
+      allowed_accounts:
+        - '1234567890'
+        - '9876543210'
       tags:
         test_override: 2

--- a/spec/stack_master/commands/status_spec.rb
+++ b/spec/stack_master/commands/status_spec.rb
@@ -2,8 +2,8 @@ RSpec.describe StackMaster::Commands::Status do
   subject(:status) { described_class.new(config, false) }
   let(:config) { instance_double(StackMaster::Config, stacks: stacks) }
   let(:stacks) { [stack_definition_1, stack_definition_2] }
-  let(:stack_definition_1) { double(:stack_definition_1, region: 'us-east-1', stack_name: 'stack1') }
-  let(:stack_definition_2) { double(:stack_definition_2, region: 'us-east-1', stack_name: 'stack2', stack_status: 'CREATE_COMPLETE') }
+  let(:stack_definition_1) { double(:stack_definition_1, region: 'us-east-1', stack_name: 'stack1', allowed_accounts: []) }
+  let(:stack_definition_2) { double(:stack_definition_2, region: 'us-east-1', stack_name: 'stack2', stack_status: 'CREATE_COMPLETE', allowed_accounts: []) }
   let(:cf) { Aws::CloudFormation::Client.new(region: 'us-east-1') }
 
   before do
@@ -36,6 +36,35 @@ RSpec.describe StackMaster::Commands::Status do
 
       it "returns the status of call stacks" do
         out = "REGION    | STACK_NAME | STACK_STATUS    | DIFFERENT\n----------|------------|-----------------|----------\nus-east-1 | stack1     | UPDATE_COMPLETE | Yes      \nus-east-1 | stack2     | CREATE_COMPLETE | No       \n * No echo parameters can't be diffed\n"
+        expect { status.perform }.to output(out).to_stdout
+      end
+    end
+
+    context 'when identity account is not allowed' do
+      let(:sts) { Aws::STS::Client.new(stub_responses: true) }
+      let(:stack_definition_1) { double(:stack_definition_1, region: 'us-east-1', stack_name: 'stack1', allowed_accounts: ['not-account-id']) }
+      let(:stack1) { double(:stack1, template_body: '{"foo": "bar"}', template_hash: {foo: 'bar'}, template_format: :json, parameters_with_defaults: {a: 1}, stack_status: 'UPDATE_COMPLETE') }
+      let(:stack2) { double(:stack2, template_body: '{}', template_hash: {}, template_format: :json, parameters_with_defaults: {a: 1}, stack_status: 'CREATE_COMPLETE') }
+      let(:proposed_stack1) { double(:proposed_stack1, template_body: "{}", template_format: :json, parameters_with_defaults: {a: 1}) }
+      let(:proposed_stack2) { double(:proposed_stack2, template_body: "{}", template_format: :json, parameters_with_defaults: {a: 1}) }
+
+      before do
+        allow(Aws::STS::Client).to receive(:new).and_return(sts)
+        sts.stub_responses(:get_caller_identity, {
+          account: 'account-id',
+          arn: 'an-arn',
+          user_id: 'a-user-id'
+        })
+      end
+
+      it 'sets stack status and different fields accordingly' do
+        out = <<~OUTPUT
+          REGION    | STACK_NAME | STACK_STATUS       | DIFFERENT
+          ----------|------------|--------------------|----------
+          us-east-1 | stack1     | Disallowed account | N/A      
+          us-east-1 | stack2     | UPDATE_COMPLETE    | Yes      
+           * No echo parameters can't be diffed
+        OUTPUT
         expect { status.perform }.to output(out).to_stdout
       end
     end

--- a/spec/stack_master/commands/status_spec.rb
+++ b/spec/stack_master/commands/status_spec.rb
@@ -23,7 +23,13 @@ RSpec.describe StackMaster::Commands::Status do
       let(:proposed_stack2) { double(:proposed_stack2, template_body: "{}", template_format: :json, parameters_with_defaults: {a: 1}) }
 
       it "returns the status of call stacks" do
-        out = "REGION    | STACK_NAME | STACK_STATUS    | DIFFERENT\n----------|------------|-----------------|----------\nus-east-1 | stack1     | UPDATE_COMPLETE | No       \nus-east-1 | stack2     | CREATE_COMPLETE | Yes      \n * No echo parameters can't be diffed\n"
+        out = <<~OUTPUT
+          REGION    | STACK_NAME | STACK_STATUS    | DIFFERENT
+          ----------|------------|-----------------|----------
+          us-east-1 | stack1     | UPDATE_COMPLETE | No       
+          us-east-1 | stack2     | CREATE_COMPLETE | Yes      
+           * No echo parameters can't be diffed
+        OUTPUT
         expect { status.perform }.to output(out).to_stdout
       end
     end
@@ -35,7 +41,13 @@ RSpec.describe StackMaster::Commands::Status do
       let(:proposed_stack2) { double(:proposed_stack2, template_body: "{}", template_format: :json, parameters_with_defaults: {a: 1}) }
 
       it "returns the status of call stacks" do
-        out = "REGION    | STACK_NAME | STACK_STATUS    | DIFFERENT\n----------|------------|-----------------|----------\nus-east-1 | stack1     | UPDATE_COMPLETE | Yes      \nus-east-1 | stack2     | CREATE_COMPLETE | No       \n * No echo parameters can't be diffed\n"
+        out = <<~OUTPUT
+          REGION    | STACK_NAME | STACK_STATUS    | DIFFERENT
+          ----------|------------|-----------------|----------
+          us-east-1 | stack1     | UPDATE_COMPLETE | Yes      
+          us-east-1 | stack2     | CREATE_COMPLETE | No       
+           * No echo parameters can't be diffed
+        OUTPUT
         expect { status.perform }.to output(out).to_stdout
       end
     end

--- a/spec/stack_master/commands/status_spec.rb
+++ b/spec/stack_master/commands/status_spec.rb
@@ -79,6 +79,27 @@ RSpec.describe StackMaster::Commands::Status do
         OUTPUT
         expect { status.perform }.to output(out).to_stdout
       end
+
+      context 'when --skip-account-check flag is set' do
+        before do
+          StackMaster.skip_account_check!
+        end
+
+        after do
+          StackMaster.reset_flags
+        end
+
+        it "returns the status of call stacks" do
+          out = <<~OUTPUT
+          REGION    | STACK_NAME | STACK_STATUS    | DIFFERENT
+          ----------|------------|-----------------|----------
+          us-east-1 | stack1     | UPDATE_COMPLETE | Yes      
+          us-east-1 | stack2     | CREATE_COMPLETE | No       
+           * No echo parameters can't be diffed
+          OUTPUT
+          expect { status.perform }.to output(out).to_stdout
+        end
+      end
     end
   end
 

--- a/spec/stack_master/config_spec.rb
+++ b/spec/stack_master/config_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe StackMaster::Config do
       region_alias: 'production',
       stack_name: 'myapp-vpc',
       template: 'myapp_vpc.json',
+      allowed_accounts: ["555555555"],
       tags: { 'application' => 'my-awesome-blog', 'environment' => 'production' },
       s3: { 'bucket' => 'my-bucket', 'region' => 'us-east-1' },
       notification_arns: ['test_arn', 'test_arn_2'],
@@ -81,6 +82,7 @@ RSpec.describe StackMaster::Config do
 
   it 'loads stack defaults' do
     expect(loaded_config.stack_defaults).to eq({
+      'allowed_accounts' => ["555555555"],
       'tags' => { 'application' => 'my-awesome-blog' },
       's3' => { 'bucket' => 'my-bucket', 'region' => 'us-east-1' }
     })
@@ -126,6 +128,7 @@ RSpec.describe StackMaster::Config do
       stack_name: 'myapp-vpc',
       region: 'ap-southeast-2',
       region_alias: 'staging',
+      allowed_accounts: ["555555555"],
       tags: {
         'application' => 'my-awesome-blog',
         'environment' => 'staging',

--- a/spec/stack_master/config_spec.rb
+++ b/spec/stack_master/config_spec.rb
@@ -143,6 +143,7 @@ RSpec.describe StackMaster::Config do
       stack_name: 'myapp-web',
       region: 'ap-southeast-2',
       region_alias: 'staging',
+      allowed_accounts: ["1234567890", "9876543210"],
       tags: {
         'application' => 'my-awesome-blog',
         'environment' => 'staging',

--- a/spec/stack_master/identity_spec.rb
+++ b/spec/stack_master/identity_spec.rb
@@ -1,0 +1,63 @@
+RSpec.describe StackMaster::Identity do
+  let(:sts) { Aws::STS::Client.new(stub_responses: true) }
+  subject(:identity) { StackMaster::Identity.new }
+
+  before do
+    allow(Aws::STS::Client).to receive(:new).and_return(sts)
+  end
+
+  describe '#running_in_allowed_account?' do
+    let(:account) { '1234567890' }
+    let(:running_in_allowed_account) { identity.running_in_allowed_account?(allowed_accounts) }
+
+    before do
+      allow(identity).to receive(:account).and_return(account)
+    end
+
+    context 'when allowed_accounts is nil' do
+      let(:allowed_accounts) { nil }
+
+      it 'returns true' do
+        expect(running_in_allowed_account).to eq(true)
+      end
+    end
+
+    context 'when allowed_accounts is an empty array' do
+      let(:allowed_accounts) { [] }
+
+      it 'returns true' do
+        expect(running_in_allowed_account).to eq(true)
+      end
+    end
+
+    context 'with an allowed account' do
+      let(:allowed_accounts) { [account] }
+
+      it 'returns true' do
+        expect(running_in_allowed_account).to eq(true)
+      end
+    end
+
+    context 'with no allowed account' do
+      let(:allowed_accounts) { ['9876543210'] }
+
+      it 'returns false' do
+        expect(running_in_allowed_account).to eq(false)
+      end
+    end
+  end
+
+  describe '#account' do
+    before do
+      sts.stub_responses(:get_caller_identity, {
+        account: 'account-id',
+        arn: 'an-arn',
+        user_id: 'a-user-id'
+      })
+    end
+
+    it 'returns the current identity account' do
+      expect(identity.account).to eq('account-id')
+    end
+  end
+end


### PR DESCRIPTION
In order to provide extra safety and reduce the risk of applying non-production changes to production, this PR adds the ability to specify which accounts are allowed to work with specific stacks.

The behaviour can be summarised using the following example stack_master.yml file:

```yaml
stack_defaults:
  allowed_accounts: '555555555'
stacks:
  us-east-1:
    myapp-vpc: # inherits allowed account 555555555
      template: myapp_vpc.rb
      tags:
        purpose: front-end
    myapp-db:
      template: myapp_db.rb
      allowed_accounts: # only these accounts
        - '1234567890'
        - '9876543210'
      tags:
        purpose: back-end
    myapp-web:
      template: myapp_web.rb
      allowed_accounts: [] # allow all accounts by overriding stack defaults
      tags:
        purpose: front-end
    myapp-redis:
      template: myapp_redis.rb
      allowed_accounts: '888888888' # only this account
      tags:
        purpose: back-end
```

#### Changes

- Add `allowed_accounts` stack definition property that lists the aws account IDs allowed to work with the stack
- Add a `--skip-account-check` flag to bypass the account checks
- Updated readme