### PR TITLE
Add a Troubleshooting section and add service-linked roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -705,9 +705,6 @@ aws iam create-service-linked-role --aws-service-name es.amazonaws.com
 
 This command will change depending on the aws service which is having issues.
 
-
-
-
 ## Maintainers
 
 - [Steve Hodgkiss](https://github.com/stevehodgkiss)

--- a/README.md
+++ b/README.md
@@ -685,6 +685,29 @@ Demo:
 
 ![Apply Demo](/apply_demo.gif?raw=true)
 
+## Troubleshooting
+
+### Service-linked Roles
+
+When applying a stack and you see a message like:
+
+```
+AWS::Elasticsearch::Domain CREATE_FAILED Before you can proceed, you must enable a service-linked role to give Amazon ES permissions to access your VPC. (Service: AWSElasticsearch; Status Code: 400; Error Code: ValidationException; Request ID: xxx)
+```
+
+It means that you need to create a service-linked role for AWS to have the correct permissions. This is not handled within code and only requires a single aws cli command to be run on the aws account.
+
+eg. To create a service-linked role to resolve the above error:
+
+```
+aws iam create-service-linked-role --aws-service-name es.amazonaws.com
+```
+
+This command will change depending on the aws service which is having issues.
+
+
+
+
 ## Maintainers
 
 - [Steve Hodgkiss](https://github.com/stevehodgkiss)


### PR DESCRIPTION
Recently I had an issue when applying a stack. This is due to our aws account not having the necessary service-linked role allowing aws to make changes from one service to another.

I have started a Troubleshooting guide here to feature things like this. This seems like the best place to put it because it will usually happen when you're using stack_master. 