### PR TITLE
Cross-account parameter resolving

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,5 @@ rvm:
 - 2.6
 before_install:
 - gem update --system
-- gem install bundler
 script: bundle exec rake spec features
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,6 @@ rvm:
 - 2.6
 before_install:
 - gem update --system
+- gem install bundler
 script: bundle exec rake spec features
 sudo: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,11 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 - Project metadata to the gemspec ([#293]).
 
+- Enable cross-account parameter resolving ([#292])
+
 [Unreleased]: https://github.com/envato/stack_master/compare/v1.17.1...HEAD
 [#293]: https://github.com/envato/stack_master/pull/293
+[#292]: https://github.com/envato/stack_master/pull/292
 
 ## [1.17.1] - 2019-10-3
 

--- a/README.md
+++ b/README.md
@@ -203,8 +203,10 @@ region/account, even though the resolved values will be different.
 One way to resolve parameter values from different accounts to the one StackMaster runs in, is to
 assume a role in another account with the relevant IAM permissions to execute successfully.
 
-This is supported in StackMaster by specifying the `role` and `account` properties for any
+This is supported in StackMaster by specifying the `role` and `account` properties for the
 parameter resolver in the stack's parameters file.
+
+All parameter resolvers are supported.
 
 ```yaml
 vpc_peering_id:
@@ -226,6 +228,11 @@ another_array_param:
   - role: cross-account-parameter-resolver
     account: 0987654321
     stack_output: stack-in-account2/output
+
+my_secret:
+  role: cross-account-parameter-resolver
+  account: 1234567890
+  parameter_store: ssm_parameter_name
 ```
 
 An example of use case where cross-account parameter resolving is particularly useful is when

--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ db_password:
 ```
 
 ### 1Password Lookup
-An Alternative to the alternative secret store is accessing 1password secrets using the 1password cli (`op`).
+An alternative to the alternative secret store is accessing 1password secrets using the 1password cli (`op`).
 You declare a 1password lookup with the following parameters in your parameters file:
 
 ```

--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ db_password:
 ```
 
 ### 1Password Lookup
-An alternative to the alternative secret store is accessing 1password secrets using the 1password cli (`op`).
+An alternative to the secrets store is accessing 1password secrets using the 1password cli (`op`).
 You declare a 1password lookup with the following parameters in your parameters file:
 
 ```

--- a/README.md
+++ b/README.md
@@ -198,6 +198,40 @@ One benefit of using parameter resolvers instead of hard coding values like VPC
 IDs and resource ARNs is that the same configuration works cross
 region/account, even though the resolved values will be different.
 
+### Cross-account parameter resolving
+
+One way to resolve parameter values from different accounts to the one StackMaster runs in, is to
+assume a role in another account with the relevant IAM permissions to execute successfully.
+
+This is supported in StackMaster by specifying the `role` and `account` properties for any
+parameter resolver in the stack's parameters file.
+
+```yaml
+vpc_peering_id:
+  role: cross-account-parameter-resolver
+  account: 1234567890
+  stack_output: vpc-peering-stack-in-other-account/peering_name
+
+an_array_param:
+  role: cross-account-parameter-resolver
+  account: 1234567890
+  stack_outputs:
+    - stack-in-account1/output
+    - stack-in-account1/another_output
+
+another_array_param:
+  - role: cross-account-parameter-resolver
+    account: 1234567890
+    stack_output: stack-in-account1/output
+  - role: cross-account-parameter-resolver
+    account: 0987654321
+    stack_output: stack-in-account2/output
+```
+
+An example of use case where cross-account parameter resolving is particularly useful is when
+setting up VPC peering where you need the VPC ID of the peer. Without the ability to assume
+a role in another account, the only option was to hard code the peer's VPC ID.
+
 ### Stack Output
 
 The stack output parameter resolver looks up outputs from other stacks in the

--- a/features/apply.feature
+++ b/features/apply.feature
@@ -383,6 +383,7 @@ Feature: Apply command
     Then the exit status should be 0
 
   Scenario: Create a stack using a stack output resolver
+    Given I stub the CloudFormation driver
     Given a file named "parameters/myapp_web.yml" with:
       """
       VpcId:

--- a/features/apply_with_assume_role_parameter_resolvers.feature
+++ b/features/apply_with_assume_role_parameter_resolvers.feature
@@ -1,0 +1,57 @@
+Feature: Apply command with assume role parameter resolvers
+
+  Background:
+    Given a file named "stack_master.yml" with:
+      """
+      stacks:
+        us-east-2:
+          vpc:
+            template: vpc.rb
+          myapp_web:
+            template: myapp_web.rb
+      """
+    And a directory named "parameters"
+    And a file named "parameters/myapp_web.yml" with:
+      """
+      vpc_id:
+        role: my-role
+        account: 1234567890
+        stack_output: vpc/vpc_id
+      """
+    And a directory named "templates"
+    And a file named "templates/myapp_web.rb" with:
+      """
+      SparkleFormation.new(:myapp_web) do
+        description "Test template"
+        set!('AWSTemplateFormatVersion', '2010-09-09')
+
+        parameters.vpc_id do
+          description 'VPC ID'
+          type 'AWS::EC2::VPC::Id'
+        end
+
+        resources.test_sg do
+          type 'AWS::EC2::SecurityGroup'
+          properties do
+            group_description 'Test SG'
+            vpc_id ref!(:vpc_id)
+          end
+        end
+      end
+      """
+
+  Scenario: Run apply and create a new stack
+    Given I stub the CloudFormation driver
+    Given I stub the following stack events:
+      | stack_id | event_id | stack_name | logical_resource_id | resource_status | resource_type              | timestamp           |
+      | 1        | 1        | myapp-web  | myapp-web           | CREATE_COMPLETE | AWS::CloudFormation::Stack | 2020-10-29 00:00:00 |
+    And I stub the following stacks:
+      | stack_id | stack_name | parameters           | outputs      | region    |
+      | 1        | vpc        | VpcCidr=10.0.0.16/22 | VpcId=vpc-id | us-east-2 |
+      | 2        | myapp_web  |                      |              | us-east-2 |
+    Then I expect the role "my-role" is assumed in account "1234567890"
+    When I run `stack_master apply us-east-2 myapp_web --trace`
+    And the output should contain all of these lines:
+      | +---           |
+      | +VpcId: vpc-id |
+    Then the exit status should be 0

--- a/features/step_definitions/asume_role_steps.rb
+++ b/features/step_definitions/asume_role_steps.rb
@@ -1,0 +1,6 @@
+Then(/^I expect the role "([^"]*)" is assumed in account "([^"]*)"$/) do |role, account|
+  expect(Aws::AssumeRoleCredentials).to receive(:new).with(
+    role_arn: "arn:aws:iam::#{account}:role/#{role}",
+    role_session_name: instance_of(String)
+  )
+end

--- a/features/step_definitions/stack_steps.rb
+++ b/features/step_definitions/stack_steps.rb
@@ -65,6 +65,10 @@ Given(/^I stub CloudFormation validate calls to fail validation with message "([
   allow(StackMaster.cloud_formation_driver).to receive(:validate_template).and_raise(Aws::CloudFormation::Errors::ValidationError.new('', message))
 end
 
+Given(/^I stub the CloudFormation driver$/) do
+  allow(StackMaster.cloud_formation_driver.class).to receive(:new).and_return(StackMaster.cloud_formation_driver)
+end
+
 When(/^an S3 file in bucket "([^"]*)" with key "([^"]*)" exists with content:$/) do |bucket, key, body|
   file = StackMaster.s3_driver.find_file(bucket: bucket, object_key: key)
   expect(file).to eq body

--- a/lib/stack_master.rb
+++ b/lib/stack_master.rb
@@ -30,6 +30,7 @@ module StackMaster
   autoload :SecurityGroupFinder, 'stack_master/security_group_finder'
   autoload :ParameterLoader, 'stack_master/parameter_loader'
   autoload :ParameterResolver, 'stack_master/parameter_resolver'
+  autoload :RoleAssumer, 'stack_master/role_assumer'
   autoload :ResolverArray, 'stack_master/resolver_array'
   autoload :Resolver, 'stack_master/resolver_array'
   autoload :Utils, 'stack_master/utils'

--- a/lib/stack_master/parameter_resolvers/latest_ami.rb
+++ b/lib/stack_master/parameter_resolvers/latest_ami.rb
@@ -6,13 +6,13 @@ module StackMaster
       def initialize(config, stack_definition)
         @config = config
         @stack_definition = stack_definition
-        @ami_finder = AmiFinder.new(@stack_definition.region)
       end
 
       def resolve(value)
         owners = Array(value.fetch('owners', 'self').to_s)
-        filters = @ami_finder.build_filters_from_hash(value.fetch('filters'))
-        @ami_finder.find_latest_ami(filters, owners).try(:image_id)
+        ami_finder = AmiFinder.new(@stack_definition.region)
+        filters = ami_finder.build_filters_from_hash(value.fetch('filters'))
+        ami_finder.find_latest_ami(filters, owners).try(:image_id)
       end
     end
   end

--- a/lib/stack_master/parameter_resolvers/parameter_store.rb
+++ b/lib/stack_master/parameter_resolvers/parameter_store.rb
@@ -11,6 +11,7 @@ module StackMaster
 
       def resolve(value)
         begin
+          ssm = Aws::SSM::Client.new(region: @stack_definition.region)
           resp = ssm.get_parameter(
             name: value,
             with_decryption: true
@@ -19,12 +20,6 @@ module StackMaster
           raise ParameterNotFound, "Unable to find #{value} in Parameter Store"
         end
         resp.parameter.value
-      end
-
-      private
-
-      def ssm
-        @ssm ||= Aws::SSM::Client.new(region: @stack_definition.region)
       end
     end
   end

--- a/lib/stack_master/parameter_resolvers/sns_topic_name.rb
+++ b/lib/stack_master/parameter_resolvers/sns_topic_name.rb
@@ -8,7 +8,6 @@ module StackMaster
       def initialize(config, stack_definition)
         @config = config
         @stack_definition = stack_definition
-        @stacks = {}
       end
 
       def resolve(value)
@@ -18,10 +17,6 @@ module StackMaster
       end
 
       private
-
-      def cf
-        @cf ||= StackMaster.cloud_formation_driver
-      end
 
       def sns_topic_finder
         StackMaster::SnsTopicFinder.new(@stack_definition.region)

--- a/lib/stack_master/role_assumer.rb
+++ b/lib/stack_master/role_assumer.rb
@@ -37,7 +37,7 @@ module StackMaster
 
     def replace_cf_driver
       driver = StackMaster.cloud_formation_driver
-      StackMaster.cloud_formation_driver = AwsDriver::CloudFormation.new
+      StackMaster.cloud_formation_driver = driver.class.new
       driver
     end
 

--- a/lib/stack_master/role_assumer.rb
+++ b/lib/stack_master/role_assumer.rb
@@ -1,0 +1,59 @@
+require 'active_support/core_ext/object/deep_dup'
+
+module StackMaster
+  class RoleAssumer
+    BlockNotSpecified = Class.new(StandardError)
+
+    def initialize
+      @credentials = {}
+    end
+
+    def assume_role(account, role, &block)
+      raise BlockNotSpecified unless block_given?
+      raise ArgumentError, "Both 'account' and 'role' are required to assume a role" if account.nil? || role.nil?
+
+      original_aws_config = replace_aws_global_config
+      Aws.config[:credentials] = assume_role_credentials(account, role)
+      begin
+        original_cf_driver = replace_cf_driver
+        block.call
+      ensure
+        restore_aws_global_config(original_aws_config)
+        restore_cf_driver(original_cf_driver)
+      end
+    end
+
+    private
+
+    def replace_aws_global_config
+      config = Aws.config
+      Aws.config = config.deep_dup
+      config
+    end
+
+    def restore_aws_global_config(config)
+      Aws.config = config
+    end
+
+    def replace_cf_driver
+      driver = StackMaster.cloud_formation_driver
+      StackMaster.cloud_formation_driver = AwsDriver::CloudFormation.new
+      driver
+    end
+
+    def restore_cf_driver(driver)
+      return if driver.nil?
+      StackMaster.cloud_formation_driver = driver
+    end
+
+    def assume_role_credentials(account, role)
+      credentials_key = "#{account}:#{role}"
+      @credentials.fetch(credentials_key) do
+        @credentials[credentials_key] = Aws::AssumeRoleCredentials.new(
+          role_arn: "arn:aws:iam::#{account}:role/#{role}",
+          role_session_name: "stack-master-assume-role-parameter-resolver"
+        )
+      end
+    end
+  end
+end

--- a/spec/stack_master/parameter_resolvers/stack_output_spec.rb
+++ b/spec/stack_master/parameter_resolvers/stack_output_spec.rb
@@ -44,13 +44,26 @@ RSpec.describe StackMaster::ParameterResolvers::StackOutput do
     context 'the stack and output exist' do
       let(:outputs) { [{output_key: 'MyOutput', output_value: 'myresolvedvalue'}] }
 
+      before do
+        allow(config).to receive(:unalias_region).with('ap-southeast-2').and_return('ap-southeast-2')
+      end
+
       it 'resolves the value' do
         expect(resolved_value).to eq 'myresolvedvalue'
       end
 
       it 'caches stacks for the lifetime of the instance' do
+        expect(cf).to receive(:describe_stacks).with(stack_name: 'my-stack').and_call_original.once
         resolver.resolve(value)
         resolver.resolve(value)
+      end
+
+      it "caches stacks by region" do
+        expect(cf).to receive(:describe_stacks).with(stack_name: 'my-stack').and_call_original.twice
+        resolver.resolve(value)
+        resolver.resolve(value)
+        resolver.resolve("ap-southeast-2:#{value}")
+        resolver.resolve("ap-southeast-2:#{value}")
       end
     end
 

--- a/spec/stack_master/role_assumer_spec.rb
+++ b/spec/stack_master/role_assumer_spec.rb
@@ -124,6 +124,7 @@ RSpec.describe StackMaster::RoleAssumer do
           role_assumer.assume_role(account, role, &my_block)
         end
       end
+
       context 'with a different account' do
         it 'assumes each role once' do
           expect(Aws::AssumeRoleCredentials).to receive(:new).with(
@@ -139,6 +140,7 @@ RSpec.describe StackMaster::RoleAssumer do
           role_assumer.assume_role('another-account', role, &my_block)
         end
       end
+
       context 'with a different role' do
         it 'assumes each role once' do
           expect(Aws::AssumeRoleCredentials).to receive(:new).with(

--- a/spec/stack_master/role_assumer_spec.rb
+++ b/spec/stack_master/role_assumer_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe StackMaster::RoleAssumer do
     end
 
     context 'CloudFormation driver' do
-      let(:new_driver) { StackMaster::TestDriver::CloudFormation.new }
+      let(:new_driver) { StackMaster.cloud_formation_driver.class.new }
 
       before do
         allow(StackMaster::AwsDriver::CloudFormation).to receive(:new).and_return(new_driver)

--- a/spec/stack_master/role_assumer_spec.rb
+++ b/spec/stack_master/role_assumer_spec.rb
@@ -1,0 +1,159 @@
+RSpec.describe StackMaster::RoleAssumer do
+  subject(:role_assumer) { described_class.new }
+
+  let(:account) { '1234567890' }
+  let(:role) { 'my-role' }
+
+  describe '#assume_role' do
+    let(:assume_role) { role_assumer.assume_role(account, role, &my_block) }
+    let(:my_block) { -> { "I've been called!" } }
+    let(:credentials) { instance_double(Aws::AssumeRoleCredentials) }
+
+    before do
+      allow(Aws::AssumeRoleCredentials).to receive(:new).and_return(credentials)
+    end
+
+    it 'calls the assume role API once' do
+      expect(Aws::AssumeRoleCredentials).to receive(:new).with(
+        role_arn: "arn:aws:iam::#{account}:role/#{role}",
+        role_session_name: instance_of(String)
+      ).once
+
+      assume_role
+    end
+
+    it 'calls the passed in block once' do
+      expect { |b| role_assumer.assume_role(account, role, &b) }.to yield_control.once
+    end
+
+    it "returns the block's return value" do
+      expect(assume_role).to eq("I've been called!")
+    end
+
+    it 'assumes the role before calling block' do
+      expect(Aws::AssumeRoleCredentials).to receive(:new).with(
+        role_arn: "arn:aws:iam::#{account}:role/#{role}",
+        role_session_name: instance_of(String)
+      ).ordered
+      expect(my_block).to receive(:call).ordered
+
+      assume_role
+    end
+
+    context 'when no block is specified' do
+      let(:my_block) { nil }
+
+      it 'raises an error' do
+        expect { assume_role }.to raise_error(StackMaster::RoleAssumer::BlockNotSpecified)
+      end
+    end
+
+    context 'when account is nil' do
+      let(:account) { nil }
+
+      it 'when raises an error' do
+        expect { assume_role }.to raise_error(ArgumentError, "Both 'account' and 'role' are required to assume a role")
+      end
+    end
+
+    context 'when role is nil' do
+      let(:role) { nil }
+
+      it 'raises an error' do
+        expect { assume_role }.to raise_error(ArgumentError, "Both 'account' and 'role' are required to assume a role")
+      end
+    end
+
+    context 'setting aws credentials' do
+      let(:new_aws_config) { {} }
+
+      before do
+        allow(Aws.config).to receive(:deep_dup).and_return(new_aws_config)
+      end
+
+      it 'updates the global Aws config with the assumed role credentials' do
+        expect(new_aws_config[:credentials]).to eq(nil)
+
+        assume_role
+
+        expect(new_aws_config[:credentials]).to eq(credentials)
+      end
+
+      it 'restores the original Aws.config after calling block' do
+        old_config = Aws.config
+
+        assume_role
+
+        expect(Aws.config).to eq(old_config)
+      end
+    end
+
+    context 'CloudFormation driver' do
+      let(:new_driver) { StackMaster::TestDriver::CloudFormation.new }
+
+      before do
+        allow(StackMaster::AwsDriver::CloudFormation).to receive(:new).and_return(new_driver)
+      end
+
+      it 'updates the global cloudformation driver' do
+        old_driver = StackMaster.cloud_formation_driver
+        expect(StackMaster).to receive(:cloud_formation_driver=).with(new_driver).once.and_call_original.ordered
+        expect(StackMaster).to receive(:cloud_formation_driver=).with(old_driver).once.and_call_original.ordered
+
+        assume_role
+      end
+
+      it 'restores the original cloudformation driver after calling block' do
+        old_driver = StackMaster.cloud_formation_driver
+
+        assume_role
+
+        expect(StackMaster.cloud_formation_driver).to eq(old_driver)
+      end
+    end
+
+    describe 'when called multiple times' do
+      context 'with the same account and role' do
+        it 'assumes the role once' do
+          expect(Aws::AssumeRoleCredentials).to receive(:new).with(
+            role_arn: "arn:aws:iam::#{account}:role/#{role}",
+            role_session_name: instance_of(String)
+          ).once
+
+          role_assumer.assume_role(account, role, &my_block)
+          role_assumer.assume_role(account, role, &my_block)
+        end
+      end
+      context 'with a different account' do
+        it 'assumes each role once' do
+          expect(Aws::AssumeRoleCredentials).to receive(:new).with(
+            role_arn: "arn:aws:iam::#{account}:role/#{role}",
+            role_session_name: instance_of(String)
+          ).once
+          expect(Aws::AssumeRoleCredentials).to receive(:new).with(
+            role_arn: "arn:aws:iam::another-account:role/#{role}",
+            role_session_name: instance_of(String)
+          ).once
+
+          role_assumer.assume_role(account, role, &my_block)
+          role_assumer.assume_role('another-account', role, &my_block)
+        end
+      end
+      context 'with a different role' do
+        it 'assumes each role once' do
+          expect(Aws::AssumeRoleCredentials).to receive(:new).with(
+            role_arn: "arn:aws:iam::#{account}:role/#{role}",
+            role_session_name: instance_of(String)
+          ).once
+          expect(Aws::AssumeRoleCredentials).to receive(:new).with(
+            role_arn: "arn:aws:iam::#{account}:role/another-role",
+            role_session_name: instance_of(String)
+          ).once
+
+          role_assumer.assume_role(account, role, &my_block)
+          role_assumer.assume_role(account, 'another-role', &my_block)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds support for assuming a role when resolving parameters.

We've recently had to configure VPC peering and found it error prone to have to hard code VPC and peering IDs in the stacks' parameters files. It's also hard and tedious to find all the relevant values, especially for old VPCs.

Being able to reference stack outputs for stacks in other accounts would make this much more maintainable and less error prone, especially if the stacks need re-creating.

Here's some examples of what it looks like:

```yaml
vpc_peering_id:
  role: cross-account-parameter-resolver
  account: 1234567890
  stack_output: vpc-peering-stack-in-other-account/peering_id
an_array_param:
  role: cross-account-parameter-resolver
  account: 1234567890
  stack_outputs:
    - stack-in-account1/output
    - stack-in-account1/another_output
another_array_param:
  - role: cross-account-parameter-resolver
    account: 1234567890
    stack_output: stack-in-account1/output
  - role: cross-account-parameter-resolver
    account: 0987654321
    stack_output: stack-in-account2/output
```

#### Considerations

- The relevant IAM permissions to allow cross-account parameter resolving is left as an exercise for the reader.