### PR TITLE
`stack_master apply` with missing params exits with status 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,12 @@ The format is based on [Keep a Changelog], and this project adheres to
 - `stack_master apply` prints list of parameter file locations if no stack
   parameters files found ([#316]).
 
+- `stack_master apply` exits with status `1` if there are missing stack
+  parameters ([#317]).
+
 [Unreleased]: https://github.com/envato/stack_master/compare/v2.2.0...HEAD
 [#316]: https://github.com/envato/stack_master/pull/316
+[#317]: https://github.com/envato/stack_master/pull/317
 
 ## [2.2.0]
 

--- a/features/apply_without_parameter_file.feature
+++ b/features/apply_without_parameter_file.feature
@@ -32,7 +32,7 @@ Feature: Apply command without parameter files
       | - parameters/myapp.y*ml                                                    |
       | - parameters/us-east-1/myapp.y*ml                                          |
       | - parameters/production/myapp.y*ml                                         |
-    And the exit status should be 0
+    And the exit status should be 1
 
   Scenario: Without a region alias
     Given a file named "stack_master.yml" with:
@@ -49,4 +49,4 @@ Feature: Apply command without parameter files
       | - parameters/myapp.y*ml                                                    |
       | - parameters/us-east-1/myapp.y*ml                                          |
     And the output should not contain "- parameters/production/myapp.y*ml"
-    And the exit status should be 0
+    And the exit status should be 1

--- a/lib/stack_master/commands/apply.rb
+++ b/lib/stack_master/commands/apply.rb
@@ -210,16 +210,16 @@ module StackMaster
 
       def ensure_valid_parameters!
         if @proposed_stack.missing_parameters?
-          StackMaster.stderr.puts <<~MESSAGE
+          message = <<~MESSAGE
             Empty/blank parameters detected, ensure values exist for those parameters.
             Parameters will be read from the following locations:
           MESSAGE
           base_dir = Pathname.new(@stack_definition.base_dir)
           @stack_definition.parameter_file_globs.each do |glob|
             parameter_file = Pathname.new(glob).relative_path_from(base_dir)
-            StackMaster.stderr.puts " - #{parameter_file}"
+            message << " - #{parameter_file}\n"
           end
-          halt!
+          failed!(message)
         end
       end
 

--- a/spec/stack_master/commands/apply_spec.rb
+++ b/spec/stack_master/commands/apply_spec.rb
@@ -270,14 +270,17 @@ RSpec.describe StackMaster::Commands::Apply do
       expect { apply }.to_not output(/Continue and apply the stack/).to_stdout
     end
 
-    it 'outputs a description of the problem' do
-      expect { apply }.to output(/Empty\/blank parameters detected/).to_stderr
+    it 'outputs a description of the problem including where param files are loaded from' do
+      expect { apply }.to output(<<~OUTPUT).to_stderr
+        Empty/blank parameters detected, ensure values exist for those parameters.
+        Parameters will be read from the following locations:
+         - parameters/myapp_vpc.y*ml
+         - parameters/us-east-1/myapp_vpc.y*ml
+      OUTPUT
     end
 
-    it 'outputs where param files are loaded from' do
-      stack_definition.parameter_files.each do |parameter_file|
-        expect { apply }.to output(/#{parameter_file}/).to_stderr
-      end
+    specify 'the command is not successful' do
+      expect(apply.success?).to be(false)
     end
   end
 end


### PR DESCRIPTION
As reported in #235, `stack_master apply` aborts when parameters are missing, however the exit status is `0` reporting success.

I propose to change this so that the exit status is `1` reporting failure. 