### PR TITLE
Include the license in the gem package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,12 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Include the license document in the gem package ([#328]).
+
 [Unreleased]: https://github.com/envato/stack_master/compare/v2.4.0...HEAD
+[#328]: https://github.com/envato/stack_master/pull/328
 
 ## [2.4.0] - 2020-04-03
 

--- a/stack_master.gemspec
+++ b/stack_master.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
     "source_code_uri"   => "https://github.com/envato/stack_master/tree/v#{spec.version}",
   }
 
-  spec.files         = Dir.glob("{bin,lib,stacktemplates}/**/*") + %w(README.md)
+  spec.files         = Dir.glob("{bin,lib,stacktemplates}/**/*") + %w(README.md LICENSE.txt)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]


### PR DESCRIPTION
The document reads:

> The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.

So we should do our part by including it in the gem package.