### PR TITLE
Add timeout option to drift command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog], and this project adheres to
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
+## [2.9.0] - Unreleased
+
+### Added
+
+- Added `--timeout 120` option to drift command with a default of 2 minutes.
+
 ## [2.8.0] - 2020-06-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
-## [2.9.0] - Unreleased
+## [2.9.0] - 2020-06-24
 
 ### Added
 

--- a/lib/stack_master/cli.rb
+++ b/lib/stack_master/cli.rb
@@ -219,9 +219,10 @@ module StackMaster
         c.syntax = 'stack_master drift [region_or_alias] [stack_name]'
         c.summary = 'Detects and displays stack drift using the CloudFormation Drift API'
         c.description = 'Detects and displays stack drift'
+        c.option '--timeout SECONDS', Integer, "The number of seconds to wait for drift detection to complete"
         c.example 'view stack drift for a stack named myapp-vpc in us-east-1', 'stack_master drift us-east-1 myapp-vpc'
         c.action do |args, options|
-          options.default config: default_config_file
+          options.default config: default_config_file, timeout: 120
           execute_stacks_command(StackMaster::Commands::Drift, args, options)
         end
       end

--- a/lib/stack_master/commands/drift.rb
+++ b/lib/stack_master/commands/drift.rb
@@ -88,17 +88,17 @@ module StackMaster
       end
 
       def wait_for_drift_results(detection_id)
-        try_count = 0
         resp = nil
+        start_time = Time.now
         loop do
-          if try_count >= 10
-            raise 'Failed to wait for stack drift detection after 10 tries'
-          end
-
           resp = cf.describe_stack_drift_detection_status(stack_drift_detection_id: detection_id)
           break if DETECTION_COMPLETE_STATES.include?(resp.detection_status)
 
-          try_count += 1
+          elapsed_time = Time.now - start_time
+          if elapsed_time > @options.timeout
+            raise "Timeout waiting for stack drift detection"
+          end
+
           sleep SLEEP_SECONDS
         end
         resp

--- a/lib/stack_master/version.rb
+++ b/lib/stack_master/version.rb
@@ -1,3 +1,3 @@
 module StackMaster
-  VERSION = "2.8.0"
+  VERSION = "2.9.0"
 end

--- a/spec/stack_master/commands/drift_spec.rb
+++ b/spec/stack_master/commands/drift_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe StackMaster::Commands::Drift do
   ] }
 
   before do
+    options.timeout = 10
     allow(StackMaster).to receive(:cloud_formation_driver).and_return(cf)
     allow(cf).to receive(:detect_stack_drift).and_return(detect_stack_drift_response)
 

--- a/spec/stack_master/commands/drift_spec.rb
+++ b/spec/stack_master/commands/drift_spec.rb
@@ -91,10 +91,11 @@ RSpec.describe StackMaster::Commands::Drift do
   context "when stack drift detection doesn't complete" do
     before do
       describe_stack_drift_detection_status_response.detection_status = 'UNKNOWN'
+      options.timeout = 0
     end
 
     it 'raises an error' do
-      expect { drift.perform }.to raise_error(/Failed to wait for stack drift detection after 10 tries/)
+      expect { drift.perform }.to raise_error(/Timeout waiting for stack drift detection/)
     end
   end
 end


### PR DESCRIPTION
Some stacks take longer than 10 seconds for drift calculation to complete. Adding a `--timeout` option with a long default to cover most cases.