### PR TITLE
Require Ruby 2.4 or later

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,11 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 - Some method calls changed to be explicit about converting hashes to keyword
   arguments. Resolves warnings raised by Ruby 2.7, ([#296]).
+- Bump the minimum required Ruby version from 2.1 to 2.4 ([#297]).
 
 [Unreleased]: https://github.com/envato/stack_master/compare/v1.18.0...HEAD
 [#296]: https://github.com/envato/stack_master/pull/296
+[#297]: https://github.com/envato/stack_master/pull/297
 
 ## [1.18.0] - 2019-12-23
 

--- a/stack_master.gemspec
+++ b/stack_master.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
-  spec.required_ruby_version = ">= 2.1.0"
+  spec.required_ruby_version = ">= 2.4.0"
   spec.platform      = gem_platform
 
   spec.add_development_dependency "bundler"


### PR DESCRIPTION
As we're about to release a new major version, we should take this opportunity to bump the minimum required Ruby version to the oldest supported by the Ruby core team.