### PR TITLE
Use correct ejson file name in error message

### DIFF
--- a/lib/stack_master/parameter_resolvers/ejson.rb
+++ b/lib/stack_master/parameter_resolvers/ejson.rb
@@ -14,7 +14,7 @@ module StackMaster
         validate_ejson_file_specified
         secrets = decrypt_ejson_file
         secrets.fetch(secret_key.to_sym) do
-          raise SecretNotFound, "Unable to find key #{secret_key} in file #{ejson_file}"
+          raise SecretNotFound, "Unable to find key #{secret_key} in file #{@stack_definition.ejson_file}"
         end
       end
 


### PR DESCRIPTION
There's no `ejson_file` variable or method and raises an error when the secret key can't be found.