### PR TITLE
Dashes in parameter filenames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 - When a stack name includes a dash (`-`), the corresponding parameter files
   can have either dash, or underscore (`_`) in the filename ([#321]).
+  `stack_master init` will use filenames that match the provided stack name.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ The format is based on [Keep a Changelog], and this project adheres to
 - Load fewer Ruby files: remove several ActiveSupport core extensions and
   Rubygems `require`s ([#318]).
 
+- When a stack name includes a dash (`-`), the corresponding parameter files
+  can have either dash, or underscore (`_`) in the filename ([#321]).
+
 ### Fixed
 
 - `stack_master apply` prints list of parameter file locations if no stack
@@ -37,6 +40,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 [#317]: https://github.com/envato/stack_master/pull/317
 [#318]: https://github.com/envato/stack_master/pull/318
 [#319]: https://github.com/envato/stack_master/pull/319
+[#321]: https://github.com/envato/stack_master/pull/321
 
 ## [2.2.0]
 

--- a/README.md
+++ b/README.md
@@ -157,14 +157,12 @@ template_compilers:
 
 Parameters are loaded from multiple YAML files, merged from the following lookup paths from bottom to top:
 
-- parameters/[underscored_stack_name].yaml
-- parameters/[underscored_stack_name].yml
-- parameters/[region]/[underscored_stack_name].yaml
-- parameters/[region]/[underscored_stack_name].yml
-- parameters/[region_alias]/[underscored_stack_name].yaml
-- parameters/[region_alias]/[underscored_stack_name].yml
-
-**Note:** The file names must be underscored, not hyphenated, even if the stack names are hyphenated.
+- parameters/[stack_name].yaml
+- parameters/[stack_name].yml
+- parameters/[region]/[stack_name].yaml
+- parameters/[region]/[stack_name].yml
+- parameters/[region_alias]/[stack_name].yaml
+- parameters/[region_alias]/[stack_name].yml
 
 A simple parameter file could look like this:
 

--- a/features/apply_with_dash_in_filenames.feature
+++ b/features/apply_with_dash_in_filenames.feature
@@ -1,0 +1,43 @@
+Feature: Apply command
+
+  Background:
+    Given a file named "stack_master.yml" with:
+      """
+      stacks:
+        us_east_1:
+          myapp-web:
+            template: myapp-web.rb
+      """
+    And a directory named "parameters"
+    And a file named "parameters/myapp-web.yml" with:
+      """
+      VpcId: vpc-id-in-properties
+      """
+    And a directory named "templates"
+    And a file named "templates/myapp-web.rb" with:
+      """
+      SparkleFormation.new(:myapp_web) do
+        description "Test template"
+        parameters.vpc_id.type 'AWS::EC2::VPC::Id'
+        resources.test_sg do
+          type 'AWS::EC2::SecurityGroup'
+          properties do
+            group_description 'Test SG'
+            vpc_id ref!(:vpc_id)
+          end
+        end
+      end
+      """
+
+  Scenario: Run apply with dash in filenames
+    Given I stub the following stack events:
+      | stack_id | event_id | stack_name | logical_resource_id | resource_status | resource_type              | timestamp           |
+      | 1        | 1        | myapp-web  | TestSg              | CREATE_COMPLETE | AWS::EC2::SecurityGroup    | 2020-10-29 00:00:00 |
+      | 1        | 1        | myapp-web  | myapp-web           | CREATE_COMPLETE | AWS::CloudFormation::Stack | 2020-10-29 00:00:00 |
+    When I run `stack_master apply us-east-1 myapp-web --trace`
+    And the output should contain all of these lines:
+      | Stack diff:                                                                    |
+      | +    "TestSg": {                                                               |
+      | Parameters diff:                                                               |
+      | +VpcId: vpc-id-in-properties                                                   |
+    Then the exit status should be 0

--- a/lib/stack_master/commands/init.rb
+++ b/lib/stack_master/commands/init.rb
@@ -24,8 +24,8 @@ module StackMaster
       def check_files
         @stack_master_filename = "stack_master.yml"
         @stack_json_filename = "templates/#{@stack_name}.json"
-        @parameters_filename = File.join("parameters", "#{underscored_stack_name}.yml")
-        @region_parameters_filename = File.join("parameters", @region, "#{underscored_stack_name}.yml")
+        @parameters_filename = File.join("parameters", "#{@stack_name}.yml")
+        @region_parameters_filename = File.join("parameters", @region, "#{@stack_name}.yml")
 
         if !@options.overwrite
           [@stack_master_filename, @stack_json_filename, @parameters_filename, @region_parameters_filename].each do |filename|
@@ -87,10 +87,6 @@ module StackMaster
 
       def parameter_region_template
         File.join(StackMaster.base_dir, "stacktemplates", "parameter_region.yml")
-      end
-
-      def underscored_stack_name
-        @stack_name.gsub('-', '_')
       end
 
       def render(renderer)

--- a/lib/stack_master/stack_definition.rb
+++ b/lib/stack_master/stack_definition.rb
@@ -105,20 +105,20 @@ module StackMaster
 
     def additional_parameter_lookup_globs
       additional_parameter_lookup_dirs.map do |a|
-        File.join(base_dir, 'parameters', a, "#{underscored_stack_name}.y*ml")
+        File.join(base_dir, 'parameters', a, "#{stack_name_glob}.y*ml")
       end
     end
 
     def region_parameter_glob
-      File.join(base_dir, 'parameters', "#{region}", "#{underscored_stack_name}.y*ml")
+      File.join(base_dir, 'parameters', "#{region}", "#{stack_name_glob}.y*ml")
     end
 
     def default_parameter_glob
-      File.join(base_dir, 'parameters', "#{underscored_stack_name}.y*ml")
+      File.join(base_dir, 'parameters', "#{stack_name_glob}.y*ml")
     end
 
-    def underscored_stack_name
-      stack_name.gsub('-', '_')
+    def stack_name_glob
+      stack_name.gsub('-', '[-_]')
     end
   end
 end

--- a/spec/stack_master/commands/apply_spec.rb
+++ b/spec/stack_master/commands/apply_spec.rb
@@ -274,8 +274,8 @@ RSpec.describe StackMaster::Commands::Apply do
       expect { apply }.to output(<<~OUTPUT).to_stderr
         Empty/blank parameters detected, ensure values exist for those parameters.
         Parameters will be read from the following locations:
-         - parameters/myapp_vpc.y*ml
-         - parameters/us-east-1/myapp_vpc.y*ml
+         - parameters/myapp[-_]vpc.y*ml
+         - parameters/us-east-1/myapp[-_]vpc.y*ml
       OUTPUT
     end
 

--- a/spec/stack_master/commands/init_spec.rb
+++ b/spec/stack_master/commands/init_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe StackMaster::Commands::Init do
   describe "#perform" do
     it "creates all the expected files" do
       expect(IO).to receive(:write).with("stack_master.yml", "stacks:\n  us-east-1:\n    test-stack:\n      template: test-stack.json\n      tags:\n        environment: production\n")
-      expect(IO).to receive(:write).with("parameters/test_stack.yml", "# Add parameters here:\n# param1: value1\n# param2: value2\n")
-      expect(IO).to receive(:write).with("parameters/us-east-1/test_stack.yml", "# Add parameters here:\n# param1: value1\n# param2: value2\n")
+      expect(IO).to receive(:write).with("parameters/test-stack.yml", "# Add parameters here:\n# param1: value1\n# param2: value2\n")
+      expect(IO).to receive(:write).with("parameters/us-east-1/test-stack.yml", "# Add parameters here:\n# param1: value1\n# param2: value2\n")
       expect(IO).to receive(:write).with("templates/test-stack.json", "{\n  \"AWSTemplateFormatVersion\" : \"2010-09-09\",\n  \"Description\" : \"Cloudformation stack for test-stack\",\n\n  \"Parameters\" : {\n    \"InstanceType\" : {\n      \"Description\" : \"EC2 instance type\",\n      \"Type\" : \"String\"\n    }\n  },\n\n  \"Mappings\" : {\n  },\n\n  \"Resources\" : {\n  },\n\n  \"Outputs\" : {\n  }\n}\n")
       init_command.perform()
     end

--- a/spec/stack_master/stack_definition_spec.rb
+++ b/spec/stack_master/stack_definition_spec.rb
@@ -50,6 +50,17 @@ RSpec.describe StackMaster::StackDefinition do
     ])
   end
 
+  context 'given a stack_name with a dash' do
+    let(:stack_name) { 'stack-name' }
+
+    it 'returns globs supporting dashes and underscores in the parameter filenames' do
+      expect(stack_definition.parameter_file_globs).to eq([
+        "/base_dir/parameters/stack[-_]name.y*ml",
+        "/base_dir/parameters/#{region}/stack[-_]name.y*ml",
+      ])
+    end
+  end
+
   context 'with additional parameter lookup dirs' do
     before do
       stack_definition.additional_parameter_lookup_dirs = ['production']
@@ -80,6 +91,18 @@ RSpec.describe StackMaster::StackDefinition do
         "/base_dir/parameters/#{region}/#{stack_name}.y*ml",
         "/base_dir/parameters/production/#{stack_name}.y*ml",
       ])
+    end
+
+    context 'given a stack_name with a dash' do
+      let(:stack_name) { 'stack-name' }
+
+      it 'returns globs supporting dashes and underscores in the parameter filenames' do
+        expect(stack_definition.parameter_file_globs).to eq([
+          "/base_dir/parameters/stack[-_]name.y*ml",
+          "/base_dir/parameters/#{region}/stack[-_]name.y*ml",
+          "/base_dir/parameters/production/stack[-_]name.y*ml",
+        ])
+      end
     end
   end
 


### PR DESCRIPTION
When a stack name includes a dash (`-`), the corresponding parameter filenames need this replaced with an underscore (`_`). This has produced much confusion (see #262).

I propose that when a stack name includes a dash, StackMaster should support a dash in the corresponding parameter filenames. For backwards compatibility, we should continue to support an underscore also.

In addition, the `stack_master init` command should produce parameter files that match the provided stack name.