### PR TITLE
Add a "tidy" command to find files that might be missing or unneeded.

### DIFF
--- a/README.md
+++ b/README.md
@@ -679,6 +679,7 @@ stack_master events [region-or-alias] [stack-name] # Display events for a stack
 stack_master outputs [region-or-alias] [stack-name] # Display outputs for a stack
 stack_master resources [region-or-alias] [stack-name] # Display outputs for a stack
 stack_master status # Displays the status of each stack
+stack_master tidy # Find missing or extra templates or parameter files
 ```
 
 ## Applying updates

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,7 +1,7 @@
 require 'aruba/cucumber'
 require 'stack_master'
 require 'stack_master/testing'
-require 'aruba/in_process'
+require 'aruba/processes/in_process'
 require 'pry'
 require 'cucumber/rspec/doubles'
 

--- a/features/tidy.feature
+++ b/features/tidy.feature
@@ -1,0 +1,29 @@
+Feature: Tidy command
+
+  Background:
+    Given a file named "stack_master.yml" with:
+      """
+      stacks:
+        us_east_1:
+          stack1:
+            template: stack1.json
+          stack5:
+            template: stack5.json
+      """
+    And a directory named "parameters"
+    And an empty file named "parameters/stack1.yml"
+    And an empty file named "parameters/stack4.yml"
+    And a directory named "templates"
+    And an empty file named "templates/stack1.json"
+    And an empty file named "templates/stack2.rb"
+    And a directory named "templates/dynamics"
+    And an empty file named "templates/dynamics/my_dynamic.rb"
+
+  Scenario: Tidy identifies extra & missing files
+    Given I run `stack_master tidy --trace`
+    Then the output should contain all of these lines:
+      | Stack "stack5" in "us-east-1" missing template "templates/stack5.json" |
+      | templates/stack2.rb: no stack found for this template |
+      | parameters/stack4.yml: no stack found for this parameter file |
+    And the output should not contain "stack1"
+    And the exit status should be 0

--- a/lib/stack_master.rb
+++ b/lib/stack_master.rb
@@ -63,6 +63,7 @@ module StackMaster
     autoload :Resources, 'stack_master/commands/resources'
     autoload :Delete, 'stack_master/commands/delete'
     autoload :Status, 'stack_master/commands/status'
+    autoload :Tidy, 'stack_master/commands/tidy'
   end
 
   module ParameterResolvers

--- a/lib/stack_master/cli.rb
+++ b/lib/stack_master/cli.rb
@@ -169,6 +169,19 @@ module StackMaster
         end
       end
 
+      command :tidy do |c|
+        c.syntax = 'stack_master tidy'
+        c.summary = 'Try to identify extra & missing files.'
+        c.description = 'Cross references stack_master.yml with the template and parameter directories to identify extra or missing files.'
+        c.example 'description', 'Check for missing or extra files'
+        c.action do |args, options|
+          options.defaults config: default_config_file
+          say "Invalid arguments. stack_master tidy" and return unless args.size == 0
+          config = load_config(options.config)
+          StackMaster::Commands::Tidy.perform(config)
+        end
+      end
+
       command :delete do |c|
         c.syntax = 'stack_master delete [region] [stack_name]'
         c.summary = 'Delete an existing stack'

--- a/lib/stack_master/commands/tidy.rb
+++ b/lib/stack_master/commands/tidy.rb
@@ -37,7 +37,7 @@ module StackMaster
         end
       end
 
-      def rel_path path
+      def rel_path(path)
         Pathname.new(path).relative_path_from(Pathname.new(@config.base_dir))
       end
 

--- a/lib/stack_master/commands/tidy.rb
+++ b/lib/stack_master/commands/tidy.rb
@@ -1,0 +1,68 @@
+module StackMaster
+  module Commands
+    class Tidy
+      include Command
+      include StackMaster::Commands::TerminalHelper
+
+      def initialize(config)
+        @config = config
+      end
+
+      def perform
+        used_templates = []
+        used_parameter_files = []
+
+        templates = Set.new(find_templates())
+        parameter_files = Set.new(find_parameter_files())
+
+        status = @config.stacks.each do |stack_definition|
+          parameter_files.subtract(stack_definition.parameter_files)
+          template = File.absolute_path(stack_definition.template_file_path)
+
+          if template
+            templates.delete(template)
+
+            if !File.exist?(template)
+              StackMaster.stdout.puts "Stack \"#{stack_definition.stack_name}\" in \"#{stack_definition.region}\" missing template \"#{rel_path(template)}\""
+            end
+          end
+        end
+
+        templates.each do |path|
+          StackMaster.stdout.puts "#{rel_path(path)}: no stack found for this template"
+        end
+
+        parameter_files.each do |path|
+          StackMaster.stdout.puts "#{rel_path(path)}: no stack found for this parameter file"
+        end
+      end
+
+      def rel_path path
+        Pathname.new(path).relative_path_from(Pathname.new(@config.base_dir))
+      end
+
+      def find_templates
+        # TODO: Inferring default template directory based on the behaviour in
+        # stack_definition.rb. For some configurations (eg, per-region
+        # template directories) this won't find the right directory.
+        template_dir = @config.template_dir || File.join(@config.base_dir, 'templates')
+
+        templates = Dir.glob(File.absolute_path(File.join(template_dir, '**', "*.{rb,yaml,yml,json}")))
+        dynamics_dir = File.join(template_dir, 'dynamics')
+
+        # Exclude sparkleformation dynamics
+        # TODO: Should this filter out anything with 'dynamics', not just the first
+        # subdirectory?
+        templates = templates.select do |path|
+          !path.start_with?(dynamics_dir)
+        end
+
+        templates
+      end
+
+      def find_parameter_files
+        Dir.glob(File.absolute_path(File.join(@config.base_dir, "parameters", "*.{yml,yaml}")))
+      end
+    end
+  end
+end


### PR DESCRIPTION
Sometimes you delete stacks but don't remove their parameter files or templates.

Sometimes a template is renamed or removed, but stacks still depend on it.

`stack_master tidy` (I feel like it needs a better name) helps you find these things.