### PR TITLE
Apply command prints names of parameters with missing values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,13 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- `stack_master apply` prints names of parameters with missing values
+  ([#322]).
+
 [Unreleased]: https://github.com/envato/stack_master/compare/v2.3.0...HEAD
+[#322]: https://github.com/envato/stack_master/pull/322
 
 ## [2.3.0] - 2020-03-19
 

--- a/features/apply_without_parameter_file.feature
+++ b/features/apply_without_parameter_file.feature
@@ -27,11 +27,12 @@ Feature: Apply command without parameter files
       """
     When I run `stack_master apply production myapp --trace`
     Then the output should contain all of these lines:
-      | Empty/blank parameters detected, ensure values exist for those parameters. |
-      | Parameters will be read from the following locations:                      |
-      | - parameters/myapp.y*ml                                                    |
-      | - parameters/us-east-1/myapp.y*ml                                          |
-      | - parameters/production/myapp.y*ml                                         |
+      | Empty/blank parameters detected. Please provide values for these parameters: |
+      | - KeyName                                                                    |
+      | Parameters will be read from files matching the following globs:             |
+      | - parameters/myapp.y*ml                                                      |
+      | - parameters/us-east-1/myapp.y*ml                                            |
+      | - parameters/production/myapp.y*ml                                           |
     And the exit status should be 1
 
   Scenario: Without a region alias
@@ -44,9 +45,10 @@ Feature: Apply command without parameter files
       """
     When I run `stack_master apply us-east-1 myapp --trace`
     Then the output should contain all of these lines:
-      | Empty/blank parameters detected, ensure values exist for those parameters. |
-      | Parameters will be read from the following locations:                      |
-      | - parameters/myapp.y*ml                                                    |
-      | - parameters/us-east-1/myapp.y*ml                                          |
+      | Empty/blank parameters detected. Please provide values for these parameters: |
+      | - KeyName                                                                    |
+      | Parameters will be read from files matching the following globs:             |
+      | - parameters/myapp.y*ml                                                      |
+      | - parameters/us-east-1/myapp.y*ml                                            |
     And the output should not contain "- parameters/production/myapp.y*ml"
     And the exit status should be 1

--- a/lib/stack_master/commands/apply.rb
+++ b/lib/stack_master/commands/apply.rb
@@ -206,14 +206,15 @@ module StackMaster
 
       def ensure_valid_parameters!
         if @proposed_stack.missing_parameters?
-          message = <<~MESSAGE
-            Empty/blank parameters detected, ensure values exist for those parameters.
-            Parameters will be read from the following locations:
-          MESSAGE
+          message = "Empty/blank parameters detected. Please provide values for these parameters:"
+          @proposed_stack.missing_parameters.each do |parameter_name|
+            message << "\n - #{parameter_name}"
+          end
+          message << "\nParameters will be read from files matching the following globs:"
           base_dir = Pathname.new(@stack_definition.base_dir)
           @stack_definition.parameter_file_globs.each do |glob|
             parameter_file = Pathname.new(glob).relative_path_from(base_dir)
-            message << " - #{parameter_file}\n"
+            message << "\n - #{parameter_file}"
           end
           failed!(message)
         end

--- a/lib/stack_master/stack.rb
+++ b/lib/stack_master/stack.rb
@@ -27,10 +27,12 @@ module StackMaster
       template_default_parameters.merge(parameters)
     end
 
+    def missing_parameters
+      parameters_with_defaults.select { |_key, value| value.nil? }.keys
+    end
+
     def missing_parameters?
-      parameters_with_defaults.any? do |key, value|
-        value == nil
-      end
+      missing_parameters.any?
     end
 
     def self.find(region, stack_name)

--- a/spec/stack_master/commands/apply_spec.rb
+++ b/spec/stack_master/commands/apply_spec.rb
@@ -264,7 +264,7 @@ RSpec.describe StackMaster::Commands::Apply do
 
   context 'one or more parameters are empty' do
     let(:stack) { StackMaster::Stack.new(stack_id: '1', parameters: parameters) }
-    let(:parameters) { { 'param_1' => nil } }
+    let(:parameters) { {'param1' => nil, 'param2' => nil, 'param3' => true} }
 
     it "doesn't allow apply" do
       expect { apply }.to_not output(/Continue and apply the stack/).to_stdout
@@ -272,8 +272,10 @@ RSpec.describe StackMaster::Commands::Apply do
 
     it 'outputs a description of the problem including where param files are loaded from' do
       expect { apply }.to output(<<~OUTPUT).to_stderr
-        Empty/blank parameters detected, ensure values exist for those parameters.
-        Parameters will be read from the following locations:
+        Empty/blank parameters detected. Please provide values for these parameters:
+         - param1
+         - param2
+        Parameters will be read from files matching the following globs:
          - parameters/myapp[-_]vpc.y*ml
          - parameters/us-east-1/myapp[-_]vpc.y*ml
       OUTPUT

--- a/spec/stack_master/stack_spec.rb
+++ b/spec/stack_master/stack_spec.rb
@@ -188,4 +188,24 @@ RSpec.describe StackMaster::Stack do
       it { should eq false }
     end
   end
+
+  describe '#missing_parameters' do
+    subject(:missing_parameters) { stack.missing_parameters }
+
+    let(:stack) { StackMaster::Stack.new(parameters: parameters, template_body: '{}', template_format: :json) }
+
+    context 'when some parameters have a nil value' do
+      let(:parameters) { {'non_nil' => true, 'nil_param1' => nil, 'nil_param2' => nil} }
+
+      it 'returns the parameter names with nil values' do
+        expect(missing_parameters).to eq(['nil_param1', 'nil_param2'])
+      end
+    end
+
+    context 'when no parameters have a nil value' do
+      let(:parameters) { {'my_param' => '1'} }
+
+      it { should eq([]) }
+    end
+  end
 end


### PR DESCRIPTION
It'd be handy two know which parameter is missing a value when `stack_master apply` fails. Let's print this out in the error message.

```
Empty/blank parameters detected. Please provide values for these parameters:
 - param1
 - param2
Parameters will be read from files matching the following globs:
 - parameters/myapp.y*ml
 - parameters/us-east-1/myapp.y*ml
```