### PR TITLE
Add `stack_master validate --no-validate-template-parameters` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,12 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 - Include the license document in the gem package ([#328]).
 
+- Add an option `stack_master validate --no-validate-template-parameters`
+  that disables the validation of template parameters ([#331]).
+
 [Unreleased]: https://github.com/envato/stack_master/compare/v2.4.0...HEAD
 [#328]: https://github.com/envato/stack_master/pull/328
+[#331]: https://github.com/envato/stack_master/pull/331
 
 ## [2.4.0] - 2020-04-03
 

--- a/features/validate_with_missing_parameters.feature
+++ b/features/validate_with_missing_parameters.feature
@@ -42,3 +42,23 @@ Feature: Validate command with missing parameters
       | - parameters/stack1.y*ml                                                     |
       | - parameters/us-east-1/stack1.y*ml                                           |
     And the exit status should be 1
+
+  Scenario: Given the --validate-template-parameters option, it reports the missing parameter values
+    Given I stub CloudFormation validate calls to pass validation
+    When I run `stack_master validate --validate-template-parameters us-east-1 stack1`
+    Then the output should contain all of these lines:
+      | stack1: invalid                                                              |
+      | Empty/blank parameters detected. Please provide values for these parameters: |
+      | - ParameterTwo                                                               |
+      | - ParameterThree                                                             |
+      | Parameters will be read from files matching the following globs:             |
+      | - parameters/stack1.y*ml                                                     |
+      | - parameters/us-east-1/stack1.y*ml                                           |
+    And the exit status should be 1
+
+  Scenario: Given the --no-validate-template-parameters option, it doesn't report the missing parameter values
+    Given I stub CloudFormation validate calls to pass validation
+    When I run `stack_master validate --no-validate-template-parameters us-east-1 stack1`
+    Then the output should contain all of these lines:
+      | stack1: valid                                                                |
+    And the exit status should be 0

--- a/lib/stack_master/cli.rb
+++ b/lib/stack_master/cli.rb
@@ -46,7 +46,7 @@ module StackMaster
         c.option '--on-failure ACTION', String, "Action to take on CREATE_FAILURE. Valid Values: [ DO_NOTHING | ROLLBACK | DELETE ]. Default: ROLLBACK\nNote: You cannot use this option with Serverless Application Model (SAM) templates."
         c.option '--yes-param PARAM_NAME', String, "Auto-approve stack updates when only parameter PARAM_NAME changes"
         c.action do |args, options|
-          options.defaults config: default_config_file
+          options.default config: default_config_file
           execute_stacks_command(StackMaster::Commands::Apply, args, options)
         end
       end
@@ -56,7 +56,7 @@ module StackMaster
         c.summary = 'Displays outputs for a stack'
         c.description = "Displays outputs for a stack"
         c.action do |args, options|
-          options.defaults config: default_config_file
+          options.default config: default_config_file
           execute_stacks_command(StackMaster::Commands::Outputs, args, options)
         end
       end
@@ -67,7 +67,7 @@ module StackMaster
         c.description = 'Initialises the expected directory structure and stack_master.yml file'
         c.option('--overwrite', 'Overwrite existing files')
         c.action do |args, options|
-          options.defaults config: default_config_file
+          options.default config: default_config_file
           unless args.size == 2
             say "Invalid arguments. stack_master init [region] [stack_name]"
           else
@@ -82,7 +82,7 @@ module StackMaster
         c.description = "Shows a diff of the proposed stack's template and parameters"
         c.example 'diff a stack named myapp-vpc in us-east-1', 'stack_master diff us-east-1 myapp-vpc'
         c.action do |args, options|
-          options.defaults config: default_config_file
+          options.default config: default_config_file
           execute_stacks_command(StackMaster::Commands::Diff, args, options)
         end
       end
@@ -96,7 +96,7 @@ module StackMaster
         c.option '--all', 'Show all events'
         c.option '--tail', 'Tail events'
         c.action do |args, options|
-          options.defaults config: default_config_file
+          options.default config: default_config_file
           execute_stacks_command(StackMaster::Commands::Events, args, options)
         end
       end
@@ -106,7 +106,7 @@ module StackMaster
         c.summary = "Shows stack resources"
         c.description = "Shows stack resources"
         c.action do |args, options|
-          options.defaults config: default_config_file
+          options.default config: default_config_file
           execute_stacks_command(StackMaster::Commands::Resources, args, options)
         end
       end
@@ -116,7 +116,7 @@ module StackMaster
         c.summary = 'List stack definitions'
         c.description = 'List stack definitions'
         c.action do |args, options|
-          options.defaults config: default_config_file
+          options.default config: default_config_file
           say "Invalid arguments." if args.size > 0
           config = load_config(options.config)
           StackMaster::Commands::ListStacks.perform(config, nil, options)
@@ -129,7 +129,7 @@ module StackMaster
         c.description = 'Validate a template'
         c.example 'validate a stack named myapp-vpc in us-east-1', 'stack_master validate us-east-1 myapp-vpc'
         c.action do |args, options|
-          options.defaults config: default_config_file
+          options.default config: default_config_file
           execute_stacks_command(StackMaster::Commands::Validate, args, options)
         end
       end
@@ -140,7 +140,7 @@ module StackMaster
         c.description = "Runs cfn-lint on the template which would be sent to AWS on apply"
         c.example 'run cfn-lint on stack myapp-vpc with us-east-1 settings', 'stack_master lint us-east-1 myapp-vpc'
         c.action do |args, options|
-          options.defaults config: default_config_file
+          options.default config: default_config_file
           execute_stacks_command(StackMaster::Commands::Lint, args, options)
         end
       end
@@ -151,7 +151,7 @@ module StackMaster
         c.description = "Processes the stack and prints out a compiled version - same we'd send to AWS"
         c.example 'print compiled stack myapp-vpc with us-east-1 settings', 'stack_master compile us-east-1 myapp-vpc'
         c.action do |args, options|
-          options.defaults config: default_config_file
+          options.default config: default_config_file
           execute_stacks_command(StackMaster::Commands::Compile, args, options)
         end
       end
@@ -162,7 +162,7 @@ module StackMaster
         c.description = 'Checks the status of all stacks defined in the stack_master.yml file. Warning this operation can be somewhat slow.'
         c.example 'description', 'Check the status of all stack definitions'
         c.action do |args, options|
-          options.defaults config: default_config_file
+          options.default config: default_config_file
           say "Invalid arguments. stack_master status" and return unless args.size == 0
           config = load_config(options.config)
           StackMaster::Commands::Status.perform(config, nil, options)
@@ -175,7 +175,7 @@ module StackMaster
         c.description = 'Cross references stack_master.yml with the template and parameter directories to identify extra or missing files.'
         c.example 'description', 'Check for missing or extra files'
         c.action do |args, options|
-          options.defaults config: default_config_file
+          options.default config: default_config_file
           say "Invalid arguments. stack_master tidy" and return unless args.size == 0
           config = load_config(options.config)
           StackMaster::Commands::Tidy.perform(config, nil, options)

--- a/lib/stack_master/cli.rb
+++ b/lib/stack_master/cli.rb
@@ -128,8 +128,9 @@ module StackMaster
         c.summary = 'Validate a template'
         c.description = 'Validate a template'
         c.example 'validate a stack named myapp-vpc in us-east-1', 'stack_master validate us-east-1 myapp-vpc'
+        c.option '--[no-]validate-template-parameters', 'Validate template parameters. Default: validate'
         c.action do |args, options|
-          options.default config: default_config_file
+          options.default config: default_config_file, validate_template_parameters: true
           execute_stacks_command(StackMaster::Commands::Validate, args, options)
         end
       end

--- a/lib/stack_master/commands/validate.rb
+++ b/lib/stack_master/commands/validate.rb
@@ -5,7 +5,7 @@ module StackMaster
       include Commander::UI
 
       def perform
-        failed unless Validator.valid?(@stack_definition, @config)
+        failed unless Validator.valid?(@stack_definition, @config, @options)
       end
     end
   end

--- a/lib/stack_master/stack.rb
+++ b/lib/stack_master/stack.rb
@@ -75,6 +75,25 @@ module StackMaster
           stack_policy_body: stack_policy_body)
     end
 
+    def self.generate_without_parameters(stack_definition, config)
+      parameter_hash = ParameterLoader.load(stack_definition.parameter_files)
+      compile_time_parameters = ParameterResolver.resolve(config, stack_definition, parameter_hash[:compile_time_parameters])
+      template_body = TemplateCompiler.compile(config, stack_definition.compiler, stack_definition.template_dir, stack_definition.template, compile_time_parameters, stack_definition.compiler_options)
+      template_format = TemplateUtils.identify_template_format(template_body)
+      stack_policy_body = if stack_definition.stack_policy_file_path
+                            File.read(stack_definition.stack_policy_file_path)
+                          end
+      new(region: stack_definition.region,
+          stack_name: stack_definition.stack_name,
+          tags: stack_definition.tags,
+          parameters: {},
+          template_body: template_body,
+          template_format: template_format,
+          role_arn: stack_definition.role_arn,
+          notification_arns: stack_definition.notification_arns,
+          stack_policy_body: stack_policy_body)
+    end
+
     def max_template_size(use_s3)
       return TemplateUtils::MAX_S3_TEMPLATE_SIZE if use_s3
       TemplateUtils::MAX_TEMPLATE_SIZE

--- a/spec/stack_master/commands/validate_spec.rb
+++ b/spec/stack_master/commands/validate_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe StackMaster::Commands::Validate do
   let(:config) { instance_double(StackMaster::Config) }
   let(:region) { "us-east-1" }
   let(:stack_name) { "mystack" }
-  let(:options) { }
+  let(:options) { Commander::Command::Options.new }
   let(:stack_definition) do
     StackMaster::StackDefinition.new(
       region: region,
@@ -18,7 +18,7 @@ RSpec.describe StackMaster::Commands::Validate do
   describe "#perform" do
     context "can find stack" do
       it "calls the validator to validate the stack definition" do
-        expect(StackMaster::Validator).to receive(:valid?).with(stack_definition, config)
+        expect(StackMaster::Validator).to receive(:valid?).with(stack_definition, config, options)
         validate.perform
       end
     end


### PR DESCRIPTION
Since version 2.4.0 and #323, the `stack_master validate` validates the presence of template parameter values. This new feature is valuable, has the potential to cause pain in the upgrade process as it:

- attempts to resolve parameters
- requires extra IAM permissions, depending on the parameter resolving features used by the given stack

To ease the upgrade path, I propose an option to disable this new functionality.

```
stack_master validate --no-validate-template-parameters <region> <stack>
```