### PR TITLE
Make the ctrl-c test more explicit

### DIFF
--- a/spec/stack_master/commands/apply_spec.rb
+++ b/spec/stack_master/commands/apply_spec.rb
@@ -249,7 +249,7 @@ RSpec.describe StackMaster::Commands::Apply do
 
       it "deletes the stack" do
         expect(cf).to receive(:delete_stack).with(stack_name: stack_name)
-        expect { apply }.to raise_error
+        expect { apply }.to raise_error(StackMaster::CtrlC)
       end
     end
   end


### PR DESCRIPTION
Also removes a warning about potential false-positives.