### PR TITLE
Test against Ruby 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,6 @@ rvm:
 - 2.4
 - 2.5
 - 2.6
+- 2.7
 script: bundle exec rake spec features
 sudo: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 - Test against Ruby 2.7, ([#296]).
 
+### Changed
+
+- Some method calls changed to be explicit about converting hashes to keyword
+  arguments. Resolves warnings raised by Ruby 2.7, ([#296]).
+
 [Unreleased]: https://github.com/envato/stack_master/compare/v1.18.0...HEAD
 [#296]: https://github.com/envato/stack_master/pull/296
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,10 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ### Added
 
-...
+- Test against Ruby 2.7, ([#296]).
 
 [Unreleased]: https://github.com/envato/stack_master/compare/v1.18.0...HEAD
+[#296]: https://github.com/envato/stack_master/pull/296
 
 ## [1.18.0] - 2019-12-23
 

--- a/lib/stack_master/commands/apply.rb
+++ b/lib/stack_master/commands/apply.rb
@@ -148,7 +148,7 @@ module StackMaster
 
       def upload_files
         return unless use_s3?
-        s3.upload_files(s3_options)
+        s3.upload_files(**s3_options)
       end
 
       def template_method

--- a/lib/stack_master/stack_events/fetcher.rb
+++ b/lib/stack_master/stack_events/fetcher.rb
@@ -1,8 +1,8 @@
 module StackMaster
   module StackEvents
     class Fetcher
-      def self.fetch(*args)
-        new(*args).fetch
+      def self.fetch(stack_name, region, **args)
+        new(stack_name, region, **args).fetch
       end
 
       def initialize(stack_name, region, from: nil)

--- a/lib/stack_master/stack_events/streamer.rb
+++ b/lib/stack_master/stack_events/streamer.rb
@@ -3,8 +3,8 @@ module StackMaster
     class Streamer
       StackFailed = Class.new(StandardError)
 
-      def self.stream(*args, &block)
-        new(*args, &block).stream
+      def self.stream(stack_name, region, **args, &block)
+        new(stack_name, region, **args, &block).stream
       end
 
       def initialize(stack_name, region, from: Time.now, break_on_finish_state: true, sleep_between_fetches: 1, io: nil, &block)

--- a/spec/stack_master/aws_driver/s3_spec.rb
+++ b/spec/stack_master/aws_driver/s3_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe StackMaster::AwsDriver::S3 do
                                                        key: 'prefix/template',
                                                        body: 'file content',
                                                        metadata: {md5: "d10b4c3ff123b26dc068d43a8bef2d23"})
-        s3_driver.upload_files(options)
+        s3_driver.upload_files(**options)
       end
     end
 
@@ -69,7 +69,7 @@ RSpec.describe StackMaster::AwsDriver::S3 do
                                                        key: 'template',
                                                        body: 'file content',
                                                        metadata: {md5: "d10b4c3ff123b26dc068d43a8bef2d23"})
-        s3_driver.upload_files(options)
+        s3_driver.upload_files(**options)
       end
     end
 
@@ -92,7 +92,7 @@ RSpec.describe StackMaster::AwsDriver::S3 do
                                                        key: 'prefix/template',
                                                        body: 'file content',
                                                        metadata: {md5: "d10b4c3ff123b26dc068d43a8bef2d23"})
-        s3_driver.upload_files(options)
+        s3_driver.upload_files(**options)
       end
     end
 
@@ -123,7 +123,7 @@ RSpec.describe StackMaster::AwsDriver::S3 do
                                                        key: 'template2',
                                                        body: 'file content',
                                                        metadata: {md5: "d10b4c3ff123b26dc068d43a8bef2d23"})
-        s3_driver.upload_files(options)
+        s3_driver.upload_files(**options)
       end
     end
   end

--- a/spec/stack_master/parameter_loader_spec.rb
+++ b/spec/stack_master/parameter_loader_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe StackMaster::ParameterLoader do
   subject(:parameters) { StackMaster::ParameterLoader.load([stack_file_name, region_file_name]) }
 
   before do
-    file_mock(stack_file_name, stack_file_returns)
-    file_mock(region_file_name, region_file_returns)
+    file_mock(stack_file_name, **stack_file_returns)
+    file_mock(region_file_name, **region_file_returns)
   end
 
   context 'no parameter file' do
@@ -63,7 +63,7 @@ RSpec.describe StackMaster::ParameterLoader do
     subject(:parameters) { StackMaster::ParameterLoader.load([stack_file_name, region_yaml_file_name, region_file_name]) }
 
     before do
-      file_mock(region_yaml_file_name, region_yaml_file_returns)
+      file_mock(region_yaml_file_name, **region_yaml_file_returns)
     end
 
     it 'returns params from the region base stack_name.yml' do


### PR DESCRIPTION
Add Ruby 2.7 to the Travis CI build matrix to ensure everything's working on the latest release of MRI.