### PR TITLE
Handle exit status from the CLI class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,18 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- Exit status is now managed by the `StackMaster::CLI` class rather than the
+  `stack_master` binstub ([#310]). The Cucumber test suite can now accurately
+  validate the exit status of each command line invocation.
+
+### Fixed
+
+- `stack_master --version` now returns an exit status `0` ([#310]).
+
 [Unreleased]: https://github.com/envato/stack_master/compare/v2.1.0...HEAD
+[#310]: https://github.com/envato/stack_master/pull/310
 
 ## [2.1.0] - 2020-03-06
 

--- a/bin/stack_master
+++ b/bin/stack_master
@@ -10,8 +10,7 @@ end
 trap("SIGINT") { raise StackMaster::CtrlC }
 
 begin
-  result = StackMaster::CLI.new(ARGV.dup).execute!
-  exit !!result
+  StackMaster::CLI.new(ARGV.dup).execute!
 rescue StackMaster::CtrlC
   StackMaster.stdout.puts "Exiting..."
 end

--- a/features/apply.feature
+++ b/features/apply.feature
@@ -123,6 +123,7 @@ Feature: Apply command
       | +    "Vpc": {                                                                  |
       | Parameters diff:                                                               |
       | KeyName: my-key                                                                |
+    And the exit status should be 0
 
   Scenario: Run apply nothing and create 2 stacks
     Given I stub the following stack events:
@@ -147,6 +148,7 @@ Feature: Apply command
   Scenario: Run apply with invalid stack
     When I run `stack_master apply foo bar`
     Then the output should contain "Could not find stack definition bar in region foo"
+    And the exit status should be 1
 
   Scenario: Create stack with --changed
     Given I stub the following stack events:
@@ -161,6 +163,7 @@ Feature: Apply command
       | +    "Vpc": {                                                                  |
       | Parameters diff:                                                               |
       | KeyName: my-key                                                                |
+    And the exit status should be 0
 
   Scenario: Run apply with 2 specific stacks and create 2 stacks
     Given I stub the following stack events:

--- a/features/apply_with_allowed_accounts.feature
+++ b/features/apply_with_allowed_accounts.feature
@@ -43,7 +43,7 @@ Feature: Apply command with allowed accounts
     And I run `stack_master apply us-east-1 myapp-db`
     And the output should contain all of these lines:
       | Account '11111111' is not an allowed account. Allowed accounts are ["22222222"].|
-    Then the exit status should be 0
+    Then the exit status should be 1
 
   Scenario: Run apply with stack overriding allowed accounts to allow all accounts
     Given I stub the following stack events:

--- a/features/apply_with_sparkle_pack_template.feature
+++ b/features/apply_with_sparkle_pack_template.feature
@@ -43,6 +43,7 @@ Feature: Apply command with compile time parameters
     When I run `stack_master apply us-east-1 sparkle_pack_test -q --trace`
     Then the output should contain all of these lines:
       | Template "template_unknown" not found in any sparkle pack |
+    And the exit status should be 1
 
   Scenario: An unknown compiler
     Given a file named "stack_master.yml" with:
@@ -56,3 +57,4 @@ Feature: Apply command with compile time parameters
     When I run `stack_master apply us-east-1 sparkle_pack_test -q --trace`
     Then the output should contain all of these lines:
       | Unknown compiler "foobar" |
+    And the exit status should be 1

--- a/features/events.feature
+++ b/features/events.feature
@@ -30,4 +30,5 @@ Feature: Events command
       | 1        | 1        | myapp-vpc  | TestSg              | CREATE_COMPLETE | AWS::EC2::SecurityGroup    | 2020-10-29 00:00:00 |
       | 1        | 1        | myapp-vpc  | myapp-vpc           | CREATE_COMPLETE | AWS::CloudFormation::Stack | 2020-10-29 00:00:00 |
     When I run `stack_master events us-east-1 myapp-vpc --trace`
-    And the output should match /2020-10-29 00:00:00 (\+|\-)[0-9]{4} myapp-vpc AWS::CloudFormation::Stack CREATE_COMPLETE/
+    Then the output should match /2020-10-29 00:00:00 (\+|\-)[0-9]{4} myapp-vpc AWS::CloudFormation::Stack CREATE_COMPLETE/
+    And the exit status should be 0

--- a/features/outputs.feature
+++ b/features/outputs.feature
@@ -33,9 +33,10 @@ Feature: Outputs command
       }
       """
     When I run `stack_master outputs us-east-1 myapp-vpc --trace`
-    And the output should contain all of these lines:
+    Then the output should contain all of these lines:
       | VpcId      |
       | vpc-123456 |
+    And the exit status should be 0
 
   Scenario: Fails when the stack doesn't exist
     When I run `stack_master outputs us-east-1 myapp-vpc --trace`

--- a/features/validate.feature
+++ b/features/validate.feature
@@ -39,8 +39,10 @@ Feature: Validate command
     Given I stub CloudFormation validate calls to pass validation
     And I run `stack_master validate us-east-1 stack1`
     Then the output should contain "stack1: valid"
+    And the exit status should be 0
 
   Scenario: Validate unsuccessfully
     Given I stub CloudFormation validate calls to fail validation with message "Blah"
     And I run `stack_master validate us-east-1 stack1`
     Then the output should contain "stack1: invalid. Blah"
+    And the exit status should be 1

--- a/features/version.feature
+++ b/features/version.feature
@@ -1,0 +1,4 @@
+Feature: Check the StackMaster version
+  Scenario: Use the --version option
+    When I run `stack_master --version`
+    Then the exit status should be 0

--- a/lib/stack_master/cli.rb
+++ b/lib/stack_master/cli.rb
@@ -227,7 +227,7 @@ module StackMaster
       StackMaster::Config.load!(stack_file)
     rescue Errno::ENOENT => e
       say "Failed to load config file #{stack_file}"
-      exit 1
+      @kernel.exit false
     end
 
     def execute_stacks_command(command, args, options)
@@ -253,7 +253,7 @@ module StackMaster
           end
         end
       end
-      success
+      @kernel.exit false unless success
     end
 
     def execute_if_allowed_account(allowed_accounts, &block)


### PR DESCRIPTION
### Context

There are a couple of peculiar StackMaster behaviours regarding exit status.

- `stack_master --version` results in a status of `1` (#183).
- The exit status is set in the `stack_master` binstub, but the Cucumber feature suite doesn't test this. It drives StackMaster via the `StackMaster::CLI` class directly. This makes validating the status code impossible.

### Change

I propose we move handling of the exit status into the `StackMaster::CLI` class. This will solve both problems:

- Running `stack_master --version` will return a status of `0` (fixes #183).
- The Cucumber test suite will accurately validate the exit status of each command. I've added this validation to all scenarios.