### PR TITLE
Print error backtrace when provided --trace option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Print backtrace when given the `--trace` option, for in-process rescued
+  errors ([#319]). `StackMaster::TemplateCompiler::TemplateCompilationFailed`
+  and `Aws::CloudFormation::Errors::ServiceError` are two such errors.
+
 ### Changed
 
 - Load fewer Ruby files: remove several ActiveSupport core extensions and
@@ -23,10 +29,14 @@ The format is based on [Keep a Changelog], and this project adheres to
 - `stack_master apply` exits with status `1` if there are missing stack
   parameters ([#317]).
 
+- Don't print unreadable error backtrace on template compilation errors
+  ([#319]).
+
 [Unreleased]: https://github.com/envato/stack_master/compare/v2.2.0...HEAD
 [#316]: https://github.com/envato/stack_master/pull/316
 [#317]: https://github.com/envato/stack_master/pull/317
 [#318]: https://github.com/envato/stack_master/pull/318
+[#319]: https://github.com/envato/stack_master/pull/319
 
 ## [2.2.0]
 

--- a/lib/stack_master/cli.rb
+++ b/lib/stack_master/cli.rb
@@ -178,7 +178,7 @@ module StackMaster
           options.defaults config: default_config_file
           say "Invalid arguments. stack_master tidy" and return unless args.size == 0
           config = load_config(options.config)
-          StackMaster::Commands::Tidy.perform(config, options)
+          StackMaster::Commands::Tidy.perform(config, nil, options)
         end
       end
 

--- a/lib/stack_master/cli.rb
+++ b/lib/stack_master/cli.rb
@@ -71,7 +71,7 @@ module StackMaster
           unless args.size == 2
             say "Invalid arguments. stack_master init [region] [stack_name]"
           else
-            StackMaster::Commands::Init.perform(options.overwrite, *args)
+            StackMaster::Commands::Init.perform(options, *args)
           end
         end
       end
@@ -119,7 +119,7 @@ module StackMaster
           options.defaults config: default_config_file
           say "Invalid arguments." if args.size > 0
           config = load_config(options.config)
-          StackMaster::Commands::ListStacks.perform(config)
+          StackMaster::Commands::ListStacks.perform(config, nil, options)
         end
       end
 
@@ -165,7 +165,7 @@ module StackMaster
           options.defaults config: default_config_file
           say "Invalid arguments. stack_master status" and return unless args.size == 0
           config = load_config(options.config)
-          StackMaster::Commands::Status.perform(config)
+          StackMaster::Commands::Status.perform(config, nil, options)
         end
       end
 
@@ -178,7 +178,7 @@ module StackMaster
           options.defaults config: default_config_file
           say "Invalid arguments. stack_master tidy" and return unless args.size == 0
           config = load_config(options.config)
-          StackMaster::Commands::Tidy.perform(config)
+          StackMaster::Commands::Tidy.perform(config, options)
         end
       end
 
@@ -208,7 +208,7 @@ module StackMaster
 
           success = execute_if_allowed_account(allowed_accounts) do
             StackMaster.cloud_formation_driver.set_region(region)
-            StackMaster::Commands::Delete.perform(region, stack_name).success?
+            StackMaster::Commands::Delete.perform(region, stack_name, options).success?
           end
           @kernel.exit false unless success
         end

--- a/lib/stack_master/command.rb
+++ b/lib/stack_master/command.rb
@@ -27,6 +27,12 @@ module StackMaster
       end
     end
 
+    def initialize(config, stack_definition, options = Commander::Command::Options.new)
+      @config = config
+      @stack_definition = stack_definition
+      @options = options
+    end
+
     def success?
       @failed != true
     end

--- a/lib/stack_master/command.rb
+++ b/lib/stack_master/command.rb
@@ -36,6 +36,13 @@ module StackMaster
     def error_message(e)
       msg = "#{e.class} #{e.message}"
       msg << "\n Caused by: #{e.cause.class} #{e.cause.message}" if e.cause
+      if defined?(@options)
+        if @options&.trace
+          msg << "\n" << e.full_message
+        else
+          msg << "\n Use --trace to view backtrace"
+        end
+      end
       msg
     end
 

--- a/lib/stack_master/command.rb
+++ b/lib/stack_master/command.rb
@@ -42,12 +42,10 @@ module StackMaster
     def error_message(e)
       msg = "#{e.class} #{e.message}"
       msg << "\n Caused by: #{e.cause.class} #{e.cause.message}" if e.cause
-      if defined?(@options)
-        if @options&.trace
-          msg << "\n#{backtrace(e)}"
-        else
-          msg << "\n Use --trace to view backtrace"
-        end
+      if options.trace
+        msg << "\n#{backtrace(e)}"
+      else
+        msg << "\n Use --trace to view backtrace"
       end
       msg
     end
@@ -75,6 +73,10 @@ module StackMaster
     def halt!(message = nil)
       StackMaster.stdout.puts(message) if message
       throw :halt
+    end
+
+    def options
+      @options ||= Commander::Command::Options.new
     end
   end
 end

--- a/lib/stack_master/command.rb
+++ b/lib/stack_master/command.rb
@@ -38,12 +38,22 @@ module StackMaster
       msg << "\n Caused by: #{e.cause.class} #{e.cause.message}" if e.cause
       if defined?(@options)
         if @options&.trace
-          msg << "\n" << e.full_message
+          msg << "\n#{backtrace(e)}"
         else
           msg << "\n Use --trace to view backtrace"
         end
       end
       msg
+    end
+
+    def backtrace(error)
+      if error.respond_to?(:full_message)
+        error.full_message
+      else
+        # full_message was introduced in Ruby 2.5
+        # remove this conditional when StackMaster no longer supports Ruby 2.4
+        error.backtrace.join("\n")
+      end
     end
 
     def failed(message = nil)

--- a/lib/stack_master/command.rb
+++ b/lib/stack_master/command.rb
@@ -27,7 +27,7 @@ module StackMaster
       end
     end
 
-    def initialize(config, stack_definition, options = Commander::Command::Options.new)
+    def initialize(config, stack_definition = nil, options = Commander::Command::Options.new)
       @config = config
       @stack_definition = stack_definition
       @options = options

--- a/lib/stack_master/commands/apply.rb
+++ b/lib/stack_master/commands/apply.rb
@@ -12,8 +12,6 @@ module StackMaster
         super
         @s3_config = @stack_definition.s3
         @from_time = Time.now
-        @options.on_failure ||= nil
-        @options.yes_param ||= nil
       end
 
       def perform

--- a/lib/stack_master/commands/apply.rb
+++ b/lib/stack_master/commands/apply.rb
@@ -8,12 +8,10 @@ module StackMaster
       include StackMaster::Prompter
       TEMPLATE_TOO_LARGE_ERROR_MESSAGE = 'The (space compressed) stack is larger than the limit set by AWS. See http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-limits.html'.freeze
 
-      def initialize(config, stack_definition, options = Commander::Command::Options.new)
-        @config = config
-        @s3_config = stack_definition.s3
-        @stack_definition = stack_definition
+      def initialize(*_args)
+        super
+        @s3_config = @stack_definition.s3
         @from_time = Time.now
-        @options = options
         @options.on_failure ||= nil
         @options.yes_param ||= nil
       end

--- a/lib/stack_master/commands/compile.rb
+++ b/lib/stack_master/commands/compile.rb
@@ -4,12 +4,6 @@ module StackMaster
       include Command
       include Commander::UI
 
-      def initialize(config, stack_definition, options = {})
-        @config = config
-        @stack_definition = stack_definition
-        @options = options
-      end
-
       def perform
         puts(proposed_stack.template_body)
       end

--- a/lib/stack_master/commands/compile.rb
+++ b/lib/stack_master/commands/compile.rb
@@ -7,6 +7,7 @@ module StackMaster
       def initialize(config, stack_definition, options = {})
         @config = config
         @stack_definition = stack_definition
+        @options = options
       end
 
       def perform

--- a/lib/stack_master/commands/delete.rb
+++ b/lib/stack_master/commands/delete.rb
@@ -5,10 +5,10 @@ module StackMaster
       include StackMaster::Prompter
 
       def initialize(region, stack_name, options)
+        super(nil, nil, options)
         @region = region
         @stack_name = stack_name
         @from_time = Time.now
-        @options = options
       end
 
       def perform

--- a/lib/stack_master/commands/delete.rb
+++ b/lib/stack_master/commands/delete.rb
@@ -4,10 +4,11 @@ module StackMaster
       include Command
       include StackMaster::Prompter
 
-      def initialize(region, stack_name)
+      def initialize(region, stack_name, options)
         @region = region
         @stack_name = stack_name
         @from_time = Time.now
+        @options = options
       end
 
       def perform

--- a/lib/stack_master/commands/diff.rb
+++ b/lib/stack_master/commands/diff.rb
@@ -7,6 +7,7 @@ module StackMaster
       def initialize(config, stack_definition, options = {})
         @config = config
         @stack_definition = stack_definition
+        @options = options
       end
 
       def perform

--- a/lib/stack_master/commands/diff.rb
+++ b/lib/stack_master/commands/diff.rb
@@ -4,12 +4,6 @@ module StackMaster
       include Command
       include Commander::UI
 
-      def initialize(config, stack_definition, options = {})
-        @config = config
-        @stack_definition = stack_definition
-        @options = options
-      end
-
       def perform
         StackMaster::StackDiffer.new(proposed_stack, stack).output_diff
       end

--- a/lib/stack_master/commands/events.rb
+++ b/lib/stack_master/commands/events.rb
@@ -4,12 +4,6 @@ module StackMaster
       include Command
       include Commander::UI
 
-      def initialize(config, stack_definition, options = {})
-        @config = config
-        @stack_definition = stack_definition
-        @options = options
-      end
-
       def perform
         events = StackEvents::Fetcher.fetch(@stack_definition.stack_name, @stack_definition.region)
         filter_events(events).each do |event|

--- a/lib/stack_master/commands/init.rb
+++ b/lib/stack_master/commands/init.rb
@@ -6,7 +6,7 @@ module StackMaster
       include Command
 
       def initialize(options, region, stack_name)
-        @options = options
+        super(nil, nil, options)
         @region = region
         @stack_name = stack_name
       end

--- a/lib/stack_master/commands/init.rb
+++ b/lib/stack_master/commands/init.rb
@@ -5,8 +5,8 @@ module StackMaster
     class Init
       include Command
 
-      def initialize(overwrite, region, stack_name)
-        @overwrite = overwrite
+      def initialize(options, region, stack_name)
+        @options = options
         @region = region
         @stack_name = stack_name
       end
@@ -27,7 +27,7 @@ module StackMaster
         @parameters_filename = File.join("parameters", "#{underscored_stack_name}.yml")
         @region_parameters_filename = File.join("parameters", @region, "#{underscored_stack_name}.yml")
 
-        if !@overwrite
+        if !@options.overwrite
           [@stack_master_filename, @stack_json_filename, @parameters_filename, @region_parameters_filename].each do |filename|
             if File.exists?(filename)
               StackMaster.stderr.puts("Aborting: #{filename} already exists. Use --overwrite to force overwriting file.")

--- a/lib/stack_master/commands/lint.rb
+++ b/lib/stack_master/commands/lint.rb
@@ -6,12 +6,6 @@ module StackMaster
       include Command
       include Commander::UI
 
-      def initialize(config, stack_definition, options = {})
-        @config = config
-        @stack_definition = stack_definition
-        @options = options
-      end
-
       def perform
         unless cfn_lint_available
           failed! 'Failed to run cfn-lint. You may need to install it using'\

--- a/lib/stack_master/commands/lint.rb
+++ b/lib/stack_master/commands/lint.rb
@@ -9,6 +9,7 @@ module StackMaster
       def initialize(config, stack_definition, options = {})
         @config = config
         @stack_definition = stack_definition
+        @options = options
       end
 
       def perform

--- a/lib/stack_master/commands/list_stacks.rb
+++ b/lib/stack_master/commands/list_stacks.rb
@@ -7,10 +7,6 @@ module StackMaster
       include Commander::UI
       include StackMaster::Commands::TerminalHelper
 
-      def initialize(config)
-        @config = config
-      end
-
       def perform
         tp.set :max_width, self.window_size
         tp @config.stacks, :region, :stack_name

--- a/lib/stack_master/commands/outputs.rb
+++ b/lib/stack_master/commands/outputs.rb
@@ -7,12 +7,6 @@ module StackMaster
       include Commander::UI
       include StackMaster::Commands::TerminalHelper
 
-      def initialize(config, stack_definition, options = {})
-        @config = config
-        @stack_definition = stack_definition
-        @options = options
-      end
-
       def perform
         if stack
           tp.set :max_width, self.window_size

--- a/lib/stack_master/commands/outputs.rb
+++ b/lib/stack_master/commands/outputs.rb
@@ -10,6 +10,7 @@ module StackMaster
       def initialize(config, stack_definition, options = {})
         @config = config
         @stack_definition = stack_definition
+        @options = options
       end
 
       def perform

--- a/lib/stack_master/commands/resources.rb
+++ b/lib/stack_master/commands/resources.rb
@@ -6,12 +6,6 @@ module StackMaster
       include Command
       include Commander::UI
 
-      def initialize(config, stack_definition, options = {})
-        @config = config
-        @stack_definition = stack_definition
-        @options = options
-      end
-
       def perform
         if stack_resources
           tp stack_resources, :logical_resource_id, :resource_type, :timestamp, :resource_status, :resource_status_reason, :description

--- a/lib/stack_master/commands/resources.rb
+++ b/lib/stack_master/commands/resources.rb
@@ -9,6 +9,7 @@ module StackMaster
       def initialize(config, stack_definition, options = {})
         @config = config
         @stack_definition = stack_definition
+        @options = options
       end
 
       def perform

--- a/lib/stack_master/commands/status.rb
+++ b/lib/stack_master/commands/status.rb
@@ -8,7 +8,7 @@ module StackMaster
       include StackMaster::Commands::TerminalHelper
 
       def initialize(config, show_progress = true)
-        @config = config
+        super(config)
         @show_progress = show_progress
       end
 

--- a/lib/stack_master/commands/status.rb
+++ b/lib/stack_master/commands/status.rb
@@ -7,8 +7,8 @@ module StackMaster
       include Command
       include StackMaster::Commands::TerminalHelper
 
-      def initialize(config, show_progress = true)
-        super(config)
+      def initialize(config, options, show_progress = true)
+        super(config, nil, options)
         @show_progress = show_progress
       end
 

--- a/lib/stack_master/commands/tidy.rb
+++ b/lib/stack_master/commands/tidy.rb
@@ -4,10 +4,6 @@ module StackMaster
       include Command
       include StackMaster::Commands::TerminalHelper
 
-      def initialize(config)
-        @config = config
-      end
-
       def perform
         used_templates = []
         used_parameter_files = []

--- a/lib/stack_master/commands/validate.rb
+++ b/lib/stack_master/commands/validate.rb
@@ -4,12 +4,6 @@ module StackMaster
       include Command
       include Commander::UI
 
-      def initialize(config, stack_definition, options = {})
-        @config = config
-        @stack_definition = stack_definition
-        @options = options
-      end
-
       def perform
         failed unless Validator.valid?(@stack_definition, @config)
       end

--- a/lib/stack_master/commands/validate.rb
+++ b/lib/stack_master/commands/validate.rb
@@ -7,6 +7,7 @@ module StackMaster
       def initialize(config, stack_definition, options = {})
         @config = config
         @stack_definition = stack_definition
+        @options = options
       end
 
       def perform

--- a/lib/stack_master/template_compiler.rb
+++ b/lib/stack_master/template_compiler.rb
@@ -11,7 +11,7 @@ module StackMaster
       compiler.require_dependencies
       compiler.compile(template_dir, template, compile_time_parameters, compiler_options)
     rescue StandardError => e
-      raise TemplateCompilationFailed.new("Failed to compile #{template} with error #{e}.\n#{e.backtrace}")
+      raise TemplateCompilationFailed, "Failed to compile #{template}"
     end
 
     def self.register(name, klass)

--- a/spec/stack_master/command_spec.rb
+++ b/spec/stack_master/command_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe StackMaster::Command do
 
     context 'when the error has a cause' do
       let(:error_proc) do
-        proc = proc do
+        proc do
           begin
             raise RuntimeError, 'the cause message'
           rescue

--- a/spec/stack_master/command_spec.rb
+++ b/spec/stack_master/command_spec.rb
@@ -47,20 +47,50 @@ RSpec.describe StackMaster::Command do
   end
 
   context 'when a template compilation error occurs' do
-    it 'outputs the message' do
-      error_proc = proc {
-        raise StackMaster::TemplateCompiler::TemplateCompilationFailed.new('the message')
-      }
-      expect { command_class.perform(error_proc) }.to output(/the message/).to_stderr
+    subject(:command) { command_class.new(error_proc) }
+
+    let(:error_proc) do
+      proc do
+        raise StackMaster::TemplateCompiler::TemplateCompilationFailed, 'the message'
+      end
     end
 
-    it 'outputs the exception\'s cause' do
-      exception_with_cause = StackMaster::TemplateCompiler::TemplateCompilationFailed.new('the message')
-      allow(exception_with_cause).to receive(:cause).and_return(RuntimeError.new('the cause message'))
-      error_proc = proc {
-        raise exception_with_cause
-      }
-      expect { command_class.perform(error_proc) }.to output(/Caused by: RuntimeError the cause message/).to_stderr
+    it 'outputs the message' do
+      expect { command.perform }.to output(/the message/).to_stderr
+    end
+
+    context 'when the error has a cause' do
+      let(:error_proc) do
+        proc = proc do
+          raise RuntimeError, 'the cause message'
+        rescue
+          raise StackMaster::TemplateCompiler::TemplateCompilationFailed, 'the message'
+        end
+      end
+
+      it 'outputs the cause message' do
+        expect { command.perform }.to output(/Caused by: RuntimeError the cause message/).to_stderr
+      end
+    end
+
+    context 'when --trace is set' do
+      before { command.instance_variable_set(:@options, spy(trace: true)) }
+
+      it 'outputs the backtrace' do
+        expect { command.perform }.to output(%r{spec/stack_master/command_spec.rb:[\d]*:in }).to_stderr
+      end
+    end
+
+    context 'when --trace is not set' do
+      before { command.instance_variable_set(:@options, spy(trace: nil)) }
+
+      it 'does not output the backtrace' do
+        expect { command.perform }.not_to output(%r{spec/stack_master/command_spec.rb:[\d]*:in }).to_stderr
+      end
+
+      it 'informs to set --trace option to see the backtrace' do
+        expect { command.perform }.to output(/Use --trace to view backtrace/).to_stderr
+      end
     end
   end
 end

--- a/spec/stack_master/command_spec.rb
+++ b/spec/stack_master/command_spec.rb
@@ -62,9 +62,11 @@ RSpec.describe StackMaster::Command do
     context 'when the error has a cause' do
       let(:error_proc) do
         proc = proc do
-          raise RuntimeError, 'the cause message'
-        rescue
-          raise StackMaster::TemplateCompiler::TemplateCompilationFailed, 'the message'
+          begin
+            raise RuntimeError, 'the cause message'
+          rescue
+            raise StackMaster::TemplateCompiler::TemplateCompilationFailed, 'the message'
+          end
         end
       end
 

--- a/spec/stack_master/commands/delete_spec.rb
+++ b/spec/stack_master/commands/delete_spec.rb
@@ -1,9 +1,10 @@
 RSpec.describe StackMaster::Commands::Delete do
 
-  subject(:delete) { described_class.new(stack_name, region) }
+  subject(:delete) { described_class.new(stack_name, region, options) }
   let(:cf) { spy(Aws::CloudFormation::Client.new) }
   let(:region) { 'us-east-1' }
   let(:stack_name) { 'mystack' }
+  let(:options) { Commander::Command::Options.new }
 
   before do
     StackMaster.cloud_formation_driver.set_region(region)

--- a/spec/stack_master/commands/init_spec.rb
+++ b/spec/stack_master/commands/init_spec.rb
@@ -1,8 +1,9 @@
 RSpec.describe StackMaster::Commands::Init do
 
-  subject(:init_command) { described_class.new(false, region, stack_name) }
+  subject(:init_command) { described_class.new(options, region, stack_name) }
   let(:region) { "us-east-1" }
   let(:stack_name) { "test-stack" }
+  let(:options) { double(overwrite: false)}
 
   describe "#perform" do
     it "creates all the expected files" do

--- a/spec/stack_master/commands/status_spec.rb
+++ b/spec/stack_master/commands/status_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe StackMaster::Commands::Status do
-  subject(:status) { described_class.new(config, false) }
+  subject(:status) { described_class.new(config, Commander::Command::Options.new, false) }
   let(:config) { instance_double(StackMaster::Config, stacks: stacks) }
   let(:stacks) { [stack_definition_1, stack_definition_2] }
   let(:stack_definition_1) { double(:stack_definition_1, region: 'us-east-1', stack_name: 'stack1', allowed_accounts: []) }


### PR DESCRIPTION
#### Context

StackMaster commands rescue a couple of error types during processing.

https://github.com/envato/stack_master/blob/d598e12de421ac7510e0e1bf1dd2e46d5bb88c91/lib/stack_master/command.rb#L25-L27

However, it's difficult to get more information on what went wrong as only the class and message is printed to the terminal.

#### Change

Also print the backtrace if the `--trace` option is provided.