### PR TITLE
Apply command prints list of parameter file locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ### Fixed
 
+- `stack_master apply` prints list of parameter file locations if no stack
+  parameters files found ([#316]).
+
+[Unreleased]: https://github.com/envato/stack_master/compare/v2.2.0...HEAD
+[#316]: https://github.com/envato/stack_master/pull/316
+
 ## [2.2.0]
 
 ### Changed
@@ -40,7 +46,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 - The `delete` command now exits with status `1` if using a disallowed AWS
   account ([#313]).
 
-[Unreleased]: https://github.com/envato/stack_master/compare/v2.1.0...HEAD
+[2.2.0]: https://github.com/envato/stack_master/compare/v2.1.0...v2.2.0
 [#248]: https://github.com/envato/stack_master/issues/248
 [#310]: https://github.com/envato/stack_master/pull/310
 [#313]: https://github.com/envato/stack_master/pull/313

--- a/features/apply_without_parameter_file.feature
+++ b/features/apply_without_parameter_file.feature
@@ -1,0 +1,52 @@
+Feature: Apply command without parameter files
+
+  Background:
+    Given a directory named "templates"
+    And a file named "templates/myapp.rb" with:
+      """
+      SparkleFormation.new(:myapp) do
+        parameters.key_name.type 'String'
+        resources.vpc do
+          type 'AWS::EC2::VPC'
+          properties.cidr_block '10.200.0.0/16'
+        end
+        outputs.vpc_id.value ref!(:vpc)
+      end
+      """
+
+  Scenario: With a region alias
+    Given a file named "stack_master.yml" with:
+      """
+      region_aliases:
+        production: us-east-1
+        staging: ap-southeast-2
+      stacks:
+        production:
+          myapp:
+            template: myapp.rb
+      """
+    When I run `stack_master apply production myapp --trace`
+    Then the output should contain all of these lines:
+      | Empty/blank parameters detected, ensure values exist for those parameters. |
+      | Parameters will be read from the following locations:                      |
+      | - parameters/myapp.y*ml                                                    |
+      | - parameters/us-east-1/myapp.y*ml                                          |
+      | - parameters/production/myapp.y*ml                                         |
+    And the exit status should be 0
+
+  Scenario: Without a region alias
+    Given a file named "stack_master.yml" with:
+      """
+      stacks:
+        us-east-1:
+          myapp:
+            template: myapp.rb
+      """
+    When I run `stack_master apply us-east-1 myapp --trace`
+    Then the output should contain all of these lines:
+      | Empty/blank parameters detected, ensure values exist for those parameters. |
+      | Parameters will be read from the following locations:                      |
+      | - parameters/myapp.y*ml                                                    |
+      | - parameters/us-east-1/myapp.y*ml                                          |
+    And the output should not contain "- parameters/production/myapp.y*ml"
+    And the exit status should be 0

--- a/lib/stack_master/commands/apply.rb
+++ b/lib/stack_master/commands/apply.rb
@@ -1,3 +1,5 @@
+require 'pathname'
+
 module StackMaster
   module Commands
     class Apply
@@ -208,8 +210,13 @@ module StackMaster
 
       def ensure_valid_parameters!
         if @proposed_stack.missing_parameters?
-          StackMaster.stderr.puts "Empty/blank parameters detected, ensure values exist for those parameters. Parameters will be read from the following locations:"
-          @stack_definition.parameter_files.each do |parameter_file|
+          StackMaster.stderr.puts <<~MESSAGE
+            Empty/blank parameters detected, ensure values exist for those parameters.
+            Parameters will be read from the following locations:
+          MESSAGE
+          base_dir = Pathname.new(@stack_definition.base_dir)
+          @stack_definition.parameter_file_globs.each do |glob|
+            parameter_file = Pathname.new(glob).relative_path_from(base_dir)
             StackMaster.stderr.puts " - #{parameter_file}"
           end
           halt!

--- a/spec/stack_master/stack_definition_spec.rb
+++ b/spec/stack_master/stack_definition_spec.rb
@@ -43,9 +43,16 @@ RSpec.describe StackMaster::StackDefinition do
     ])
   end
 
+  it 'returns all globs' do
+    expect(stack_definition.parameter_file_globs).to eq([
+      "/base_dir/parameters/#{stack_name}.y*ml",
+      "/base_dir/parameters/#{region}/#{stack_name}.y*ml",
+    ])
+  end
+
   context 'with additional parameter lookup dirs' do
     before do
-      stack_definition.send(:additional_parameter_lookup_dirs=, ['production'])
+      stack_definition.additional_parameter_lookup_dirs = ['production']
       allow(Dir).to receive(:glob).with(
         File.join(base_dir, 'parameters', "production", "#{stack_name}.y*ml")
       ).and_return(
@@ -64,6 +71,14 @@ RSpec.describe StackMaster::StackDefinition do
         "/base_dir/parameters/#{region}/#{stack_name}.yml",
         "/base_dir/parameters/production/#{stack_name}.yaml",
         "/base_dir/parameters/production/#{stack_name}.yml",
+      ])
+    end
+
+    it 'returns all globs' do
+      expect(stack_definition.parameter_file_globs).to eq([
+        "/base_dir/parameters/#{stack_name}.y*ml",
+        "/base_dir/parameters/#{region}/#{stack_name}.y*ml",
+        "/base_dir/parameters/production/#{stack_name}.y*ml",
       ])
     end
   end


### PR DESCRIPTION
#### Context

I found that if a parameter file couldn't be found for a stack, StackMaster would print this curious line:

```
Empty/blank parameters detected, ensure values exist for those parameters. Parameters will be read from the following locations:
```

But no locations were presented.

Upon investigation, I found it's because we're using `Dir.glob`. This only returns files actually present on the file system.

https://github.com/envato/stack_master/blob/28e088414ad85a13176bc901136e405cb45b3c5a/lib/stack_master/stack_definition.rb#L113-L115

#### Change

I propose to fix this by introducing a way to obtain the glob patterns before they're provided to `Dir.glob`.

With this change it'll print something like:

```
Empty/blank parameters detected, ensure values exist for those parameters.
Parameters will be read from the following locations:
- parameters/myapp.y*ml
- parameters/us-east-1/myapp.y*ml
- parameters/production/myapp.y*ml
```