### PR TITLE
Enable reading the templates from sparkle-packs

### DIFF
--- a/README.md
+++ b/README.md
@@ -588,7 +588,15 @@ end
 
 Note though that if a dynamic with the same name exists in your `templates/dynamics/` directory it will get loaded since it has higher precedence.
 
-Templates can be also loaded from sparkle packs by defining `sparkle_pack_template`. No extension should be added in this case:
+Templates can be also loaded from sparkle packs by defining `sparkle_pack_template`. The name corresponds to the registered symbol rather than specific name. That means for a sparkle pack containing:
+
+```ruby
+SparkleFormation.new(:template_name) do
+  ...
+end
+```
+
+we can use stack defined as follows:
 
 ```yaml
 stacks:

--- a/README.md
+++ b/README.md
@@ -588,6 +588,19 @@ end
 
 Note though that if a dynamic with the same name exists in your `templates/dynamics/` directory it will get loaded since it has higher precedence.
 
+Templates can be also loaded from sparkle packs by defining the compiler option `sparkle_pack_template`. No extension should be added in this case:
+
+```yaml
+stacks:
+  us-east-1
+    my-stack:
+      template: template_name
+      compiler_options:
+        sparkle_packs:
+          - some-sparkle-pack
+        sparkle_pack_template: true
+```
+
 ## Allowed accounts
 
 The AWS account the command is executing in can be restricted to a specific list of allowed accounts. This is useful in reducing the possibility of applying non-production changes in a production account. Each stack definition can specify the `allowed_accounts` property with an array of AWS account IDs the stack is allowed to work with.

--- a/README.md
+++ b/README.md
@@ -570,7 +570,7 @@ stacks:
 
 ```yaml
 stacks:
-  us-east-1
+  us-east-1:
     my-stack:
       template: my-stack-with-dynamic.rb
       compiler_options:
@@ -600,7 +600,7 @@ we can use stack defined as follows:
 
 ```yaml
 stacks:
-  us-east-1
+  us-east-1:
     my-stack:
       sparkle_pack_template: template_name
       compiler_options:

--- a/README.md
+++ b/README.md
@@ -588,17 +588,16 @@ end
 
 Note though that if a dynamic with the same name exists in your `templates/dynamics/` directory it will get loaded since it has higher precedence.
 
-Templates can be also loaded from sparkle packs by defining the compiler option `sparkle_pack_template`. No extension should be added in this case:
+Templates can be also loaded from sparkle packs by defining `sparkle_pack_template`. No extension should be added in this case:
 
 ```yaml
 stacks:
   us-east-1
     my-stack:
-      template: template_name
+      sparkle_pack_template: template_name
       compiler_options:
         sparkle_packs:
           - some-sparkle-pack
-        sparkle_pack_template: true
 ```
 
 ## Allowed accounts

--- a/lib/stack_master/stack.rb
+++ b/lib/stack_master/stack.rb
@@ -65,7 +65,7 @@ module StackMaster
       parameter_hash = ParameterLoader.load(stack_definition.parameter_files)
       template_parameters = ParameterResolver.resolve(config, stack_definition, parameter_hash[:template_parameters])
       compile_time_parameters = ParameterResolver.resolve(config, stack_definition, parameter_hash[:compile_time_parameters])
-      template_body = TemplateCompiler.compile(config, stack_definition.template_file_path, compile_time_parameters, stack_definition.compiler_options)
+      template_body = TemplateCompiler.compile(config, stack_definition, compile_time_parameters, stack_definition.compiler_options)
       template_format = TemplateUtils.identify_template_format(template_body)
       stack_policy_body = if stack_definition.stack_policy_file_path
                             File.read(stack_definition.stack_policy_file_path)

--- a/lib/stack_master/stack.rb
+++ b/lib/stack_master/stack.rb
@@ -65,7 +65,7 @@ module StackMaster
       parameter_hash = ParameterLoader.load(stack_definition.parameter_files)
       template_parameters = ParameterResolver.resolve(config, stack_definition, parameter_hash[:template_parameters])
       compile_time_parameters = ParameterResolver.resolve(config, stack_definition, parameter_hash[:compile_time_parameters])
-      template_body = TemplateCompiler.compile(config, stack_definition, compile_time_parameters, stack_definition.compiler_options)
+      template_body = TemplateCompiler.compile(config, stack_definition.template_dir, stack_definition.template_file_path, stack_definition.sparkle_pack_template, compile_time_parameters, stack_definition.compiler_options)
       template_format = TemplateUtils.identify_template_format(template_body)
       stack_policy_body = if stack_definition.stack_policy_file_path
                             File.read(stack_definition.stack_policy_file_path)

--- a/lib/stack_master/stack_definition.rb
+++ b/lib/stack_master/stack_definition.rb
@@ -3,6 +3,7 @@ module StackMaster
     attr_accessor :region,
                   :stack_name,
                   :template,
+                  :sparkle_pack_template,
                   :tags,
                   :role_arn,
                   :allowed_accounts,
@@ -39,6 +40,7 @@ module StackMaster
         @region == other.region &&
         @stack_name == other.stack_name &&
         @template == other.template &&
+        @sparkle_pack_template == other.sparkle_pack_template &&
         @tags == other.tags &&
         @role_arn == other.role_arn &&
         @allowed_accounts == other.allowed_accounts &&

--- a/lib/stack_master/stack_definition.rb
+++ b/lib/stack_master/stack_definition.rb
@@ -57,6 +57,7 @@ module StackMaster
     end
 
     def template_file_path
+      return unless template
       File.expand_path(File.join(template_dir, template))
     end
 

--- a/lib/stack_master/template_compiler.rb
+++ b/lib/stack_master/template_compiler.rb
@@ -3,13 +3,15 @@ module StackMaster
     TemplateCompilationFailed = Class.new(RuntimeError)
 
     def self.compile(config, stack_definition, compile_time_parameters, compiler_options = {})
-      sparkle_template = compiler_options['sparkle_pack_template']
-      template_file_path = sparkle_template ? stack_definition.template : stack_definition.template_file_path
-      compiler = template_compiler_for_file(stack_definition.template_file_path, config, sparkle_template)
+      compiler = if stack_definition.sparkle_pack_template
+        sparkle_template_compiler(config)
+      else
+        template_compiler_for_file(stack_definition.template_file_path, config)
+      end
       compiler.require_dependencies
-      compiler.compile(template_file_path, compile_time_parameters, compiler_options)
+      compiler.compile(stack_definition, compile_time_parameters, compiler_options)
     rescue StandardError => e
-      raise TemplateCompilationFailed.new("Failed to compile #{template_file_path} with error #{e}.")
+      raise TemplateCompilationFailed.new("Failed to compile #{stack_definition.template_file_path} with error #{e}.\n#{e.backtrace}")
     end
 
     def self.register(name, klass)
@@ -18,9 +20,15 @@ module StackMaster
     end
 
     # private
-    def self.template_compiler_for_file(template_file_path, config, sparkle_template)
-      ext = sparkle_template ? :rb : file_ext(template_file_path)
-      compiler_name = config.template_compilers.fetch(ext)
+    def self.template_compiler_for_file(template_file_path, config)
+      compiler_name = config.template_compilers.fetch(file_ext(template_file_path))
+      @compilers.fetch(compiler_name)
+    end
+    private_class_method :template_compiler_for_file
+
+    # private
+    def self.sparkle_template_compiler(config)
+      compiler_name = config.template_compilers.fetch(:rb)
       @compilers.fetch(compiler_name)
     end
     private_class_method :template_compiler_for_file

--- a/lib/stack_master/template_compiler.rb
+++ b/lib/stack_master/template_compiler.rb
@@ -2,12 +2,12 @@ module StackMaster
   class TemplateCompiler
     TemplateCompilationFailed = Class.new(RuntimeError)
 
-    def self.compile(config, stack_definition, compile_time_parameters, compiler_options = {})
-      compiler = template_compiler_for_stack(stack_definition, config)
+    def self.compile(config, template_dir, template_file_path, sparkle_pack_template, compile_time_parameters, compiler_options = {})
+      compiler = template_compiler_for_stack(template_file_path, sparkle_pack_template, config)
       compiler.require_dependencies
-      compiler.compile(stack_definition, compile_time_parameters, compiler_options)
+      compiler.compile(template_dir, template_file_path, sparkle_pack_template, compile_time_parameters, compiler_options)
     rescue StandardError => e
-      raise TemplateCompilationFailed.new("Failed to compile #{stack_definition.template_file_path} with error #{e}.\n#{e.backtrace}")
+      raise TemplateCompilationFailed.new("Failed to compile #{template_file_path || sparkle_pack_template} with error #{e}.\n#{e.backtrace}")
     end
 
     def self.register(name, klass)
@@ -16,11 +16,11 @@ module StackMaster
     end
 
     # private
-    def self.template_compiler_for_stack(stack_definition, config)
-      ext = if stack_definition.sparkle_pack_template
+    def self.template_compiler_for_stack(template_file_path, sparkle_pack_template, config)
+      ext = if sparkle_pack_template
         :rb
       else
-        file_ext(stack_definition.template_file_path)
+        file_ext(template_file_path)
       end
       compiler_name = config.template_compilers.fetch(ext)
       @compilers.fetch(compiler_name)

--- a/lib/stack_master/template_compiler.rb
+++ b/lib/stack_master/template_compiler.rb
@@ -9,7 +9,7 @@ module StackMaster
       compiler.require_dependencies
       compiler.compile(template_file_path, compile_time_parameters, compiler_options)
     rescue StandardError => e
-      raise TemplateCompilationFailed.new("Failed to compile #{template_file_path} with error #{e}.\n#{e.backtrace}")
+      raise TemplateCompilationFailed.new("Failed to compile #{template_file_path} with error #{e}.")
     end
 
     def self.register(name, klass)

--- a/lib/stack_master/template_compiler.rb
+++ b/lib/stack_master/template_compiler.rb
@@ -3,11 +3,7 @@ module StackMaster
     TemplateCompilationFailed = Class.new(RuntimeError)
 
     def self.compile(config, stack_definition, compile_time_parameters, compiler_options = {})
-      compiler = if stack_definition.sparkle_pack_template
-        sparkle_template_compiler(config)
-      else
-        template_compiler_for_file(stack_definition.template_file_path, config)
-      end
+      compiler = template_compiler_for_stack(stack_definition, config)
       compiler.require_dependencies
       compiler.compile(stack_definition, compile_time_parameters, compiler_options)
     rescue StandardError => e
@@ -20,18 +16,16 @@ module StackMaster
     end
 
     # private
-    def self.template_compiler_for_file(template_file_path, config)
-      compiler_name = config.template_compilers.fetch(file_ext(template_file_path))
+    def self.template_compiler_for_stack(stack_definition, config)
+      ext = if stack_definition.sparkle_pack_template
+        :rb
+      else
+        file_ext(stack_definition.template_file_path)
+      end
+      compiler_name = config.template_compilers.fetch(ext)
       @compilers.fetch(compiler_name)
     end
-    private_class_method :template_compiler_for_file
-
-    # private
-    def self.sparkle_template_compiler(config)
-      compiler_name = config.template_compilers.fetch(:rb)
-      @compilers.fetch(compiler_name)
-    end
-    private_class_method :sparkle_template_compiler
+    private_class_method :template_compiler_for_stack
 
     def self.file_ext(template_file_path)
       File.extname(template_file_path).gsub('.', '').to_sym

--- a/lib/stack_master/template_compiler.rb
+++ b/lib/stack_master/template_compiler.rb
@@ -2,8 +2,10 @@ module StackMaster
   class TemplateCompiler
     TemplateCompilationFailed = Class.new(RuntimeError)
 
-    def self.compile(config, template_file_path, compile_time_parameters, compiler_options = {})
-      compiler = template_compiler_for_file(template_file_path, config)
+    def self.compile(config, stack_definition, compile_time_parameters, compiler_options = {})
+      sparkle_template = compiler_options['sparkle_pack_template']
+      template_file_path = sparkle_template ? stack_definition.template : stack_definition.template_file_path
+      compiler = template_compiler_for_file(stack_definition.template_file_path, config, sparkle_template)
       compiler.require_dependencies
       compiler.compile(template_file_path, compile_time_parameters, compiler_options)
     rescue StandardError => e
@@ -16,8 +18,9 @@ module StackMaster
     end
 
     # private
-    def self.template_compiler_for_file(template_file_path, config)
-      compiler_name = config.template_compilers.fetch(file_ext(template_file_path))
+    def self.template_compiler_for_file(template_file_path, config, sparkle_template)
+      ext = sparkle_template ? :rb : file_ext(template_file_path)
+      compiler_name = config.template_compilers.fetch(ext)
       @compilers.fetch(compiler_name)
     end
     private_class_method :template_compiler_for_file

--- a/lib/stack_master/template_compiler.rb
+++ b/lib/stack_master/template_compiler.rb
@@ -31,7 +31,7 @@ module StackMaster
       compiler_name = config.template_compilers.fetch(:rb)
       @compilers.fetch(compiler_name)
     end
-    private_class_method :template_compiler_for_file
+    private_class_method :sparkle_template_compiler
 
     def self.file_ext(template_file_path)
       File.extname(template_file_path).gsub('.', '').to_sym

--- a/lib/stack_master/template_compilers/cfndsl.rb
+++ b/lib/stack_master/template_compilers/cfndsl.rb
@@ -4,11 +4,11 @@ module StackMaster::TemplateCompilers
       require 'cfndsl'
     end
 
-    def self.compile(template_file_path, compile_time_parameters, _compiler_options = {})
+    def self.compile(stack_definition, compile_time_parameters, _compiler_options = {})
       CfnDsl.disable_binding
       CfnDsl::ExternalParameters.defaults.clear # Ensure there's no leakage across invocations
       CfnDsl::ExternalParameters.defaults(compile_time_parameters.symbolize_keys)
-      ::CfnDsl.eval_file_with_extras(template_file_path).to_json
+      ::CfnDsl.eval_file_with_extras(stack_definition.template_file_path).to_json
     end
 
     StackMaster::TemplateCompiler.register(:cfndsl, self)

--- a/lib/stack_master/template_compilers/cfndsl.rb
+++ b/lib/stack_master/template_compilers/cfndsl.rb
@@ -4,11 +4,11 @@ module StackMaster::TemplateCompilers
       require 'cfndsl'
     end
 
-    def self.compile(stack_definition, compile_time_parameters, _compiler_options = {})
+    def self.compile(_template_dir, template_file_path, _sparkle_pack_template, compile_time_parameters, _compiler_options = {})
       CfnDsl.disable_binding
       CfnDsl::ExternalParameters.defaults.clear # Ensure there's no leakage across invocations
       CfnDsl::ExternalParameters.defaults(compile_time_parameters.symbolize_keys)
-      ::CfnDsl.eval_file_with_extras(stack_definition.template_file_path).to_json
+      ::CfnDsl.eval_file_with_extras(template_file_path).to_json
     end
 
     StackMaster::TemplateCompiler.register(:cfndsl, self)

--- a/lib/stack_master/template_compilers/json.rb
+++ b/lib/stack_master/template_compilers/json.rb
@@ -7,8 +7,8 @@ module StackMaster::TemplateCompilers
       require 'json'
     end
 
-    def self.compile(stack_definition, _compile_time_parameters, _compiler_options = {})
-      template_body = File.read(stack_definition.template_file_path)
+    def self.compile(_template_dir, template_file_path, _sparkle_pack_template, _compile_time_parameters, _compiler_options = {})
+      template_body = File.read(template_file_path)
       if template_body.size > MAX_TEMPLATE_SIZE
         # Parse the json and rewrite compressed
         JSON.dump(JSON.parse(template_body))

--- a/lib/stack_master/template_compilers/json.rb
+++ b/lib/stack_master/template_compilers/json.rb
@@ -7,8 +7,8 @@ module StackMaster::TemplateCompilers
       require 'json'
     end
 
-    def self.compile(template_file_path, _compile_time_parameters, _compiler_options = {})
-      template_body = File.read(template_file_path)
+    def self.compile(stack_definition, _compile_time_parameters, _compiler_options = {})
+      template_body = File.read(stack_definition.template_file_path)
       if template_body.size > MAX_TEMPLATE_SIZE
         # Parse the json and rewrite compressed
         JSON.dump(JSON.parse(template_body))

--- a/lib/stack_master/template_compilers/sparkle_formation.rb
+++ b/lib/stack_master/template_compilers/sparkle_formation.rb
@@ -28,13 +28,18 @@ module StackMaster::TemplateCompilers
     private
 
     def self.compile_sparkle_template(stack_definition, compiler_options)
-      sparkle_path = compiler_options['sparkle_path'] ?
-                        File.expand_path(compiler_options['sparkle_path']) : File.dirname(stack_definition.template_file_path)
+      sparkle_path = if compiler_options['sparkle_path']
+        File.expand_path(compiler_options['sparkle_path'])
+      else
+        stack_definition.template_dir
+      end
 
       collection = ::SparkleFormation::SparkleCollection.new
+      puts(collection.inspect)
       root_pack = ::SparkleFormation::Sparkle.new(
         :root => sparkle_path,
       )
+      puts(root_pack.inspect)
       collection.set_root(root_pack)
       if compiler_options['sparkle_packs']
         compiler_options['sparkle_packs'].each do |pack_name|

--- a/lib/stack_master/template_compilers/sparkle_formation.rb
+++ b/lib/stack_master/template_compilers/sparkle_formation.rb
@@ -12,8 +12,8 @@ module StackMaster::TemplateCompilers
       require 'stack_master/sparkle_formation/template_file'
     end
 
-    def self.compile(stack_definition, compile_time_parameters, compiler_options = {})
-      sparkle_template = compile_sparkle_template(stack_definition, compiler_options)
+    def self.compile(template_dir, template_file_path, sparkle_pack_template, compile_time_parameters, compiler_options = {})
+      sparkle_template = compile_sparkle_template(template_dir, template_file_path, sparkle_pack_template, compiler_options)
       definitions = sparkle_template.parameters
       validate_definitions(definitions)
       validate_parameters(definitions, compile_time_parameters)
@@ -27,11 +27,11 @@ module StackMaster::TemplateCompilers
 
     private
 
-    def self.compile_sparkle_template(stack_definition, compiler_options)
+    def self.compile_sparkle_template(template_dir, template_file_path, sparkle_pack_template, compiler_options)
       sparkle_path = if compiler_options['sparkle_path']
         File.expand_path(compiler_options['sparkle_path'])
       else
-        stack_definition.template_dir
+        template_dir
       end
 
       collection = ::SparkleFormation::SparkleCollection.new
@@ -47,11 +47,9 @@ module StackMaster::TemplateCompilers
         end
       end
 
-      if template_name = stack_definition.sparkle_pack_template
-        raise ArgumentError.new("Template #{template_name} not found in any sparkle pack") unless collection.templates['aws'].include? template_name
-        template_file_path = collection.templates['aws'][template_name].top['path']
-      else
-        template_file_path = stack_definition.template_file_path
+      if sparkle_pack_template
+        raise ArgumentError.new("Template #{sparkle_pack_template} not found in any sparkle pack") unless collection.templates['aws'].include? sparkle_pack_template
+        template_file_path = collection.templates['aws'][sparkle_pack_template].top['path']
       end
 
       sparkle_template = compile_template_with_sparkle_path(template_file_path, sparkle_path)

--- a/lib/stack_master/template_compilers/sparkle_formation.rb
+++ b/lib/stack_master/template_compilers/sparkle_formation.rb
@@ -35,11 +35,9 @@ module StackMaster::TemplateCompilers
       end
 
       collection = ::SparkleFormation::SparkleCollection.new
-      puts(collection.inspect)
       root_pack = ::SparkleFormation::Sparkle.new(
         :root => sparkle_path,
       )
-      puts(root_pack.inspect)
       collection.set_root(root_pack)
       if compiler_options['sparkle_packs']
         compiler_options['sparkle_packs'].each do |pack_name|

--- a/lib/stack_master/template_compilers/sparkle_formation.rb
+++ b/lib/stack_master/template_compilers/sparkle_formation.rb
@@ -44,6 +44,12 @@ module StackMaster::TemplateCompilers
         end
       end
 
+      # update path if the template comes from an imported sparkle pack
+      if compiler_options['sparkle_pack_template']
+        raise ArgumentError.new("Template #{template_file_path} not found in any sparkle pack") unless collection.templates['aws'].include? template_file_path
+        template_file_path = collection.templates['aws'][template_file_path].top['path']
+      end
+
       sparkle_template = compile_template_with_sparkle_path(template_file_path, sparkle_path)
       sparkle_template.sparkle.apply(collection)
       sparkle_template

--- a/lib/stack_master/template_compilers/yaml.rb
+++ b/lib/stack_master/template_compilers/yaml.rb
@@ -5,8 +5,8 @@ module StackMaster::TemplateCompilers
       require 'json'
     end
 
-    def self.compile(template_file_path, _compile_time_parameters, _compiler_options = {})
-      File.read(template_file_path)
+    def self.compile(stack_definition, _compile_time_parameters, _compiler_options = {})
+      File.read(stack_definition.template_file_path)
     end
 
     StackMaster::TemplateCompiler.register(:yaml, self)

--- a/lib/stack_master/template_compilers/yaml.rb
+++ b/lib/stack_master/template_compilers/yaml.rb
@@ -5,8 +5,8 @@ module StackMaster::TemplateCompilers
       require 'json'
     end
 
-    def self.compile(stack_definition, _compile_time_parameters, _compiler_options = {})
-      File.read(stack_definition.template_file_path)
+    def self.compile(_template_dir, template_file_path, _sparkle_pack_template, _compile_time_parameters, _compiler_options = {})
+      File.read(template_file_path)
     end
 
     StackMaster::TemplateCompiler.register(:yaml, self)

--- a/lib/stack_master/validator.rb
+++ b/lib/stack_master/validator.rb
@@ -14,7 +14,7 @@ module StackMaster
       compile_time_parameters = ParameterResolver.resolve(@config, @stack_definition, parameter_hash[:compile_time_parameters])
 
       StackMaster.stdout.print "#{@stack_definition.stack_name}: "
-      template_body = TemplateCompiler.compile(@config, @stack_definition.template_file_path, compile_time_parameters, @stack_definition.compiler_options)
+      template_body = TemplateCompiler.compile(@config, @stack_definition, compile_time_parameters, @stack_definition.compiler_options)
       cf.validate_template(template_body: TemplateUtils.maybe_compressed_template_body(template_body))
       StackMaster.stdout.puts "valid"
       true

--- a/lib/stack_master/validator.rb
+++ b/lib/stack_master/validator.rb
@@ -14,7 +14,7 @@ module StackMaster
       compile_time_parameters = ParameterResolver.resolve(@config, @stack_definition, parameter_hash[:compile_time_parameters])
 
       StackMaster.stdout.print "#{@stack_definition.stack_name}: "
-      template_body = TemplateCompiler.compile(@config, @stack_definition, compile_time_parameters, @stack_definition.compiler_options)
+      template_body = TemplateCompiler.compile(@config, @stack_definition.template_dir, @stack_definition.template_file_path, @stack_definition.sparkle_pack_template, compile_time_parameters, @stack_definition.compiler_options)
       cf.validate_template(template_body: TemplateUtils.maybe_compressed_template_body(template_body))
       StackMaster.stdout.puts "valid"
       true

--- a/spec/stack_master/stack_spec.rb
+++ b/spec/stack_master/stack_spec.rb
@@ -89,7 +89,14 @@ RSpec.describe StackMaster::Stack do
       allow(StackMaster::ParameterLoader).to receive(:load).and_return(parameter_hash)
       allow(StackMaster::ParameterResolver).to receive(:resolve).with(config,stack_definition,parameter_hash[:template_parameters]).and_return(resolved_template_parameters)
       allow(StackMaster::ParameterResolver).to receive(:resolve).with(config,stack_definition,parameter_hash[:compile_time_parameters]).and_return(resolved_compile_time_parameters)
-      allow(StackMaster::TemplateCompiler).to receive(:compile).with(config, stack_definition, resolved_compile_time_parameters, stack_definition.compiler_options).and_return(template_body)
+      allow(StackMaster::TemplateCompiler).to receive(:compile).with(
+        config,
+        stack_definition.template_dir,
+        stack_definition.template_file_path,
+        stack_definition.sparkle_pack_template,
+        resolved_compile_time_parameters,
+        stack_definition.compiler_options
+      ).and_return(template_body)
       allow(File).to receive(:read).with(stack_definition.stack_policy_file_path).and_return(stack_policy_body)
     end
 

--- a/spec/stack_master/stack_spec.rb
+++ b/spec/stack_master/stack_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe StackMaster::Stack do
       allow(StackMaster::ParameterLoader).to receive(:load).and_return(parameter_hash)
       allow(StackMaster::ParameterResolver).to receive(:resolve).with(config,stack_definition,parameter_hash[:template_parameters]).and_return(resolved_template_parameters)
       allow(StackMaster::ParameterResolver).to receive(:resolve).with(config,stack_definition,parameter_hash[:compile_time_parameters]).and_return(resolved_compile_time_parameters)
-      allow(StackMaster::TemplateCompiler).to receive(:compile).with(config, stack_definition.template_file_path, resolved_compile_time_parameters, stack_definition.compiler_options).and_return(template_body)
+      allow(StackMaster::TemplateCompiler).to receive(:compile).with(config, stack_definition, resolved_compile_time_parameters, stack_definition.compiler_options).and_return(template_body)
       allow(File).to receive(:read).with(stack_definition.stack_policy_file_path).and_return(stack_policy_body)
     end
 

--- a/spec/stack_master/template_compiler_spec.rb
+++ b/spec/stack_master/template_compiler_spec.rb
@@ -1,16 +1,19 @@
 RSpec.describe StackMaster::TemplateCompiler do
   describe '.compile' do
     let(:config) { double(template_compilers: { fab: :test_template_compiler, rb: :test_template_compiler }) }
+    let(:template_file_path) { '/base_dir/templates/template.fab' }
+    let(:template_dir) { File.dirname(template_file_path) }
     let(:stack_definition) {
       instance_double(StackMaster::StackDefinition,
-        template_file_path: '/base_dir/templates/template.fab',
-        sparkle_pack_template: nil)
+        template_file_path: template_file_path,
+        template_dir: template_dir,
+        )
     }
     let(:compile_time_parameters) { { 'InstanceType' => 't2.medium' } }
 
     class TestTemplateCompiler
       def self.require_dependencies; end
-      def self.compile(stack_definition, compile_time_parameters, compile_options); end
+      def self.compile(template_dir, template_file_path, sparkle_pack_template, compile_time_parameters, compile_options); end
     end
 
     context 'when a template compiler is registered for the given file type' do
@@ -19,21 +22,21 @@ RSpec.describe StackMaster::TemplateCompiler do
       }
 
       it 'compiles the template using the relevant template compiler' do
-        expect(TestTemplateCompiler).to receive(:compile).with(stack_definition, compile_time_parameters, anything)
-        StackMaster::TemplateCompiler.compile(config, stack_definition, compile_time_parameters, compile_time_parameters)
+        expect(TestTemplateCompiler).to receive(:compile).with(nil, template_file_path, nil, compile_time_parameters, anything)
+        StackMaster::TemplateCompiler.compile(config, nil, template_file_path, nil, compile_time_parameters, compile_time_parameters)
       end
 
       it 'passes compile_options to the template compiler' do
         opts = {foo: 1, bar: true, baz: "meh"}
-        expect(TestTemplateCompiler).to receive(:compile).with(stack_definition, compile_time_parameters, opts)
-        StackMaster::TemplateCompiler.compile(config, stack_definition, compile_time_parameters,opts)
+        expect(TestTemplateCompiler).to receive(:compile).with(nil, template_file_path, nil, compile_time_parameters, opts)
+        StackMaster::TemplateCompiler.compile(config, nil, template_file_path, nil, compile_time_parameters,opts)
       end
 
       context 'when template compilation fails' do
         before { allow(TestTemplateCompiler).to receive(:compile).and_raise(RuntimeError) }
 
         it 'raise TemplateCompilationFailed exception' do
-          expect{ StackMaster::TemplateCompiler.compile(config, stack_definition, compile_time_parameters, compile_time_parameters)
+          expect{ StackMaster::TemplateCompiler.compile(config, template_dir, template_file_path, nil, compile_time_parameters, compile_time_parameters)
           }.to raise_error(
                  StackMaster::TemplateCompiler::TemplateCompilationFailed, /^Failed to compile #{stack_definition.template_file_path}/)
         end
@@ -43,16 +46,18 @@ RSpec.describe StackMaster::TemplateCompiler do
     context 'when a sparkle pack template is being requested' do
       let(:stack_definition) {
         instance_double(StackMaster::StackDefinition,
-          sparkle_pack_template: 'foobar')
+          sparkle_pack_template: template_name)
       }
+      let(:template_name) { 'foobar' }
+      let(:template_dir) { '/base_dir/templates' }
 
       before {
         StackMaster::TemplateCompiler.register(:test_template_compiler, TestTemplateCompiler)
       }
 
       it 'compiles the template using the sparkle pack compiler' do
-        expect(TestTemplateCompiler).to receive(:compile).with(stack_definition, compile_time_parameters, anything)
-        StackMaster::TemplateCompiler.compile(config, stack_definition, compile_time_parameters, compile_time_parameters)
+        expect(TestTemplateCompiler).to receive(:compile).with(template_dir, nil, template_name, compile_time_parameters, anything)
+        StackMaster::TemplateCompiler.compile(config, template_dir, nil, template_name, compile_time_parameters, compile_time_parameters)
       end
     end
   end

--- a/spec/stack_master/template_compiler_spec.rb
+++ b/spec/stack_master/template_compiler_spec.rb
@@ -1,7 +1,11 @@
 RSpec.describe StackMaster::TemplateCompiler do
   describe '.compile' do
     let(:config) { double(template_compilers: { fab: :test_template_compiler }) }
-    let(:stack_definition) { instance_double(StackMaster::StackDefinition, template_file_path: '/base_dir/templates/template.fab') }
+    let(:stack_definition) {
+      instance_double(StackMaster::StackDefinition,
+        template_file_path: '/base_dir/templates/template.fab',
+        sparkle_pack_template: nil)
+    }
     let(:compile_time_parameters) { { 'InstanceType' => 't2.medium' } }
 
     class TestTemplateCompiler
@@ -15,13 +19,13 @@ RSpec.describe StackMaster::TemplateCompiler do
       }
 
       it 'compiles the template using the relevant template compiler' do
-        expect(TestTemplateCompiler).to receive(:compile).with(stack_definition.template_file_path, compile_time_parameters, anything)
+        expect(TestTemplateCompiler).to receive(:compile).with(stack_definition, compile_time_parameters, anything)
         StackMaster::TemplateCompiler.compile(config, stack_definition, compile_time_parameters, compile_time_parameters)
       end
 
       it 'passes compile_options to the template compiler' do
         opts = {foo: 1, bar: true, baz: "meh"}
-        expect(TestTemplateCompiler).to receive(:compile).with(stack_definition.template_file_path, compile_time_parameters, opts)
+        expect(TestTemplateCompiler).to receive(:compile).with(stack_definition, compile_time_parameters, opts)
         StackMaster::TemplateCompiler.compile(config, stack_definition, compile_time_parameters,opts)
       end
 

--- a/spec/stack_master/template_compiler_spec.rb
+++ b/spec/stack_master/template_compiler_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe StackMaster::TemplateCompiler do
   describe '.compile' do
-    let(:config) { double(template_compilers: { fab: :test_template_compiler }) }
+    let(:config) { double(template_compilers: { fab: :test_template_compiler, rb: :test_template_compiler }) }
     let(:stack_definition) {
       instance_double(StackMaster::StackDefinition,
         template_file_path: '/base_dir/templates/template.fab',
@@ -37,6 +37,22 @@ RSpec.describe StackMaster::TemplateCompiler do
           }.to raise_error(
                  StackMaster::TemplateCompiler::TemplateCompilationFailed, /^Failed to compile #{stack_definition.template_file_path}/)
         end
+      end
+    end
+
+    context 'when a sparkle pack template is being requested' do
+      let(:stack_definition) {
+        instance_double(StackMaster::StackDefinition,
+          sparkle_pack_template: 'foobar')
+      }
+
+      before {
+        StackMaster::TemplateCompiler.register(:test_template_compiler, TestTemplateCompiler)
+      }
+
+      it 'compiles the template using the sparkle pack compiler' do
+        expect(TestTemplateCompiler).to receive(:compile).with(stack_definition, compile_time_parameters, anything)
+        StackMaster::TemplateCompiler.compile(config, stack_definition, compile_time_parameters, compile_time_parameters)
       end
     end
   end

--- a/spec/stack_master/template_compiler_spec.rb
+++ b/spec/stack_master/template_compiler_spec.rb
@@ -1,12 +1,12 @@
 RSpec.describe StackMaster::TemplateCompiler do
   describe '.compile' do
     let(:config) { double(template_compilers: { fab: :test_template_compiler }) }
-    let(:template_file_path) { '/base_dir/templates/template.fab' }
+    let(:stack_definition) { instance_double(StackMaster::StackDefinition, template_file_path: '/base_dir/templates/template.fab') }
     let(:compile_time_parameters) { { 'InstanceType' => 't2.medium' } }
 
     class TestTemplateCompiler
       def self.require_dependencies; end
-      def self.compile(template_file_path, compile_time_parameters, compile_options); end
+      def self.compile(stack_definition, compile_time_parameters, compile_options); end
     end
 
     context 'when a template compiler is registered for the given file type' do
@@ -15,23 +15,23 @@ RSpec.describe StackMaster::TemplateCompiler do
       }
 
       it 'compiles the template using the relevant template compiler' do
-        expect(TestTemplateCompiler).to receive(:compile).with(template_file_path, compile_time_parameters, anything)
-        StackMaster::TemplateCompiler.compile(config, template_file_path, compile_time_parameters, compile_time_parameters)
+        expect(TestTemplateCompiler).to receive(:compile).with(stack_definition.template_file_path, compile_time_parameters, anything)
+        StackMaster::TemplateCompiler.compile(config, stack_definition, compile_time_parameters, compile_time_parameters)
       end
 
       it 'passes compile_options to the template compiler' do
         opts = {foo: 1, bar: true, baz: "meh"}
-        expect(TestTemplateCompiler).to receive(:compile).with(template_file_path, compile_time_parameters, opts)
-        StackMaster::TemplateCompiler.compile(config, template_file_path, compile_time_parameters,opts)
+        expect(TestTemplateCompiler).to receive(:compile).with(stack_definition.template_file_path, compile_time_parameters, opts)
+        StackMaster::TemplateCompiler.compile(config, stack_definition, compile_time_parameters,opts)
       end
 
       context 'when template compilation fails' do
         before { allow(TestTemplateCompiler).to receive(:compile).and_raise(RuntimeError) }
 
         it 'raise TemplateCompilationFailed exception' do
-          expect{ StackMaster::TemplateCompiler.compile(config, template_file_path, compile_time_parameters, compile_time_parameters)
+          expect{ StackMaster::TemplateCompiler.compile(config, stack_definition, compile_time_parameters, compile_time_parameters)
           }.to raise_error(
-                 StackMaster::TemplateCompiler::TemplateCompilationFailed, /^Failed to compile #{template_file_path}/)
+                 StackMaster::TemplateCompiler::TemplateCompilationFailed, /^Failed to compile #{stack_definition.template_file_path}/)
         end
       end
     end

--- a/spec/stack_master/template_compilers/cfndsl_spec.rb
+++ b/spec/stack_master/template_compilers/cfndsl_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe StackMaster::TemplateCompilers::Cfndsl do
   describe '.compile' do
     let(:stack_definition) { instance_double(StackMaster::StackDefinition, template_file_path: template_file_path) }
     def compile
-      described_class.compile(stack_definition, compile_time_parameters)
+      described_class.compile(nil, stack_definition.template_file_path, nil, compile_time_parameters)
     end
 
     context 'valid cfndsl template' do

--- a/spec/stack_master/template_compilers/cfndsl_spec.rb
+++ b/spec/stack_master/template_compilers/cfndsl_spec.rb
@@ -5,8 +5,9 @@ RSpec.describe StackMaster::TemplateCompilers::Cfndsl do
   before(:all) { described_class.require_dependencies }
 
   describe '.compile' do
+    let(:stack_definition) { instance_double(StackMaster::StackDefinition, template_file_path: template_file_path) }
     def compile
-      described_class.compile(template_file_path, compile_time_parameters)
+      described_class.compile(stack_definition, compile_time_parameters)
     end
 
     context 'valid cfndsl template' do

--- a/spec/stack_master/template_compilers/json_spec.rb
+++ b/spec/stack_master/template_compilers/json_spec.rb
@@ -4,9 +4,10 @@ RSpec.describe StackMaster::TemplateCompilers::Json do
 
   describe '.compile' do
     def compile
-      described_class.compile(template_file_path, compile_time_parameters)
+      described_class.compile(stack_definition, compile_time_parameters)
     end
 
+    let(:stack_definition) { instance_double(StackMaster::StackDefinition, template_file_path: template_file_path) }
     let(:template_file_path) { '/base_dir/templates/template.json' }
 
     context "small json template" do

--- a/spec/stack_master/template_compilers/json_spec.rb
+++ b/spec/stack_master/template_compilers/json_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe StackMaster::TemplateCompilers::Json do
 
   describe '.compile' do
     def compile
-      described_class.compile(stack_definition, compile_time_parameters)
+      described_class.compile(nil, template_file_path, nil, compile_time_parameters)
     end
 
     let(:stack_definition) { instance_double(StackMaster::StackDefinition, template_file_path: template_file_path) }

--- a/spec/stack_master/template_compilers/sparkle_formation_spec.rb
+++ b/spec/stack_master/template_compilers/sparkle_formation_spec.rb
@@ -2,9 +2,14 @@ RSpec.describe StackMaster::TemplateCompilers::SparkleFormation do
 
   describe '.compile' do
     def compile
-      described_class.compile(template_file_path, compile_time_parameters, compiler_options)
+      described_class.compile(stack_definition, compile_time_parameters, compiler_options)
     end
 
+    let(:stack_definition) {
+      instance_double(StackMaster::StackDefinition,
+        template_file_path: template_file_path,
+        sparkle_pack_template: nil)
+    }
     let(:template_file_path) { '/base_dir/templates/template.rb' }
     let(:compile_time_parameters) { {'Ip' => '10.0.0.0', 'Name' => 'Something'} }
     let(:compiler_options) { {} }
@@ -87,7 +92,12 @@ RSpec.describe StackMaster::TemplateCompilers::SparkleFormation do
 
   describe '.compile with sparkle packs' do
     let(:compile_time_parameters) { {} }
-    subject(:compile) { described_class.compile(template_file_path, compile_time_parameters, compiler_options)}
+    let(:stack_definition) {
+      instance_double(StackMaster::StackDefinition,
+        template_file_path: template_file_path,
+        sparkle_pack_template: nil)
+    }
+    subject(:compile) { described_class.compile(stack_definition, compile_time_parameters, compiler_options)}
 
     context 'with a sparkle_pack loaded' do
       let(:template_file_path) { File.join(File.dirname(__FILE__), "..", "..", "fixtures", "sparkle_pack_integration", "templates", "template_with_dynamic_from_pack.rb")}

--- a/spec/stack_master/template_compilers/sparkle_formation_spec.rb
+++ b/spec/stack_master/template_compilers/sparkle_formation_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe StackMaster::TemplateCompilers::SparkleFormation do
 
   describe '.compile' do
     def compile
-      described_class.compile(stack_definition, compile_time_parameters, compiler_options)
+      described_class.compile(template_dir, template_file_path, nil, compile_time_parameters, compiler_options)
     end
 
     let(:stack_definition) {
@@ -25,6 +25,7 @@ RSpec.describe StackMaster::TemplateCompilers::SparkleFormation do
         sparkle_pack_template: nil)
     }
     let(:template_file_path) { '/base_dir/templates/template.rb' }
+    let(:template_dir) { File.dirname(template_file_path) }
     let(:compile_time_parameters) { {'Ip' => '10.0.0.0', 'Name' => 'Something'} }
     let(:compiler_options) { {} }
 
@@ -103,7 +104,7 @@ RSpec.describe StackMaster::TemplateCompilers::SparkleFormation do
         template_dir: File.dirname(template_file_path),
         sparkle_pack_template: nil)
     }
-    subject(:compile) { described_class.compile(stack_definition, compile_time_parameters, compiler_options)}
+    subject(:compile) { described_class.compile(stack_definition.template_dir, stack_definition.template_file_path, stack_definition.sparkle_pack_template, compile_time_parameters, compiler_options)}
 
     context 'with a sparkle_pack loaded' do
       let(:template_file_path) { File.join(File.dirname(__FILE__), "..", "..", "fixtures", "sparkle_pack_integration", "templates", "template_with_dynamic_from_pack.rb")}

--- a/spec/stack_master/template_compilers/yaml_spec.rb
+++ b/spec/stack_master/template_compilers/yaml_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe StackMaster::TemplateCompilers::Yaml do
     let(:compile_time_parameters) { {'InstanceType' => 't2.medium'} }
 
     def compile
-      described_class.compile(stack_definition, compile_time_parameters)
+      described_class.compile(nil, stack_definition.template_file_path, nil, compile_time_parameters)
     end
 
     context 'valid YAML template' do

--- a/spec/stack_master/template_compilers/yaml_spec.rb
+++ b/spec/stack_master/template_compilers/yaml_spec.rb
@@ -4,14 +4,15 @@ RSpec.describe StackMaster::TemplateCompilers::Yaml do
     let(:compile_time_parameters) { {'InstanceType' => 't2.medium'} }
 
     def compile
-      described_class.compile(template_file_path, compile_time_parameters)
+      described_class.compile(stack_definition, compile_time_parameters)
     end
 
     context 'valid YAML template' do
+      let(:stack_definition) { instance_double(StackMaster::StackDefinition, template_file_path: template_file_path) }
       let(:template_file_path) { 'spec/fixtures/templates/yml/valid_myapp_vpc.yml' }
 
       it 'produces valid YAML' do
-        valid_myapp_vpc_yaml = File.read('spec/fixtures/templates/yml/valid_myapp_vpc.yml')
+        valid_myapp_vpc_yaml = File.read(template_file_path)
 
         expect(compile).to eq(valid_myapp_vpc_yaml)
       end


### PR DESCRIPTION
Use a separate compiler option to specify where we should look for the
template.