### PR TITLE
Fix json template detection with extra leading whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,13 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- JSON template bodies with whitespace on leading lines would incorrectly be
+  identified as YAML, leading to `diff` issues. ([#335])
+
 [Unreleased]: https://github.com/envato/stack_master/compare/v2.6.0...HEAD
+[#335]: https://github.com/envato/stack_master/pull/335
 
 ## [2.6.0] - 2020-05-15
 

--- a/lib/stack_master/template_utils.rb
+++ b/lib/stack_master/template_utils.rb
@@ -2,14 +2,14 @@ module StackMaster
   module TemplateUtils
     MAX_TEMPLATE_SIZE = 51200
     MAX_S3_TEMPLATE_SIZE = 460800
+    # Matches if the first non-whitespace character is a '{', handling cases
+    # with leading whitespace and extra (whitespace-only) lines.
+    JSON_IDENTIFICATION_PATTERN = Regexp.new('\A\s*{', Regexp::MULTILINE)
 
     extend self
 
     def identify_template_format(template_body)
-      # if the first non-whitespace character across all lines is a '{'
-      json_pattern = Regexp.new('\A\s*{', Regexp::MULTILINE)
-
-      if template_body =~ json_pattern
+      if template_body =~ JSON_IDENTIFICATION_PATTERN
         :json
       else
         :yaml

--- a/lib/stack_master/template_utils.rb
+++ b/lib/stack_master/template_utils.rb
@@ -6,8 +6,14 @@ module StackMaster
     extend self
 
     def identify_template_format(template_body)
-      return :json if template_body =~ /^{/x # ignore leading whitespaces
-      :yaml
+      # if the first non-whitespace character across all lines is a '{'
+      json_pattern = Regexp.new('\A\s*{', Regexp::MULTILINE)
+
+      if template_body =~ json_pattern
+        :json
+      else
+        :yaml
+      end
     end
 
     def template_hash(template_body=nil)

--- a/spec/stack_master/template_utils_spec.rb
+++ b/spec/stack_master/template_utils_spec.rb
@@ -6,6 +6,12 @@ RSpec.describe StackMaster::TemplateUtils do
       let(:template_body) { '{"AWSTemplateFormatVersion": "2010-09-09"}' }
 
       it { is_expected.to eq(:json) }
+
+      context "starting with a blank line with whitespace" do
+        let(:template_body) { "\n " + '{"AWSTemplateFormatVersion" : "2010-09-09"}' }
+
+        it { is_expected.to eq(:json) }
+      end
     end
 
     context "with a non-json template body" do

--- a/spec/stack_master/template_utils_spec.rb
+++ b/spec/stack_master/template_utils_spec.rb
@@ -1,4 +1,20 @@
 RSpec.describe StackMaster::TemplateUtils do
+  describe "#identify_template_format" do
+    subject { described_class.identify_template_format(template_body) }
+
+    context "with a json template body" do
+      let(:template_body) { '{"AWSTemplateFormatVersion": "2010-09-09"}' }
+
+      it { is_expected.to eq(:json) }
+    end
+
+    context "with a non-json template body" do
+      let(:template_body) { 'AWSTemplateFormatVersion: 2010-09-09' }
+
+        it { is_expected.to eq(:yaml) }
+    end
+  end
+
   describe "#maybe_compressed_template_body" do
     subject(:maybe_compressed_template_body) do
       described_class.maybe_compressed_template_body(template_body)


### PR DESCRIPTION
When running template format detection on a template body, extra leading whitespace (e.g. `"\n {"`) would lead to the template being detected as YAML.

This in turn resulted in guaranteed diff mismatches if the last applied template began with `"\n {"` and wasn't prettily formatted.

Also added specs for `StackMaster::TemplateUtils.identify_template_format` to test current behaviour and identify regressions.