### PR TITLE
Add cfn_nag integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ The format is based on [Keep a Changelog], and this project adheres to
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
+## [2.10.0] - 2020-07-02
+
+### Added
+
+- A new command, `stack_master nag`, uses the open-source cfn_nag tool to perform
+  static analysis of templates for patterns that may indicate insecure infrastructure
+
 ## [2.9.0] - 2020-06-24
 
 ### Added

--- a/lib/stack_master.rb
+++ b/lib/stack_master.rb
@@ -70,6 +70,7 @@ module StackMaster
     autoload :Delete, 'stack_master/commands/delete'
     autoload :Status, 'stack_master/commands/status'
     autoload :Tidy, 'stack_master/commands/tidy'
+    autoload :Nag, 'stack_master/commands/nag'
   end
 
   module ParameterResolvers

--- a/lib/stack_master/cli.rb
+++ b/lib/stack_master/cli.rb
@@ -146,6 +146,17 @@ module StackMaster
         end
       end
 
+      command :nag do |c|
+        c.syntax = 'stack_master nag [region_or_alias] [stack_name]'
+        c.summary = "Check this stack's template with cfn_nag"
+        c.description = "Runs SAST scan cfn_nag on the template"
+        c.example 'run cfn_nag on stack myapp-vpc with us-east-1 settings', 'stack_master nag us-east-1 myapp-vpc'
+        c.action do |args, options|
+          options.default config: default_config_file
+          execute_stacks_command(StackMaster::Commands::Nag, args, options)
+        end
+      end
+
       command :compile do |c|
         c.syntax = 'stack_master compile [region_or_alias] [stack_name]'
         c.summary = "Print the compiled version of a given stack"

--- a/lib/stack_master/commands/nag.rb
+++ b/lib/stack_master/commands/nag.rb
@@ -1,0 +1,44 @@
+module StackMaster
+  module Commands
+    class Nag
+      include Command
+      include Commander::UI
+
+      def perform
+        unless cfn_nag_available
+          failed! 'Failed to run cfn_nag. You may need to install it using'\
+                  '`gem install cfn_nag`, or add it to $PATH.'\
+                  "\n"\
+                  '(See https://github.com/stelligent/cfn_nag'\
+                  ' for package information)'
+        end
+
+        if proposed_stack.template_format == :yaml
+          failed! 'cfn_nag doesn\'t support yaml formatted templates.'
+        end
+
+        Tempfile.open(['stack', "___#{stack_definition.stack_name}.#{proposed_stack.template_format}"]) do |f|
+          f.write(proposed_stack.template_body)
+          f.flush
+          system('cfn_nag', f.path)
+          puts "cfn_nag run complete"
+        end
+      end
+
+      private
+
+      def stack_definition
+        @stack_definition ||= @config.find_stack(@region, @stack_name)
+      end
+
+      def proposed_stack
+        @proposed_stack ||= Stack.generate(stack_definition, @config)
+      end
+
+      def cfn_nag_available
+        system('type -a cfn_nag >/dev/null 2>&1')
+        $?.exitstatus == 0
+      end
+    end
+  end
+end

--- a/lib/stack_master/commands/nag.rb
+++ b/lib/stack_master/commands/nag.rb
@@ -5,12 +5,14 @@ module StackMaster
       include Commander::UI
 
       def perform
-        Tempfile.open(['stack', "___#{stack_definition.stack_name}.#{proposed_stack.template_format}"]) do |f|
+        rv = Tempfile.open(['stack', "___#{stack_definition.stack_name}.#{proposed_stack.template_format}"]) do |f|
           f.write(proposed_stack.template_body)
           f.flush
           system('cfn_nag', f.path)
-          STDERR.puts "cfn_nag run complete"
+          $?.exitstatus
         end
+
+        failed!("cfn_nag check failed with exit status #{rv}") if rv > 0
       end
 
       private

--- a/lib/stack_master/commands/nag.rb
+++ b/lib/stack_master/commands/nag.rb
@@ -5,10 +5,6 @@ module StackMaster
       include Commander::UI
 
       def perform
-        if proposed_stack.template_format == :yaml
-          failed! 'cfn_nag doesn\'t support yaml formatted templates.'
-        end
-
         Tempfile.open(['stack', "___#{stack_definition.stack_name}.#{proposed_stack.template_format}"]) do |f|
           f.write(proposed_stack.template_body)
           f.flush

--- a/lib/stack_master/commands/nag.rb
+++ b/lib/stack_master/commands/nag.rb
@@ -9,7 +9,7 @@ module StackMaster
           f.write(proposed_stack.template_body)
           f.flush
           system('cfn_nag', f.path)
-          puts "cfn_nag run complete"
+          STDERR.puts "cfn_nag run complete"
         end
       end
 

--- a/lib/stack_master/commands/nag.rb
+++ b/lib/stack_master/commands/nag.rb
@@ -5,14 +5,6 @@ module StackMaster
       include Commander::UI
 
       def perform
-        unless cfn_nag_available
-          failed! 'Failed to run cfn_nag. You may need to install it using'\
-                  '`gem install cfn_nag`, or add it to $PATH.'\
-                  "\n"\
-                  '(See https://github.com/stelligent/cfn_nag'\
-                  ' for package information)'
-        end
-
         if proposed_stack.template_format == :yaml
           failed! 'cfn_nag doesn\'t support yaml formatted templates.'
         end
@@ -35,10 +27,6 @@ module StackMaster
         @proposed_stack ||= Stack.generate(stack_definition, @config)
       end
 
-      def cfn_nag_available
-        system('type -a cfn_nag >/dev/null 2>&1')
-        $?.exitstatus == 0
-      end
     end
   end
 end

--- a/lib/stack_master/version.rb
+++ b/lib/stack_master/version.rb
@@ -1,3 +1,3 @@
 module StackMaster
-  VERSION = "2.9.0"
+  VERSION = "2.10.0"
 end

--- a/spec/stack_master/commands/nag_spec.rb
+++ b/spec/stack_master/commands/nag_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe StackMaster::Commands::Nag do
     let(:template_body) { '{}' }
     let(:template_format) { :json }
 
-    it 'outputs the template' do
+    it 'calls the nag gem' do
       expect_any_instance_of(described_class).to receive(:system).once.with('cfn_nag', /.*\.json/)
       run
     end
@@ -35,8 +35,9 @@ RSpec.describe StackMaster::Commands::Nag do
     let(:template_body) { '---' }
     let(:template_format) { :yaml }
 
-    it 'outputs an error' do
-      expect { run }.to output(/cfn_nag doesn't support yaml formatted templates/).to_stderr
+    it 'calls the nag gem' do
+      expect_any_instance_of(described_class).to receive(:system).once.with('cfn_nag', /.*\.yaml/)
+      run
     end
   end
 end

--- a/spec/stack_master/commands/nag_spec.rb
+++ b/spec/stack_master/commands/nag_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe StackMaster::Commands::Nag do
   let(:region) { 'us-east-1' }
   let(:stack_name) { 'myapp-vpc' }
   let(:stack_definition) { StackMaster::StackDefinition.new(base_dir: '/base_dir', region: region, stack_name: stack_name) }
-  let(:config) { double(find_stack: stack_definition) }
+  let(:config) { instance_double(StackMaster::Config, find_stack: stack_definition) }
   let(:parameters) { {} }
   let(:proposed_stack) {
     StackMaster::Stack.new(
@@ -10,8 +10,8 @@ RSpec.describe StackMaster::Commands::Nag do
       template_format: template_format,
       parameters: parameters)
   }
-  let(:tempfile) { double(:tempfile) }
-  let(:path) { double(:path) }
+  let(:tempfile) { double(Tempfile) }
+  let(:path) { double(String) }
 
   before do
     allow(StackMaster::Stack).to receive(:generate).with(stack_definition, config).and_return(proposed_stack)
@@ -26,6 +26,8 @@ RSpec.describe StackMaster::Commands::Nag do
     let(:template_format) { :json }
 
     it 'calls the nag gem' do
+      expect_any_instance_of(File).to receive(:write).once
+      expect_any_instance_of(File).to receive(:flush).once
       expect_any_instance_of(described_class).to receive(:system).once.with('cfn_nag', /.*\.json/)
       run
     end
@@ -36,6 +38,8 @@ RSpec.describe StackMaster::Commands::Nag do
     let(:template_format) { :yaml }
 
     it 'calls the nag gem' do
+      expect_any_instance_of(File).to receive(:write).once
+      expect_any_instance_of(File).to receive(:flush).once
       expect_any_instance_of(described_class).to receive(:system).once.with('cfn_nag', /.*\.yaml/)
       run
     end

--- a/spec/stack_master/commands/nag_spec.rb
+++ b/spec/stack_master/commands/nag_spec.rb
@@ -1,0 +1,64 @@
+RSpec.describe StackMaster::Commands::Nag do
+  let(:region) { 'us-east-1' }
+  let(:stack_name) { 'myapp-vpc' }
+  let(:stack_definition) { StackMaster::StackDefinition.new(base_dir: '/base_dir', region: region, stack_name: stack_name) }
+  let(:config) { double(find_stack: stack_definition) }
+  let(:parameters) { {} }
+  let(:proposed_stack) {
+    StackMaster::Stack.new(
+      template_body: template_body,
+      template_format: template_format,
+      parameters: parameters)
+  }
+  let(:tempfile) { double(:tempfile) }
+  let(:path) { double(:path) }
+
+  before do
+    allow(StackMaster::Stack).to receive(:generate).with(stack_definition, config).and_return(proposed_stack)
+  end
+
+  def run
+    described_class.perform(config, stack_definition)
+  end
+
+  def set_exit_status(status)
+    `(exit #{status})`
+  end
+
+  context "when cfn_nag is installed" do
+    before do
+      expect_any_instance_of(described_class).to receive(:system).once.with('type -a cfn_nag >/dev/null 2>&1').and_return(0)
+      set_exit_status 0
+    end
+
+    context "with a json stack" do
+      let(:template_body) { '{}' }
+      let(:template_format) { :json }
+
+      it 'outputs the template' do
+        expect_any_instance_of(described_class).to receive(:system).once.with('cfn_nag', /.*\.json/)
+        run
+      end
+    end
+
+    context "with a yaml stack" do
+      let(:template_body) { '---' }
+      let(:template_format) { :yaml }
+
+      it 'outputs a warning' do
+        expect { run }.to output(/cfn_nag doesn't support yaml formatted templates/).to_stderr
+      end
+    end
+  end
+
+  context "when cfn_nag is missing" do
+    let(:template_body) { '' }
+    let(:template_format) { :json}
+
+    it 'outputs a warning' do
+      expect_any_instance_of(described_class).to receive(:system).once.with('type -a cfn_nag >/dev/null 2>&1').and_return(1)
+      set_exit_status 1
+      expect { run }.to output(/Failed to run cfn_nag/).to_stderr
+    end
+  end
+end

--- a/spec/stack_master/commands/nag_spec.rb
+++ b/spec/stack_master/commands/nag_spec.rb
@@ -21,44 +21,22 @@ RSpec.describe StackMaster::Commands::Nag do
     described_class.perform(config, stack_definition)
   end
 
-  def set_exit_status(status)
-    `(exit #{status})`
-  end
+  context "with a json stack" do
+    let(:template_body) { '{}' }
+    let(:template_format) { :json }
 
-  context "when cfn_nag is installed" do
-    before do
-      expect_any_instance_of(described_class).to receive(:system).once.with('type -a cfn_nag >/dev/null 2>&1').and_return(0)
-      set_exit_status 0
-    end
-
-    context "with a json stack" do
-      let(:template_body) { '{}' }
-      let(:template_format) { :json }
-
-      it 'outputs the template' do
-        expect_any_instance_of(described_class).to receive(:system).once.with('cfn_nag', /.*\.json/)
-        run
-      end
-    end
-
-    context "with a yaml stack" do
-      let(:template_body) { '---' }
-      let(:template_format) { :yaml }
-
-      it 'outputs a warning' do
-        expect { run }.to output(/cfn_nag doesn't support yaml formatted templates/).to_stderr
-      end
+    it 'outputs the template' do
+      expect_any_instance_of(described_class).to receive(:system).once.with('cfn_nag', /.*\.json/)
+      run
     end
   end
 
-  context "when cfn_nag is missing" do
-    let(:template_body) { '' }
-    let(:template_format) { :json}
+  context "with a yaml stack" do
+    let(:template_body) { '---' }
+    let(:template_format) { :yaml }
 
-    it 'outputs a warning' do
-      expect_any_instance_of(described_class).to receive(:system).once.with('type -a cfn_nag >/dev/null 2>&1').and_return(1)
-      set_exit_status 1
-      expect { run }.to output(/Failed to run cfn_nag/).to_stderr
+    it 'outputs an error' do
+      expect { run }.to output(/cfn_nag doesn't support yaml formatted templates/).to_stderr
     end
   end
 end

--- a/stack_master.gemspec
+++ b/stack_master.gemspec
@@ -56,4 +56,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "hashdiff", "~> 1"
   spec.add_dependency "ejson_wrapper"
   spec.add_dependency "diff-lcs"
+  spec.add_dependency "cfn-nag", "~> 0.6.7"
 end


### PR DESCRIPTION
[cfn_nag](https://github.com/stelligent/cfn_nag) is an open-source SAST (static application security testing) tool that checks CloudFormation templates for common patterns that may indicate a security problem.

While it is a Ruby library, it doesn't lend itself to direct integration.  For this reason the gem is installed from the gemspec but stack_master shells out to call the CLI command.

This PR adds a new `nag` command that runs `cfn_nag` on a given stack and outputs a report.