### PR TITLE
Improve diff output on stack_master apply/diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ The format is based on [Keep a Changelog], and this project adheres to
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
+## [2.8.0] - Unreleased
+
+### Changed
+
+- The diff in `stack_master apply` and `stack_master diff` has been improved to
+  no longer display temporary file path context, and remove the empty newline
+
 ## [2.7.0] - 2020-06-15
 
 ### Added

--- a/lib/stack_master/stack_differ.rb
+++ b/lib/stack_master/stack_differ.rb
@@ -10,13 +10,13 @@ module StackMaster
 
     def proposed_template
       return @proposed_stack.template_body unless @proposed_stack.template_format == :json
-      JSON.pretty_generate(JSON.parse(@proposed_stack.template_body))
+      JSON.pretty_generate(JSON.parse(@proposed_stack.template_body)) + "\n"
     end
 
     def current_template
       return '' unless @current_stack
       return @current_stack.template_body unless @current_stack.template_format == :json
-      JSON.pretty_generate(TemplateUtils.template_hash(@current_stack.template_body))
+      JSON.pretty_generate(TemplateUtils.template_hash(@current_stack.template_body)) + "\n"
     end
 
     def current_parameters
@@ -43,7 +43,7 @@ module StackMaster
     end
 
     def body_diff
-      @body_diff ||= Diffy::Diff.new(current_template, proposed_template, context: 7, include_diff_info: true).to_s
+      @body_diff ||= Diffy::Diff.new(current_template, proposed_template, context: 7).to_s
     end
 
     def params_different?


### PR DESCRIPTION
Removes the diff context from `stack_master apply`:

```
--- /var/folders/69/g1dq6ycs0zb58cghkcyltl800000gn/T/diffy20200615-83399-zpfflu 2020-06-15 14:43:32.000000000 +1000
+++ /var/folders/69/g1dq6ycs0zb58cghkcyltl800000gn/T/diffy20200615-83399-1u2zdvv  
```

And the empty newline message that can be present sometimes such as when
creating a new stack:

```
+}
\ No newline at end of file
Parameters diff:
+---
```