### PR TITLE
Support hashdiff v1

### DIFF
--- a/lib/stack_master/stack_differ.rb
+++ b/lib/stack_master/stack_differ.rb
@@ -75,7 +75,7 @@ module StackMaster
 
     def single_param_update?(param_name)
       return false if param_name.blank? || @current_stack.blank? || body_different?
-      differences = HashDiff.diff(@current_stack.parameters_with_defaults, @proposed_stack.parameters_with_defaults)
+      differences = Hashdiff.diff(@current_stack.parameters_with_defaults, @proposed_stack.parameters_with_defaults)
       return false if differences.count != 1
       diff = differences[0]
       diff[0] == "~" && diff[1] == param_name

--- a/stack_master.gemspec
+++ b/stack_master.gemspec
@@ -56,7 +56,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "deep_merge"
   spec.add_dependency "cfndsl"
   spec.add_dependency "multi_json"
-  spec.add_dependency "hashdiff"
+  spec.add_dependency "hashdiff", "~> 1"
   spec.add_dependency "dotgpg" unless windows_build
   spec.add_dependency "diff-lcs" if windows_build
 end


### PR DESCRIPTION
The hashdiff gem recently changed its module name from `HashDiff` to `Hashdiff` (liufengyun/hashdiff#65). This has [broken the build](https://travis-ci.org/envato/stack_master/builds/560389564). Let's migrate so we can support hashdiff v1.