### PR TITLE
Exit status 1 if stack is not found in AWS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,13 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 - `stack_master --version` now returns an exit status `0` ([#310]).
 
+- `delete`, `outputs`, and `resources` commands now exit with a status `1` if
+  the specified stack is not in AWS ([#313]).
+
 [Unreleased]: https://github.com/envato/stack_master/compare/v2.1.0...HEAD
 [#248]: https://github.com/envato/stack_master/issues/248
 [#310]: https://github.com/envato/stack_master/pull/310
+[#313]: https://github.com/envato/stack_master/pull/313
 [#314]: https://github.com/envato/stack_master/pull/314
 
 ## [2.1.0] - 2020-03-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ The format is based on [Keep a Changelog], and this project adheres to
 - `delete`, `outputs`, and `resources` commands now exit with a status `1` if
   the specified stack is not in AWS ([#313]).
 
+- The `delete` command now exits with status `1` if using a disallowed AWS
+  account ([#313]).
+
 [Unreleased]: https://github.com/envato/stack_master/compare/v2.1.0...HEAD
 [#248]: https://github.com/envato/stack_master/issues/248
 [#310]: https://github.com/envato/stack_master/pull/310

--- a/features/outputs.feature
+++ b/features/outputs.feature
@@ -40,7 +40,8 @@ Feature: Outputs command
 
   Scenario: Fails when the stack doesn't exist
     When I run `stack_master outputs us-east-1 myapp-vpc --trace`
-    And the output should not contain all of these lines:
+    Then the output should not contain all of these lines:
       | VpcId      |
       | vpc-123456 |
     And the output should contain "Stack doesn't exist"
+    And the exit status should be 1

--- a/features/resources.feature
+++ b/features/resources.feature
@@ -39,4 +39,5 @@ Feature: Resources command
 
   Scenario: Fails when the stack doesn't exist
     When I run `stack_master resources us-east-1 myapp-vpc --trace`
-    And the output should contain "Stack doesn't exist"
+    Then the output should contain "Stack doesn't exist"
+    And the exit status should be 1

--- a/lib/stack_master/cli.rb
+++ b/lib/stack_master/cli.rb
@@ -206,10 +206,11 @@ module StackMaster
             region = args[0]
           end
 
-          execute_if_allowed_account(allowed_accounts) do
+          success = execute_if_allowed_account(allowed_accounts) do
             StackMaster.cloud_formation_driver.set_region(region)
-            StackMaster::Commands::Delete.perform(region, stack_name)
+            StackMaster::Commands::Delete.perform(region, stack_name).success?
           end
+          @kernel.exit false unless success
         end
       end
 

--- a/lib/stack_master/commands/delete.rb
+++ b/lib/stack_master/commands/delete.rb
@@ -33,7 +33,7 @@ module StackMaster
         cf.describe_stacks({stack_name: @stack_name})
         true
       rescue Aws::CloudFormation::Errors::ValidationError
-        StackMaster.stdout.puts "Stack does not exist"
+        failed("Stack does not exist")
         false
       end
 

--- a/lib/stack_master/commands/outputs.rb
+++ b/lib/stack_master/commands/outputs.rb
@@ -17,7 +17,7 @@ module StackMaster
           tp.set :max_width, self.window_size
           tp stack.outputs, :output_key, :output_value, :description
         else
-          StackMaster.stdout.puts "Stack doesn't exist"
+          failed("Stack doesn't exist")
         end
       end
 

--- a/lib/stack_master/commands/resources.rb
+++ b/lib/stack_master/commands/resources.rb
@@ -1,3 +1,5 @@
+require 'table_print'
+
 module StackMaster
   module Commands
     class Resources
@@ -13,14 +15,14 @@ module StackMaster
         if stack_resources
           tp stack_resources, :logical_resource_id, :resource_type, :timestamp, :resource_status, :resource_status_reason, :description
         else
-          StackMaster.stdout.puts "Stack doesn't exist"
+          failed("Stack doesn't exist")
         end
       end
 
       private
 
       def stack_resources
-        @stack_resources = cf.describe_stack_resources(stack_name: @stack_definition.stack_name).stack_resources
+        @stack_resources ||= cf.describe_stack_resources(stack_name: @stack_definition.stack_name).stack_resources
       rescue Aws::CloudFormation::Errors::ValidationError
         nil
       end

--- a/spec/stack_master/commands/delete_spec.rb
+++ b/spec/stack_master/commands/delete_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe StackMaster::Commands::Delete do
 
   subject(:delete) { described_class.new(stack_name, region) }
-  let(:cf) { Aws::CloudFormation::Client.new }
+  let(:cf) { spy(Aws::CloudFormation::Client.new) }
   let(:region) { 'us-east-1' }
   let(:stack_name) { 'mystack' }
 
@@ -15,24 +15,26 @@ RSpec.describe StackMaster::Commands::Delete do
   describe "#perform" do
     context "The stack exists" do
       before do
-        cf.stub_responses(:describe_stacks, stacks: [{ stack_id: "ABC", stack_name: stack_name, creation_time: Time.now, stack_status: 'UPDATE_COMPLETE', parameters: []}])
-
+        allow(cf).to receive(:describe_stacks).and_return(
+          {stacks: [{ stack_id: "ABC", stack_name: stack_name, creation_time: Time.now, stack_status: 'UPDATE_COMPLETE', parameters: []}]}
+        )
       end
       it "deletes the stack and tails the events" do
-        expect(cf).to receive(:delete_stack).with({:stack_name => region})
-        expect(StackMaster::StackEvents::Streamer).to receive(:stream)
         delete.perform
+        expect(cf).to have_received(:delete_stack).with({:stack_name => region})
+        expect(StackMaster::StackEvents::Streamer).to have_received(:stream)
       end
     end
 
     context "The stack does not exist" do
       before do
-        cf.stub_responses(:describe_stacks, Aws::CloudFormation::Errors::ValidationError.new("x", "y"))
+        allow(cf).to receive(:describe_stacks).and_raise(Aws::CloudFormation::Errors::ValidationError.new("x", "y"))
       end
-      it "raises an error" do
-        expect(StackMaster::StackEvents::Streamer).to_not receive(:stream)
-        expect(cf).to_not receive(:delete_stack)
+      it "is not successful" do
         delete.perform
+        expect(StackMaster::StackEvents::Streamer).not_to have_received(:stream)
+        expect(cf).not_to have_received(:delete_stack)
+        expect(delete.success?).to be false
       end
     end
   end

--- a/spec/stack_master/commands/outputs_spec.rb
+++ b/spec/stack_master/commands/outputs_spec.rb
@@ -1,0 +1,45 @@
+RSpec.describe StackMaster::Commands::Outputs do
+  subject(:outputs) { described_class.new(config, stack_definition) }
+
+  let(:config) { spy(StackMaster::Config) }
+  let(:stack_definition) { spy(StackMaster::StackDefinition, stack_name: 'mystack', region: 'us-east-1') }
+  let(:stack) { spy(StackMaster::Stack, outputs: stack_outputs) }
+  let(:stack_outputs) { double(:outputs) }
+
+  before do
+    allow(StackMaster::Stack).to receive(:find).and_return(stack)
+    allow(outputs).to receive(:tp).and_return(spy)
+  end
+
+  describe '#perform' do
+    subject(:perform) { outputs.perform }
+
+    context 'given the stack exists' do
+      it 'prints the details in a table form' do
+        perform
+        expect(outputs).to have_received(:tp).with(stack_outputs, :output_key, :output_value, :description)
+      end
+
+      specify 'the command is successful' do
+        perform
+        expect(outputs.success?).to be(true)
+      end
+
+      it 'makes the API call only once' do
+        perform
+        expect(StackMaster::Stack).to have_received(:find).with('us-east-1', 'mystack').once
+      end
+    end
+
+    context 'given the stack does not exist' do
+      before do
+        allow(StackMaster::Stack).to receive(:find).and_return(nil)
+      end
+
+      specify 'the command is not successful' do
+        perform
+        expect(outputs.success?).to be(false)
+      end
+    end
+  end
+end

--- a/spec/stack_master/commands/resources_spec.rb
+++ b/spec/stack_master/commands/resources_spec.rb
@@ -1,0 +1,49 @@
+RSpec.describe StackMaster::Commands::Resources do
+  subject(:resources) { described_class.new(config, stack_definition) }
+
+  let(:config) { spy(StackMaster::Config) }
+  let(:stack_definition) { spy(StackMaster::StackDefinition, stack_name: 'mystack', region: 'us-east-1') }
+  let(:cf) { spy(Aws::CloudFormation::Client, describe_stack_resources: stack_resources) }
+  let(:stack_resources) { double(stack_resources: [stack_resource]) }
+  let(:stack_resource) { double('stack_resource') }
+
+  before do
+    allow(Aws::CloudFormation::Client).to receive(:new).and_return(cf)
+    allow(resources).to receive(:tp)
+  end
+
+  describe '#perform' do
+    subject(:perform) { resources.perform }
+
+    context 'given the stack exists' do
+      it 'prints the details in a table form' do
+        perform
+        expect(resources).to have_received(:tp).with(
+          [stack_resource], :logical_resource_id, :resource_type, :timestamp,
+          :resource_status, :resource_status_reason, :description
+        )
+      end
+
+      specify 'the command is successful' do
+        perform
+        expect(resources.success?).to be(true)
+      end
+
+      it 'makes the API call only once' do
+        perform
+        expect(cf).to have_received(:describe_stack_resources).with(stack_name: 'mystack').once
+      end
+    end
+
+    context 'given the stack does not exist' do
+      before do
+        allow(cf).to receive(:describe_stack_resources).and_raise(Aws::CloudFormation::Errors::ValidationError.new('x', 'y'))
+      end
+
+      specify 'the command is not successful' do
+        perform
+        expect(resources.success?).to be(false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
As reported in https://github.com/envato/stack_master/issues/235#issuecomment-393512594, StackMaster aborts, but with exit status `0` upon not finding the specified stack in AWS. It is expected to report an error via a non-zero exit status.

Update the `delete`, `outputs`, and `resources` commands to exit with a status of `1` if the specified stack does not exist in AWS.

Also the `delete` command now exits with status `1` if using a disallowed AWS account.