### PR TITLE
Unpin and use the latest release of the commander gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,18 @@ The format is based on [Keep a Changelog], and this project adheres to
   `stack_master` binstub ([#310]). The Cucumber test suite can now accurately
   validate the exit status of each command line invocation.
 
+- Unpin and use the latest release of the `commander` gem ([#314]). This
+  latest release includes fixes for the global option parsing defect reported
+  in [#248].
+
 ### Fixed
 
 - `stack_master --version` now returns an exit status `0` ([#310]).
 
 [Unreleased]: https://github.com/envato/stack_master/compare/v2.1.0...HEAD
+[#248]: https://github.com/envato/stack_master/issues/248
 [#310]: https://github.com/envato/stack_master/pull/310
+[#314]: https://github.com/envato/stack_master/pull/314
 
 ## [2.1.0] - 2020-03-06
 

--- a/stack_master.gemspec
+++ b/stack_master.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "timecop"
   spec.add_dependency "os"
   spec.add_dependency "ruby-progressbar"
-  spec.add_dependency "commander", "<= 4.4.5"
+  spec.add_dependency "commander", ">= 4.5.2", "< 5"
   spec.add_dependency "aws-sdk-acm", "~> 1"
   spec.add_dependency "aws-sdk-cloudformation", "~> 1"
   spec.add_dependency "aws-sdk-ec2", "~> 1"


### PR DESCRIPTION
This latest release includes fixes for the global option parsing defect that resulting in us pinning the gem in #249 ([changelog](https://github.com/commander-rb/commander/blob/master/History.rdoc)).