### PR TITLE
Add parameter_files and parameters configuration options to stack definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,12 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ### Added
 
-- `parameter_dir` is now configurable to match the existing `template_dir`.
-- A `parameter_files` array allows configuring an array of *explicit* parameter
-  files relative to `parameter_dir`. If this option is specified, automatic
-  parameter files based on region and the stack name will not be used.
-- A `parameters` hash key allows defining parameters directly on the stack
-  definition rather than requiring an external parameter file.
+- `parameters_dir` is now configurable to match the existing `template_dir`.
+- `parameter_files` configures an array of parameter files relative to
+  `parameters_dir` that will be used instead of automatic parameter file globs
+  based on region and stack name.
+- `parameters` configures stack parameters directly on the stack definition
+  rather than requiring an external parameter file.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
-## [Unreleased]
+## [2.7.0] - 2020-06-15
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- `parameter_dir` is now configurable to match the existing `template_dir`.
+- A `parameter_files` array allows configuring an array of *explicit* parameter
+  files relative to `parameter_dir`. If this option is specified, automatic
+  parameter files based on region and the stack name will be be used.
+- A `parameters` hash key allows defining parameters directly on the stack
+  definition rather than requiring an external parameter file.
+
 ### Fixed
 
 - JSON template bodies with whitespace on leading lines would incorrectly be

--- a/README.md
+++ b/README.md
@@ -157,7 +157,8 @@ template_compilers:
 
 ## Parameters
 
-Parameters are loaded from multiple YAML files, merged from the following lookup paths from bottom to top:
+By default, parameters are loaded from multiple YAML files, merged from the
+following lookup paths from bottom to top:
 
 - parameters/[stack_name].yaml
 - parameters/[stack_name].yml
@@ -170,6 +171,30 @@ A simple parameter file could look like this:
 
 ```yaml
 key_name: myapp-us-east-1
+```
+
+Alternatively, a `parameter_files` array can be defined to explicitly list
+parameter files that will be loaded. If `parameter_files` are defined, the
+automatic search locations will not be used.
+
+```yaml
+parameters_dir: parameters # the default
+stacks:
+  us-east-1:
+    my-app:
+      parameter_files:
+        - my-app.yml # parameters/my-app.yml
+```
+
+Parameters can also be defined inline with stack definitions:
+
+```yaml
+stacks:
+  us-east-1:
+    my-app:
+      parameters:
+        VpcId:
+          stack_output: my-vpc/VpcId
 ```
 
 ### Compile Time Parameters

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ stack_defaults:
 ```
 
 Additional files can be configured to be uploaded to S3 alongside the templates:
+
 ```yaml
 stacks:
   production:
@@ -131,6 +132,7 @@ stacks:
       files:
         - userdata.sh
 ```
+
 ## Directories
 
 - `templates` - CloudFormation, SparkleFormation or CfnDsl templates.

--- a/features/apply_with_explicit_parameter_files.feature
+++ b/features/apply_with_explicit_parameter_files.feature
@@ -20,6 +20,7 @@ Feature: Apply command with explicit parameter files
     And a file named "parameters/myapp-web-parameters.yml" with:
       """
       KeyName: my-key
+      Color: red
       """
     And a directory named "templates"
     And a file named "templates/myapp.rb" with:
@@ -35,7 +36,6 @@ Feature: Apply command with explicit parameter files
         parameters.color do
           description 'Color'
           type 'String'
-          default 'red'
         end
 
         resources.instance do

--- a/features/apply_with_explicit_parameter_files.feature
+++ b/features/apply_with_explicit_parameter_files.feature
@@ -1,0 +1,53 @@
+Feature: Apply command with explicit parameter files
+
+  Background:
+    Given a file named "stack_master.yml" with:
+      """
+      stack_defaults:
+        tags:
+          Application: myapp
+      stacks:
+        us-east-1:
+          myapp-web:
+            template: myapp.rb
+            parameter_files:
+            - myapp-web-parameters.yml
+      """
+    And a file named "parameters/myapp-web-parameters.yml" with:
+      """
+      KeyName: my-key
+      """
+    And a directory named "templates"
+    And a file named "templates/myapp.rb" with:
+      """
+      SparkleFormation.new(:myapp) do
+        description "Test template"
+
+        parameters.key_name do
+          description 'Key name'
+          type 'String'
+        end
+
+        resources.instance do
+          type 'AWS::EC2::Instance'
+          properties do
+            image_id 'ami-0080e4c5bc078760e'
+            instance_type 't2.micro'
+          end
+        end
+      end
+      """
+
+  Scenario: Run apply and create stack with explicit parameter files
+    Given I stub the following stack events:
+      | stack_id | event_id | stack_name | logical_resource_id | resource_status | resource_type              | timestamp           |
+      | 1        | 1        | myapp-web  | myapp-web           | CREATE_COMPLETE | AWS::CloudFormation::Stack | 2020-10-29 00:00:00 |
+    When I run `stack_master apply us-east-1 myapp-web --trace`
+    Then the output should match /2020-10-29 00:00:00 (\+|\-)[0-9]{4} myapp-web AWS::CloudFormation::Stack CREATE_COMPLETE/
+    And the output should contain all of these lines:
+      | Stack diff:          |
+      | +    "Instance": {   |
+      | Parameters diff:     |
+      | KeyName: my-key      |
+      | Proposed change set: |
+    And the exit status should be 0

--- a/features/apply_with_explicit_parameter_files.feature
+++ b/features/apply_with_explicit_parameter_files.feature
@@ -13,6 +13,10 @@ Feature: Apply command with explicit parameter files
             parameter_files:
             - myapp-web-parameters.yml
       """
+    And a file named "parameters/us-east-1/myapp-web.yml" with:
+      """
+      Color: blue
+      """
     And a file named "parameters/myapp-web-parameters.yml" with:
       """
       KeyName: my-key
@@ -26,6 +30,12 @@ Feature: Apply command with explicit parameter files
         parameters.key_name do
           description 'Key name'
           type 'String'
+        end
+
+        parameters.color do
+          description 'Color'
+          type 'String'
+          default 'red'
         end
 
         resources.instance do
@@ -50,4 +60,6 @@ Feature: Apply command with explicit parameter files
       | Parameters diff:     |
       | KeyName: my-key      |
       | Proposed change set: |
+    And the output should not contain "Color: blue"
+    And the output should contain "Color: red"
     And the exit status should be 0

--- a/features/apply_with_s3.feature
+++ b/features/apply_with_s3.feature
@@ -69,7 +69,7 @@ Feature: Apply command
       | Parameters diff:                                                               |
       | KeyName: my-key                                                                |
     And the output should match /2020-10-29 00:00:00 (\+|\-)[0-9]{4} myapp-vpc AWS::CloudFormation::Stack CREATE_COMPLETE/
-    And an S3 file in bucket "my-bucket" with key "cfn_templates/my-app/myapp_vpc.json" exists with content:
+    And an S3 file in bucket "my-bucket" with key "cfn_templates/my-app/myapp_vpc.json" exists with JSON content:
       """
       {
         "Description": "Test template",

--- a/features/apply_with_stack_definition_parameters.feature
+++ b/features/apply_with_stack_definition_parameters.feature
@@ -1,0 +1,46 @@
+Feature: Apply command with stack definition parameters
+
+  Background:
+    Given a file named "stack_master.yml" with:
+      """
+      stacks:
+        us-east-1:
+          myapp_web:
+            template: myapp.rb
+            parameters:
+              KeyName: my-key
+      """
+    And a directory named "templates"
+    And a file named "templates/myapp.rb" with:
+      """
+      SparkleFormation.new(:myapp) do
+        description "Test template"
+
+        parameters.key_name do
+          description 'Key name'
+          type 'String'
+        end
+
+        resources.instance do
+          type 'AWS::EC2::Instance'
+          properties do
+            image_id 'ami-0080e4c5bc078760e'
+            instance_type 't2.micro'
+          end
+        end
+      end
+      """
+
+  Scenario: Run apply with parameters contained in
+    Given I stub the following stack events:
+      | stack_id | event_id | stack_name | logical_resource_id | resource_status | resource_type              | timestamp           |
+      | 1        | 1        | myapp-web  | myapp-web           | CREATE_COMPLETE | AWS::CloudFormation::Stack | 2020-10-29 00:00:00 |
+    When I run `stack_master apply us-east-1 myapp-web --trace`
+    Then the output should match /2020-10-29 00:00:00 (\+|\-)[0-9]{4} myapp-web AWS::CloudFormation::Stack CREATE_COMPLETE/
+    And the output should contain all of these lines:
+      | Stack diff:          |
+      | +    "Instance": {   |
+      | Parameters diff:     |
+      | KeyName: my-key      |
+      | Proposed change set: |
+    And the exit status should be 0

--- a/features/step_definitions/stack_steps.rb
+++ b/features/step_definitions/stack_steps.rb
@@ -73,3 +73,9 @@ When(/^an S3 file in bucket "([^"]*)" with key "([^"]*)" exists with content:$/)
   file = StackMaster.s3_driver.find_file(bucket: bucket, object_key: key)
   expect(file).to eq body
 end
+
+When(/^an S3 file in bucket "([^"]*)" with key "([^"]*)" exists with JSON content:$/) do |bucket, key, body|
+  file = StackMaster.s3_driver.find_file(bucket: bucket, object_key: key)
+  parsed_file = JSON.parse(file)
+  expect(parsed_file).to eq JSON.parse(body)
+end

--- a/features/step_definitions/stack_steps.rb
+++ b/features/step_definitions/stack_steps.rb
@@ -69,12 +69,12 @@ Given(/^I stub the CloudFormation driver$/) do
   allow(StackMaster.cloud_formation_driver.class).to receive(:new).and_return(StackMaster.cloud_formation_driver)
 end
 
-When(/^an S3 file in bucket "([^"]*)" with key "([^"]*)" exists with content:$/) do |bucket, key, body|
+Then(/^an S3 file in bucket "([^"]*)" with key "([^"]*)" exists with content:$/) do |bucket, key, body|
   file = StackMaster.s3_driver.find_file(bucket: bucket, object_key: key)
   expect(file).to eq body
 end
 
-When(/^an S3 file in bucket "([^"]*)" with key "([^"]*)" exists with JSON content:$/) do |bucket, key, body|
+Then(/^an S3 file in bucket "([^"]*)" with key "([^"]*)" exists with JSON content:$/) do |bucket, key, body|
   file = StackMaster.s3_driver.find_file(bucket: bucket, object_key: key)
   parsed_file = JSON.parse(file)
   expect(parsed_file).to eq JSON.parse(body)

--- a/lib/stack_master/commands/tidy.rb
+++ b/lib/stack_master/commands/tidy.rb
@@ -12,7 +12,7 @@ module StackMaster
         parameter_files = Set.new(find_parameter_files())
 
         status = @config.stacks.each do |stack_definition|
-          parameter_files.subtract(stack_definition.parameter_files)
+          parameter_files.subtract(stack_definition.parameter_files_from_globs)
           template = File.absolute_path(stack_definition.template_file_path)
 
           if template

--- a/lib/stack_master/config.rb
+++ b/lib/stack_master/config.rb
@@ -17,6 +17,7 @@ module StackMaster
     attr_accessor :stacks,
                   :base_dir,
                   :template_dir,
+                  :parameters_dir,
                   :stack_defaults,
                   :region_defaults,
                   :region_aliases,
@@ -39,6 +40,7 @@ module StackMaster
       @config = config
       @base_dir = base_dir
       @template_dir = config.fetch('template_dir', nil)
+      @parameters_dir = config.fetch('parameters_dir', nil)
       @stack_defaults = config.fetch('stack_defaults', {})
       @region_aliases = Utils.underscore_keys_to_hyphen(config.fetch('region_aliases', {}))
       @region_to_aliases = @region_aliases.inject({}) do |hash, (key, value)|
@@ -115,6 +117,7 @@ module StackMaster
             'stack_name' => stack_name,
             'base_dir' => @base_dir,
             'template_dir' => @template_dir,
+            'parameters_dir' => @parameters_dir,
             'additional_parameter_lookup_dirs' => @region_to_aliases[region])
           stack_attributes['allowed_accounts'] = attributes['allowed_accounts'] if attributes['allowed_accounts']
           @stacks << StackDefinition.new(stack_attributes)

--- a/lib/stack_master/parameter_loader.rb
+++ b/lib/stack_master/parameter_loader.rb
@@ -5,10 +5,10 @@ module StackMaster
 
     COMPILE_TIME_PARAMETERS_KEY = 'compile_time_parameters'
 
-    def self.load(parameter_files)
+    def self.load(parameter_files: [], parameters: {})
       StackMaster.debug 'Searching for parameter files...'
-      parameter_files.reduce({template_parameters: {}, compile_time_parameters: {}}) do |hash, file_name|
-        parameters = load_parameters(file_name)
+      all_parameters = parameter_files.map { |file_name| load_parameters(file_name) } + [parameters]
+      all_parameters.reduce({template_parameters: {}, compile_time_parameters: {}}) do |hash, parameters|
         template_parameters = create_template_parameters(parameters)
         compile_time_parameters = create_compile_time_parameters(parameters)
 
@@ -16,7 +16,6 @@ module StackMaster
         merge_and_camelize(hash[:compile_time_parameters], compile_time_parameters)
         hash
       end
-
     end
 
     private

--- a/lib/stack_master/parameter_validator.rb
+++ b/lib/stack_master/parameter_validator.rb
@@ -9,15 +9,14 @@ module StackMaster
 
     def error_message
       return nil unless missing_parameters?
-      message = "Empty/blank parameters detected. Please provide values for these parameters:"
+      message = "Empty/blank parameters detected. Please provide values for these parameters:\n"
       missing_parameters.each do |parameter_name|
-        message << "\n - #{parameter_name}"
+        message << " - #{parameter_name}\n"
       end
-      message << "\nParameters will be read from files matching the following globs:"
-      base_dir = Pathname.new(@stack_definition.base_dir)
-      @stack_definition.parameter_file_globs.each do |glob|
-        parameter_file = Pathname.new(glob).relative_path_from(base_dir)
-        message << "\n - #{parameter_file}"
+      if @stack_definition.parameter_files.empty?
+        message << message_for_parameter_globs
+      else
+        message << message_for_parameter_files
       end
       message
     end
@@ -27,6 +26,24 @@ module StackMaster
     end
 
     private
+
+    def message_for_parameter_files
+      "Parameters are configured to be read from the following files:\n".tap do |message|
+        @stack_definition.parameter_files.each do |parameter_file|
+          message << " - #{parameter_file}\n"
+        end
+      end
+    end
+
+    def message_for_parameter_globs
+      "Parameters will be read from files matching the following globs:\n".tap do |message|
+        base_dir = Pathname.new(@stack_definition.base_dir)
+        @stack_definition.parameter_file_globs.each do |glob|
+          parameter_file = Pathname.new(glob).relative_path_from(base_dir)
+          message << " - #{parameter_file}\n"
+        end
+      end
+    end
 
     def missing_parameters
       @missing_parameters ||=

--- a/lib/stack_master/stack.rb
+++ b/lib/stack_master/stack.rb
@@ -56,7 +56,7 @@ module StackMaster
     end
 
     def self.generate(stack_definition, config)
-      parameter_hash = ParameterLoader.load(parameter_files: stack_definition.parameter_files, parameters: stack_definition.parameters)
+      parameter_hash = ParameterLoader.load(parameter_files: stack_definition.all_parameter_files, parameters: stack_definition.parameters)
       template_parameters = ParameterResolver.resolve(config, stack_definition, parameter_hash[:template_parameters])
       compile_time_parameters = ParameterResolver.resolve(config, stack_definition, parameter_hash[:compile_time_parameters])
       template_body = TemplateCompiler.compile(config, stack_definition.compiler, stack_definition.template_dir, stack_definition.template, compile_time_parameters, stack_definition.compiler_options)
@@ -76,7 +76,7 @@ module StackMaster
     end
 
     def self.generate_without_parameters(stack_definition, config)
-      parameter_hash = ParameterLoader.load(stack_definition.parameter_files)
+      parameter_hash = ParameterLoader.load(parameter_files: stack_definition.all_parameter_files, parameters: stack_definition.parameters)
       compile_time_parameters = ParameterResolver.resolve(config, stack_definition, parameter_hash[:compile_time_parameters])
       template_body = TemplateCompiler.compile(config, stack_definition.compiler, stack_definition.template_dir, stack_definition.template, compile_time_parameters, stack_definition.compiler_options)
       template_format = TemplateUtils.identify_template_format(template_body)

--- a/lib/stack_master/stack.rb
+++ b/lib/stack_master/stack.rb
@@ -56,7 +56,7 @@ module StackMaster
     end
 
     def self.generate(stack_definition, config)
-      parameter_hash = ParameterLoader.load(stack_definition.parameter_files)
+      parameter_hash = ParameterLoader.load(parameter_files: stack_definition.parameter_files, parameters: stack_definition.parameters)
       template_parameters = ParameterResolver.resolve(config, stack_definition, parameter_hash[:template_parameters])
       compile_time_parameters = ParameterResolver.resolve(config, stack_definition, parameter_hash[:compile_time_parameters])
       template_body = TemplateCompiler.compile(config, stack_definition.compiler, stack_definition.template_dir, stack_definition.template, compile_time_parameters, stack_definition.compiler_options)

--- a/lib/stack_master/stack_definition.rb
+++ b/lib/stack_master/stack_definition.rb
@@ -93,7 +93,11 @@ module StackMaster
     end
 
     def all_parameter_files
-      parameter_files_from_globs + parameter_files
+      if parameter_files.empty?
+        parameter_files_from_globs
+      else
+        parameter_files
+      end
     end
 
     def parameter_files_from_globs

--- a/lib/stack_master/stack_definition.rb
+++ b/lib/stack_master/stack_definition.rb
@@ -16,7 +16,8 @@ module StackMaster
                   :additional_parameter_lookup_dirs,
                   :s3,
                   :files,
-                  :compiler_options
+                  :compiler_options,
+                  :parameters
 
     attr_reader :compiler
 
@@ -34,6 +35,7 @@ module StackMaster
       @additional_parameter_lookup_dirs ||= []
       @template_dir ||= File.join(@base_dir, 'templates')
       @allowed_accounts = Array(@allowed_accounts)
+      @parameters ||= {}
     end
 
     def ==(other)

--- a/lib/stack_master/stack_definition.rb
+++ b/lib/stack_master/stack_definition.rb
@@ -63,10 +63,6 @@ module StackMaster
         @compiler_options == other.compiler_options
     end
 
-    def compiler=(compiler)
-      @compiler = compiler&.to_sym
-    end
-
     def template_file_path
       return unless template
       File.expand_path(File.join(template_dir, template))

--- a/lib/stack_master/stack_definition.rb
+++ b/lib/stack_master/stack_definition.rb
@@ -65,7 +65,7 @@ module StackMaster
 
     def template_file_path
       return unless template
-      File.expand_path(File.join(template_dir, template))
+      File.expand_path(template, template_dir)
     end
 
     def files_dir
@@ -114,7 +114,7 @@ module StackMaster
 
     def parameter_files
       Array(@parameter_files).map do |file|
-        File.expand_path(File.join(parameters_dir, file))
+        File.expand_path(file, parameters_dir)
       end
     end
 

--- a/lib/stack_master/version.rb
+++ b/lib/stack_master/version.rb
@@ -1,3 +1,3 @@
 module StackMaster
-  VERSION = "2.6.1"
+  VERSION = "2.7.0"
 end

--- a/spec/stack_master/parameter_loader_spec.rb
+++ b/spec/stack_master/parameter_loader_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe StackMaster::ParameterLoader do
   let(:stack_file_name) { '/base_dir/parameters/stack_name.yml' }
   let(:region_file_name) { '/base_dir/parameters/us-east-1/stack_name.yml' }
 
-  subject(:parameters) { StackMaster::ParameterLoader.load([stack_file_name, region_file_name]) }
+  subject(:parameters) { StackMaster::ParameterLoader.load(parameter_files: [stack_file_name, region_file_name]) }
 
   before do
     file_mock(stack_file_name, **stack_file_returns)
@@ -60,7 +60,7 @@ RSpec.describe StackMaster::ParameterLoader do
     let(:region_yaml_file_returns) { {exists: true, read: "Param1: value1\nParam2: valueX"} }
     let(:region_yaml_file_name) { "/base_dir/parameters/us-east-1/stack_name.yaml" }
 
-    subject(:parameters) { StackMaster::ParameterLoader.load([stack_file_name, region_yaml_file_name, region_file_name]) }
+    subject(:parameters) { StackMaster::ParameterLoader.load(parameter_files: [stack_file_name, region_yaml_file_name, region_file_name]) }
 
     before do
       file_mock(region_yaml_file_name, **region_yaml_file_returns)

--- a/spec/stack_master/parameter_validator_spec.rb
+++ b/spec/stack_master/parameter_validator_spec.rb
@@ -2,7 +2,8 @@ RSpec.describe StackMaster::ParameterValidator do
   subject(:parameter_validator) { described_class.new(stack: stack, stack_definition: stack_definition) }
 
   let(:stack) { StackMaster::Stack.new(parameters: parameters, template_body: '{}', template_format: :json) }
-  let(:stack_definition) { StackMaster::StackDefinition.new(base_dir: '/base_dir', region: 'ap-southeast-2', stack_name: 'stack_name') }
+  let(:parameter_files) { nil }
+  let(:stack_definition) { StackMaster::StackDefinition.new(base_dir: '/base_dir', region: 'ap-southeast-2', stack_name: 'stack_name', parameter_files: parameter_files) }
 
   describe '#missing_parameters?' do
     subject { parameter_validator.missing_parameters? }
@@ -27,7 +28,7 @@ RSpec.describe StackMaster::ParameterValidator do
       let(:parameters) { {'Param1' => true, 'Param2' => nil, 'Param3' => 'string', 'Param4' => nil} }
 
       it 'returns a descriptive message' do
-        expect(error_message).to eq(<<~MESSAGE.chomp)
+        expect(error_message).to eq(<<~MESSAGE)
           Empty/blank parameters detected. Please provide values for these parameters:
            - Param2
            - Param4
@@ -35,6 +36,21 @@ RSpec.describe StackMaster::ParameterValidator do
            - parameters/stack_name.y*ml
            - parameters/ap-southeast-2/stack_name.y*ml
         MESSAGE
+      end
+    end
+
+    context 'when the stack definition is using explicit parameter files' do
+      let(:parameters) { {'Param1' => true, 'Param2' => nil, 'Param3' => 'string', 'Param4' => nil} }
+      let(:parameter_files) { ["params.yml"] }
+
+      it 'returns a descriptive message' do
+        expect(error_message).to eq(<<~MESSAGE)
+          Empty/blank parameters detected. Please provide values for these parameters:
+           - Param2
+           - Param4
+          Parameters are configured to be read from the following files:
+           - /base_dir/parameters/params.yml
+         MESSAGE
       end
     end
 

--- a/spec/stack_master/stack_definition_spec.rb
+++ b/spec/stack_master/stack_definition_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe StackMaster::StackDefinition do
       stack_name: stack_name,
       template: template,
       tags: tags,
-      base_dir: base_dir)
+      base_dir: base_dir,
+      parameter_files: parameter_files)
   end
 
   let(:region) { 'us-east-1' }
@@ -13,6 +14,7 @@ RSpec.describe StackMaster::StackDefinition do
   let(:template) { 'template.json' }
   let(:tags) { {'environment' => 'production'} }
   let(:base_dir) { '/base_dir' }
+  let(:parameter_files) { nil }
 
   before do
     allow(Dir).to receive(:glob).with(
@@ -35,7 +37,7 @@ RSpec.describe StackMaster::StackDefinition do
   end
 
   it 'has default and region specific parameter file locations' do
-    expect(stack_definition.parameter_files).to eq([
+    expect(stack_definition.all_parameter_files).to eq([
       "/base_dir/parameters/#{stack_name}.yaml",
       "/base_dir/parameters/#{stack_name}.yml",
       "/base_dir/parameters/#{region}/#{stack_name}.yaml",
@@ -75,7 +77,7 @@ RSpec.describe StackMaster::StackDefinition do
     end
 
     it 'includes a parameter lookup dir for it' do
-      expect(stack_definition.parameter_files).to eq([
+      expect(stack_definition.all_parameter_files).to eq([
         "/base_dir/parameters/#{stack_name}.yaml",
         "/base_dir/parameters/#{stack_name}.yml",
         "/base_dir/parameters/#{region}/#{stack_name}.yaml",
@@ -108,5 +110,13 @@ RSpec.describe StackMaster::StackDefinition do
 
   it 'defaults ejson_file_kms to true' do
     expect(stack_definition.ejson_file_kms).to eq true
+  end
+
+  context "with explicit parameter_files" do
+    let(:parameter_files) { ["my-stack.yml", "../my-stack.yml"] }
+
+    it "resolves them relative to parameters_dir" do
+      expect(stack_definition.parameter_files).to eq ["/base_dir/parameters/my-stack.yml", "/base_dir/my-stack.yml"]
+    end
   end
 end

--- a/spec/stack_master/stack_definition_spec.rb
+++ b/spec/stack_master/stack_definition_spec.rb
@@ -115,8 +115,8 @@ RSpec.describe StackMaster::StackDefinition do
   context "with explicit parameter_files" do
     let(:parameter_files) { ["my-stack.yml", "../my-stack.yml"] }
 
-    it "resolves them relative to parameters_dir" do
-      expect(stack_definition.parameter_files).to eq ["/base_dir/parameters/my-stack.yml", "/base_dir/my-stack.yml"]
+    it "ignores parameter globs and resolves them relative to parameters_dir" do
+      expect(stack_definition.all_parameter_files).to eq ["/base_dir/parameters/my-stack.yml", "/base_dir/my-stack.yml"]
     end
   end
 end

--- a/spec/stack_master/template_compiler_spec.rb
+++ b/spec/stack_master/template_compiler_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe StackMaster::TemplateCompiler do
     context 'when a template compiler is explicitly specified' do
       it 'uses it' do
         expect(StackMaster::TemplateCompilers::SparkleFormation).to receive(:compile).with('/base_dir/templates', 'template', compile_time_parameters, anything)
-        StackMaster::TemplateCompiler.compile(config, :sparkle_formation, '/base_dir/templates', 'template', compile_time_parameters, {})
+        StackMaster::TemplateCompiler.compile(config, :sparkle_formation, '/base_dir/templates', 'template', compile_time_parameters, compile_time_parameters)
       end
     end
 

--- a/spec/stack_master/template_compiler_spec.rb
+++ b/spec/stack_master/template_compiler_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe StackMaster::TemplateCompiler do
     context 'when a template compiler is explicitly specified' do
       it 'uses it' do
         expect(StackMaster::TemplateCompilers::SparkleFormation).to receive(:compile).with('/base_dir/templates', 'template', compile_time_parameters, anything)
-        StackMaster::TemplateCompiler.compile(config, :sparkle_formation, '/base_dir/templates', 'template', compile_time_parameters, compile_time_parameters)
+        StackMaster::TemplateCompiler.compile(config, :sparkle_formation, '/base_dir/templates', 'template', compile_time_parameters, {})
       end
     end
 


### PR DESCRIPTION
Following on from an earlier spike, but without the stack definition moving to its own file for better backwards compatibility. https://github.com/envato/stack_master/pull/330.

#### Added `parameters_dir` config

This matches what we have for `template_dir` and is useful for the `parameter_files` feature.

#### `parameter_files` - an array of explicit parameter file locations based from `parameter_dir`

Adds the ability to explicitly define parameter file locations in stack definitions. It's more obvious this way, and it can also be used to massively reduce duplication between stacks that follow a blue/green setup. For example, if we have `myapp-blue` and `myapp-green`, they could share a parameter file for the majority of parameters, whereas currently that's not possible without duplicating all the parameters.

```yaml
stacks:
  us-east-1:
    myapp-blue:
      parameter_files:
        - myapp.yml
        - myapp-blue.yml
      template: myapp.rb
```

#### `parameters` hash key can add parameters inline with the rest of the stack definition

This can be useful when switching to a new stack that only needs a small change in parameters:

```yaml
stacks:
  us-east-1:
    aws-elasticsearch-green:
      parameter_files:
        - aws-elasticsearch.yml
      template: aws-elasticsearch.rb
    aws-elasticsearch-blue:
      parameter_files:
        - aws-elasticsearch.yml
      parameters:
        engine_version: 7.4
      template: aws-elasticsearch.rb
````