### PR TITLE
Fix role assumer region issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,14 @@ The format is based on [Keep a Changelog], and this project adheres to
 - `stack_master apply` prints names of parameters with missing values
   ([#322]).
 
+### Fixed
+
+- Error assuming role when default aws region not configured in the
+  environment ([324])
+
 [Unreleased]: https://github.com/envato/stack_master/compare/v2.3.0...HEAD
 [#322]: https://github.com/envato/stack_master/pull/322
+[#324]: https://github.com/envato/stack_master/pull/324
 
 ## [2.3.0] - 2020-03-19
 

--- a/features/step_definitions/asume_role_steps.rb
+++ b/features/step_definitions/asume_role_steps.rb
@@ -1,5 +1,6 @@
 Then(/^I expect the role "([^"]*)" is assumed in account "([^"]*)"$/) do |role, account|
   expect(Aws::AssumeRoleCredentials).to receive(:new).with(
+    region: instance_of(String),
     role_arn: "arn:aws:iam::#{account}:role/#{role}",
     role_session_name: instance_of(String)
   )

--- a/lib/stack_master/role_assumer.rb
+++ b/lib/stack_master/role_assumer.rb
@@ -45,6 +45,7 @@ module StackMaster
       credentials_key = "#{account}:#{role}"
       @credentials.fetch(credentials_key) do
         @credentials[credentials_key] = Aws::AssumeRoleCredentials.new(
+          region: StackMaster.cloud_formation_driver.region,
           role_arn: "arn:aws:iam::#{account}:role/#{role}",
           role_session_name: "stack-master-role-assumer"
         )

--- a/spec/stack_master/role_assumer_spec.rb
+++ b/spec/stack_master/role_assumer_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe StackMaster::RoleAssumer do
 
     before do
       allow(Aws::AssumeRoleCredentials).to receive(:new).and_return(credentials)
+      StackMaster.cloud_formation_driver.set_region('us-east-1')
     end
 
     it 'calls the assume role API once' do

--- a/spec/stack_master/role_assumer_spec.rb
+++ b/spec/stack_master/role_assumer_spec.rb
@@ -3,6 +3,7 @@ RSpec.describe StackMaster::RoleAssumer do
 
   let(:account) { '1234567890' }
   let(:role) { 'my-role' }
+  let(:role_arn) { "arn:aws:iam::#{account}:role/#{role}" }
 
   describe '#assume_role' do
     let(:assume_role) { role_assumer.assume_role(account, role, &my_block) }
@@ -15,7 +16,7 @@ RSpec.describe StackMaster::RoleAssumer do
 
     it 'calls the assume role API once' do
       expect(Aws::AssumeRoleCredentials).to receive(:new).with(
-        role_arn: "arn:aws:iam::#{account}:role/#{role}",
+        role_arn: role_arn,
         role_session_name: instance_of(String)
       ).once
 
@@ -32,7 +33,7 @@ RSpec.describe StackMaster::RoleAssumer do
 
     it 'assumes the role before calling block' do
       expect(Aws::AssumeRoleCredentials).to receive(:new).with(
-        role_arn: "arn:aws:iam::#{account}:role/#{role}",
+        role_arn: role_arn,
         role_session_name: instance_of(String)
       ).ordered
       expect(my_block).to receive(:call).ordered
@@ -116,7 +117,7 @@ RSpec.describe StackMaster::RoleAssumer do
       context 'with the same account and role' do
         it 'assumes the role once' do
           expect(Aws::AssumeRoleCredentials).to receive(:new).with(
-            role_arn: "arn:aws:iam::#{account}:role/#{role}",
+            role_arn: role_arn,
             role_session_name: instance_of(String)
           ).once
 
@@ -128,7 +129,7 @@ RSpec.describe StackMaster::RoleAssumer do
       context 'with a different account' do
         it 'assumes each role once' do
           expect(Aws::AssumeRoleCredentials).to receive(:new).with(
-            role_arn: "arn:aws:iam::#{account}:role/#{role}",
+            role_arn: role_arn,
             role_session_name: instance_of(String)
           ).once
           expect(Aws::AssumeRoleCredentials).to receive(:new).with(
@@ -144,7 +145,7 @@ RSpec.describe StackMaster::RoleAssumer do
       context 'with a different role' do
         it 'assumes each role once' do
           expect(Aws::AssumeRoleCredentials).to receive(:new).with(
-            role_arn: "arn:aws:iam::#{account}:role/#{role}",
+            role_arn: role_arn,
             role_session_name: instance_of(String)
           ).once
           expect(Aws::AssumeRoleCredentials).to receive(:new).with(

--- a/spec/stack_master/role_assumer_spec.rb
+++ b/spec/stack_master/role_assumer_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe StackMaster::RoleAssumer do
 
     it 'calls the assume role API once' do
       expect(Aws::AssumeRoleCredentials).to receive(:new).with(
+        region: instance_of(String),
         role_arn: role_arn,
         role_session_name: instance_of(String)
       ).once
@@ -33,10 +34,22 @@ RSpec.describe StackMaster::RoleAssumer do
 
     it 'assumes the role before calling block' do
       expect(Aws::AssumeRoleCredentials).to receive(:new).with(
+        region: instance_of(String),
         role_arn: role_arn,
         role_session_name: instance_of(String)
       ).ordered
       expect(my_block).to receive(:call).ordered
+
+      assume_role
+    end
+
+    it "uses the cloudformation driver's region" do
+      StackMaster.cloud_formation_driver.set_region('my-region')
+      expect(Aws::AssumeRoleCredentials).to receive(:new).with(
+        region: 'my-region',
+        role_arn: instance_of(String),
+        role_session_name: instance_of(String)
+      )
 
       assume_role
     end
@@ -117,6 +130,7 @@ RSpec.describe StackMaster::RoleAssumer do
       context 'with the same account and role' do
         it 'assumes the role once' do
           expect(Aws::AssumeRoleCredentials).to receive(:new).with(
+            region: instance_of(String),
             role_arn: role_arn,
             role_session_name: instance_of(String)
           ).once
@@ -129,10 +143,12 @@ RSpec.describe StackMaster::RoleAssumer do
       context 'with a different account' do
         it 'assumes each role once' do
           expect(Aws::AssumeRoleCredentials).to receive(:new).with(
+            region: instance_of(String),
             role_arn: role_arn,
             role_session_name: instance_of(String)
           ).once
           expect(Aws::AssumeRoleCredentials).to receive(:new).with(
+            region: instance_of(String),
             role_arn: "arn:aws:iam::another-account:role/#{role}",
             role_session_name: instance_of(String)
           ).once
@@ -145,10 +161,12 @@ RSpec.describe StackMaster::RoleAssumer do
       context 'with a different role' do
         it 'assumes each role once' do
           expect(Aws::AssumeRoleCredentials).to receive(:new).with(
+            region: instance_of(String),
             role_arn: role_arn,
             role_session_name: instance_of(String)
           ).once
           expect(Aws::AssumeRoleCredentials).to receive(:new).with(
+            region: instance_of(String),
             role_arn: "arn:aws:iam::#{account}:role/another-role",
             role_session_name: instance_of(String)
           ).once


### PR DESCRIPTION
#### Context

There is an error when assuming a role without having configured a default AWS region in your environment:

```
Executing apply on my-stack in us-east-1
Aws::Errors::MissingRegionError: missing region; use :region option or export region name to ENV['AWS_REGION']
```

#### Changes

- Use the CloudFormation driver's region, which includes fallbacks when it's not specified, when assuming a role

#### Considerations

Which region is used doesn't actually matter when assuming a role, as IAM and STS are global services.