### PR TITLE
Specify 'underscored_stack_name' for all parameters file names with note

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,12 +157,14 @@ template_compilers:
 
 Parameters are loaded from multiple YAML files, merged from the following lookup paths from bottom to top:
 
-- parameters/[stack_name].yaml
-- parameters/[stack_name].yml
+- parameters/[underscored_stack_name].yaml
+- parameters/[underscored_stack_name].yml
 - parameters/[region]/[underscored_stack_name].yaml
 - parameters/[region]/[underscored_stack_name].yml
 - parameters/[region_alias]/[underscored_stack_name].yaml
 - parameters/[region_alias]/[underscored_stack_name].yml
+
+**Note:** The file names must be underscored, not hyphenated, even if the stack names are hyphenated.
 
 A simple parameter file could look like this:
 


### PR DESCRIPTION
Hi folks. I had trouble with the parameter file names. I thought the docs were telling me they only needed to be underscored if they were in nested directories under `parameters/`. I've just updated the README to be a little more clear on that in case anyone else runs into the same thing. No code changes.