### PR TITLE
Require sparkle_formation version 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,20 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ## [Unreleased]
 
-[Unreleased]: https://github.com/envato/stack_master/compare/v2.0.0...HEAD
+### Changed
+
+- Restrict `sparkle_formation` to version 3 ([#307]).
+
+[Unreleased]: https://github.com/envato/stack_master/compare/v2.0.1...HEAD
+[#307]: https://github.com/envato/stack_master/pull/307
 
 ## [2.0.1] - 2020-01-22
 
 ### Changed
 
 - Pin cfndsl to below 1.0
+
+[2.0.1]: https://github.com/envato/stack_master/compare/v2.0.0...v2.0.1
 
 ## [2.0.0] - 2020-01-15
 

--- a/stack_master.gemspec
+++ b/stack_master.gemspec
@@ -57,7 +57,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "erubis"
   spec.add_dependency "colorize"
   spec.add_dependency "activesupport", '>= 4'
-  spec.add_dependency "sparkle_formation"
+  spec.add_dependency "sparkle_formation", "~> 3"
   spec.add_dependency "table_print"
   spec.add_dependency "deep_merge"
   spec.add_dependency "cfndsl", "< 1.0"


### PR DESCRIPTION
I came across the following error while running the latest `stack_master` in conjunction with an old version of `sparkle_formation`.

```
StackMaster::TemplateCompiler::TemplateCompilationFailed Failed to compile <redacted>.rb with error undefined method `apply' for #<SparkleFormation::SparkleCollection:0x00007f9118c8d808>
``` 

I found `stack_master` is incompatible with older versions: the RSpec suite doesn't pass with any version before 3.0.0.

Limit `sparkle_formation` to any 3.x.x version.