### PR TITLE
Validate command checks for missing parameter values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,14 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ### Added
 
+- `stack_master validate` checks for missing parameter values ([#323]).
+
 - `stack_master apply` prints names of parameters with missing values
   ([#322]).
 
 [Unreleased]: https://github.com/envato/stack_master/compare/v2.3.0...HEAD
 [#322]: https://github.com/envato/stack_master/pull/322
+[#323]: https://github.com/envato/stack_master/pull/323
 
 ## [2.3.0] - 2020-03-19
 

--- a/features/validate_with_missing_parameters.feature
+++ b/features/validate_with_missing_parameters.feature
@@ -1,0 +1,44 @@
+Feature: Validate command with missing parameters
+
+  Background:
+    Given a file named "stack_master.yml" with:
+      """
+      stacks:
+        us_east_1:
+          stack1:
+            template: stack1.rb
+      """
+    And a directory named "parameters"
+    And a file named "parameters/stack1.yml" with:
+      """
+      ParameterOne: populated
+      """
+    And a directory named "templates"
+    And a file named "templates/stack1.rb" with:
+      """
+      SparkleFormation.new(:awesome_stack) do
+        parameters do
+          parameter_one.type 'String'
+          parameter_two.type 'String'
+          parameter_three.type 'String'
+        end
+        resources.vpc do
+          type 'AWS::EC2::VPC'
+          properties.cidr_block '10.200.0.0/16'
+        end
+        outputs.vpc_id.value ref!(:vpc)
+      end
+      """
+
+  Scenario: Reports the missing parameter values
+    Given I stub CloudFormation validate calls to pass validation
+    When I run `stack_master validate us-east-1 stack1`
+    Then the output should contain all of these lines:
+      | stack1: invalid                                                              |
+      | Empty/blank parameters detected. Please provide values for these parameters: |
+      | - ParameterTwo                                                               |
+      | - ParameterThree                                                             |
+      | Parameters will be read from files matching the following globs:             |
+      | - parameters/stack1.y*ml                                                     |
+      | - parameters/us-east-1/stack1.y*ml                                           |
+    And the exit status should be 1

--- a/lib/stack_master.rb
+++ b/lib/stack_master.rb
@@ -45,6 +45,7 @@ module StackMaster
 
   autoload :StackDiffer, 'stack_master/stack_differ'
   autoload :Validator, 'stack_master/validator'
+  autoload :ParameterValidator, 'stack_master/parameter_validator'
 
   require 'stack_master/template_compilers/sparkle_formation'
   require 'stack_master/template_compilers/json'

--- a/lib/stack_master/commands/apply.rb
+++ b/lib/stack_master/commands/apply.rb
@@ -1,5 +1,3 @@
-require 'pathname'
-
 module StackMaster
   module Commands
     class Apply
@@ -205,19 +203,8 @@ module StackMaster
       end
 
       def ensure_valid_parameters!
-        if @proposed_stack.missing_parameters?
-          message = "Empty/blank parameters detected. Please provide values for these parameters:"
-          @proposed_stack.missing_parameters.each do |parameter_name|
-            message << "\n - #{parameter_name}"
-          end
-          message << "\nParameters will be read from files matching the following globs:"
-          base_dir = Pathname.new(@stack_definition.base_dir)
-          @stack_definition.parameter_file_globs.each do |glob|
-            parameter_file = Pathname.new(glob).relative_path_from(base_dir)
-            message << "\n - #{parameter_file}"
-          end
-          failed!(message)
-        end
+        pv = ParameterValidator.new(stack: @proposed_stack, stack_definition: @stack_definition)
+        failed!(pv.error_message) if pv.missing_parameters?
       end
 
       def ensure_valid_template_body_size!

--- a/lib/stack_master/parameter_validator.rb
+++ b/lib/stack_master/parameter_validator.rb
@@ -1,0 +1,36 @@
+require 'pathname'
+
+module StackMaster
+  class ParameterValidator
+    def initialize(stack:, stack_definition:)
+      @stack = stack
+      @stack_definition = stack_definition
+    end
+
+    def error_message
+      return nil unless missing_parameters?
+      message = "Empty/blank parameters detected. Please provide values for these parameters:"
+      missing_parameters.each do |parameter_name|
+        message << "\n - #{parameter_name}"
+      end
+      message << "\nParameters will be read from files matching the following globs:"
+      base_dir = Pathname.new(@stack_definition.base_dir)
+      @stack_definition.parameter_file_globs.each do |glob|
+        parameter_file = Pathname.new(glob).relative_path_from(base_dir)
+        message << "\n - #{parameter_file}"
+      end
+      message
+    end
+
+    def missing_parameters?
+      missing_parameters.any?
+    end
+
+    private
+
+    def missing_parameters
+      @missing_parameters ||=
+        @stack.parameters_with_defaults.select { |_key, value| value.nil? }.keys
+    end
+  end
+end

--- a/lib/stack_master/stack.rb
+++ b/lib/stack_master/stack.rb
@@ -27,14 +27,6 @@ module StackMaster
       template_default_parameters.merge(parameters)
     end
 
-    def missing_parameters
-      parameters_with_defaults.select { |_key, value| value.nil? }.keys
-    end
-
-    def missing_parameters?
-      missing_parameters.any?
-    end
-
     def self.find(region, stack_name)
       cf = StackMaster.cloud_formation_driver
       cf_stack = cf.describe_stacks(stack_name: stack_name).stacks.first

--- a/lib/stack_master/validator.rb
+++ b/lib/stack_master/validator.rb
@@ -11,6 +11,10 @@ module StackMaster
 
     def perform
       StackMaster.stdout.print "#{@stack_definition.stack_name}: "
+      if parameter_validator.missing_parameters?
+        StackMaster.stdout.puts "invalid\n#{parameter_validator.error_message}"
+        return false
+      end
       cf.validate_template(template_body: TemplateUtils.maybe_compressed_template_body(stack.template_body))
       StackMaster.stdout.puts "valid"
       true
@@ -27,6 +31,10 @@ module StackMaster
 
     def stack
       @stack ||= Stack.generate(@stack_definition, @config)
+    end
+
+    def parameter_validator
+      @parameter_validator ||= ParameterValidator.new(stack: stack, stack_definition: @stack_definition)
     end
   end
 end

--- a/lib/stack_master/validator.rb
+++ b/lib/stack_master/validator.rb
@@ -10,12 +10,8 @@ module StackMaster
     end
 
     def perform
-      parameter_hash = ParameterLoader.load(@stack_definition.parameter_files)
-      compile_time_parameters = ParameterResolver.resolve(@config, @stack_definition, parameter_hash[:compile_time_parameters])
-
       StackMaster.stdout.print "#{@stack_definition.stack_name}: "
-      template_body = TemplateCompiler.compile(@config, @stack_definition.compiler, @stack_definition.template_dir, @stack_definition.template, compile_time_parameters, @stack_definition.compiler_options)
-      cf.validate_template(template_body: TemplateUtils.maybe_compressed_template_body(template_body))
+      cf.validate_template(template_body: TemplateUtils.maybe_compressed_template_body(stack.template_body))
       StackMaster.stdout.puts "valid"
       true
     rescue Aws::CloudFormation::Errors::ValidationError => e
@@ -27,6 +23,10 @@ module StackMaster
 
     def cf
       @cf ||= StackMaster.cloud_formation_driver
+    end
+
+    def stack
+      @stack ||= Stack.generate(@stack_definition, @config)
     end
   end
 end

--- a/spec/fixtures/templates/mystack-with-parameters.yaml
+++ b/spec/fixtures/templates/mystack-with-parameters.yaml
@@ -1,0 +1,6 @@
+Parameters:
+  ParamOne:
+    Type: string
+  ParamTwo:
+    Type: string
+

--- a/spec/stack_master/parameter_validator_spec.rb
+++ b/spec/stack_master/parameter_validator_spec.rb
@@ -1,0 +1,47 @@
+RSpec.describe StackMaster::ParameterValidator do
+  subject(:parameter_validator) { described_class.new(stack: stack, stack_definition: stack_definition) }
+
+  let(:stack) { StackMaster::Stack.new(parameters: parameters, template_body: '{}', template_format: :json) }
+  let(:stack_definition) { StackMaster::StackDefinition.new(base_dir: '/base_dir', region: 'ap-southeast-2', stack_name: 'stack_name') }
+
+  describe '#missing_parameters?' do
+    subject { parameter_validator.missing_parameters? }
+
+    context 'when a parameter has a nil value' do
+      let(:parameters) { {'my_param' => nil} }
+
+      it { should eq true }
+    end
+
+    context 'when no parameers have a nil value' do
+      let(:parameters) { {'my_param' => '1'} }
+
+      it { should eq false }
+    end
+  end
+
+  describe '#error_message' do
+    subject(:error_message) { parameter_validator.error_message }
+
+    context 'when a parameter has a nil value' do
+      let(:parameters) { {'Param1' => true, 'Param2' => nil, 'Param3' => 'string', 'Param4' => nil} }
+
+      it 'returns a descriptive message' do
+        expect(error_message).to eq(<<~MESSAGE.chomp)
+          Empty/blank parameters detected. Please provide values for these parameters:
+           - Param2
+           - Param4
+          Parameters will be read from files matching the following globs:
+           - parameters/stack_name.y*ml
+           - parameters/ap-southeast-2/stack_name.y*ml
+        MESSAGE
+      end
+    end
+
+    context 'when no parameers have a nil value' do
+      let(:parameters) { {'Param' => '1'} }
+
+      it { should eq nil }
+    end
+  end
+end

--- a/spec/stack_master/stack_spec.rb
+++ b/spec/stack_master/stack_spec.rb
@@ -170,42 +170,4 @@ RSpec.describe StackMaster::Stack do
       end
     end
   end
-
-  describe '#missing_parameters?' do
-    subject { stack.missing_parameters? }
-
-    let(:stack) { StackMaster::Stack.new(parameters: parameters, template_body: '{}', template_format: :json) }
-
-    context 'when a parameter has a nil value' do
-      let(:parameters) { {'my_param' => nil} }
-
-      it { should eq true }
-    end
-
-    context 'when no parameers have a nil value' do
-      let(:parameters) { {'my_param' => '1'} }
-
-      it { should eq false }
-    end
-  end
-
-  describe '#missing_parameters' do
-    subject(:missing_parameters) { stack.missing_parameters }
-
-    let(:stack) { StackMaster::Stack.new(parameters: parameters, template_body: '{}', template_format: :json) }
-
-    context 'when some parameters have a nil value' do
-      let(:parameters) { {'non_nil' => true, 'nil_param1' => nil, 'nil_param2' => nil} }
-
-      it 'returns the parameter names with nil values' do
-        expect(missing_parameters).to eq(['nil_param1', 'nil_param2'])
-      end
-    end
-
-    context 'when no parameters have a nil value' do
-      let(:parameters) { {'my_param' => '1'} }
-
-      it { should eq([]) }
-    end
-  end
 end


### PR DESCRIPTION
An implementation of the improvement suggested in #189.

There is some custom code in the `apply` command that checks for parameters with no values. If blank parameters are found, it aborts the process and prints a friendly message.

In this proposal, the code has been extracted to a separate class, `ParameterValidator` and the `validate` command modified to use this check. It prints out the same helpful message if it finds this issue.

```
myapp_vpc: invalid
Empty/blank parameters detected. Please provide values for these parameters:
 - ParamOne
 - ParamTwo
Parameters will be read from files matching the following globs:
 - parameters/myapp_vpc.y*ml
 - parameters/us-east-1/myapp_vpc.y*ml
```