### PR TITLE
Speed up CI: run only one CI job on macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 language: ruby
-os:
-- linux
-- osx
+os: linux
 rvm:
 - 2.4
 - 2.5
 - 2.6
 - 2.7
+jobs:
+  include:
+    os: osx
+    rvm: 2.6
 script: bundle exec rake spec features
 sudo: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ The format is based on [Keep a Changelog], and this project adheres to
   latest release includes fixes for the global option parsing defect reported
   in [#248].
 
+- Speed up CI: Only run one build job on macOS ([#315]).
+
 ### Fixed
 
 - `stack_master --version` now returns an exit status `0` ([#310]).
@@ -35,6 +37,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 [#310]: https://github.com/envato/stack_master/pull/310
 [#313]: https://github.com/envato/stack_master/pull/313
 [#314]: https://github.com/envato/stack_master/pull/314
+[#315]: https://github.com/envato/stack_master/pull/315
 
 ## [2.1.0] - 2020-03-06
 


### PR DESCRIPTION
The CI is rather slow. It's seems there're not many macOS agents so queue times on our macOS build jobs are high. The macOS build jobs also take longer to complete when compared to the Linux  build jobs.

![image](https://user-images.githubusercontent.com/497874/76584869-003caa00-6531-11ea-9dd6-80c0fd71082d.png)


I propose to run only one macOS build job. One should be enough to give us confidence StackMaster works on this operating system.

I've selected to run it with Ruby 2.6 as anecdotally, that's the fastest.

![image](https://user-images.githubusercontent.com/497874/76585028-6cb7a900-6531-11ea-9bc0-3fb463402c42.png)
 