### PR TITLE
Suggest other regions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 - A new command, `stack_master nag`, uses the open-source cfn_nag tool to perform
   static analysis of templates for patterns that may indicate insecure infrastructure
+- Print available regions if the specified stack is not available in the chosen one.
 
 ## [2.9.0] - 2020-06-24
 

--- a/features/apply.feature
+++ b/features/apply.feature
@@ -151,8 +151,8 @@ Feature: Apply command
     And the exit status should be 1
 
   Scenario: Run apply with stack in wrong region
-    When I run `stack_master apply foo myapp_web`
-    Then the output should contain "Stack name myapp_web exists in regions: us-east-1"
+    When I run `stack_master apply foo myapp-web`
+    Then the output should contain "Stack name myapp-web exists in regions: us-east-1"
     And the exit status should be 1
 
   Scenario: Create stack with --changed

--- a/features/apply.feature
+++ b/features/apply.feature
@@ -150,6 +150,11 @@ Feature: Apply command
     Then the output should contain "Could not find stack definition bar in region foo"
     And the exit status should be 1
 
+  Scenario: Run apply with stack in wrong region
+    When I run `stack_master apply foo myapp_web`
+    Then the output should contain "Stack name myapp_web exists in regions: us-east-1"
+    And the exit status should be 1
+
   Scenario: Create stack with --changed
     Given I stub the following stack events:
       | stack_id | event_id | stack_name | logical_resource_id | resource_status | resource_type              | timestamp           |

--- a/lib/stack_master/cli.rb
+++ b/lib/stack_master/cli.rb
@@ -272,7 +272,7 @@ module StackMaster
     end
 
     def show_other_region_candidates(config, stack_name)
-      candidates = config.filter(stack_name=stack_name)
+      candidates = config.filter(region="", stack_name=stack_name)
       return if candidates.empty?
 
       StackMaster.stdout.puts "Stack name #{stack_name} exists in regions: #{candidates.map(&:region).join(', ')}"

--- a/lib/stack_master/cli.rb
+++ b/lib/stack_master/cli.rb
@@ -254,7 +254,7 @@ module StackMaster
         stack_definitions = config.filter(region, stack_name)
         if stack_definitions.empty?
           StackMaster.stdout.puts "Could not find stack definition #{stack_name} in region #{region}"
-          show_other_region_candidates(stack_name)
+          show_other_region_candidates(config, stack_name)
           success = false
         end
         stack_definitions = stack_definitions.select do |stack_definition|
@@ -271,7 +271,7 @@ module StackMaster
       @kernel.exit false unless success
     end
 
-    def show_other_region_candidates(stack_name)
+    def show_other_region_candidates(config, stack_name)
       candidates = config.filter(stack_name=stack_name)
       return if candidates.empty?
 

--- a/lib/stack_master/cli.rb
+++ b/lib/stack_master/cli.rb
@@ -275,7 +275,7 @@ module StackMaster
       candidates = config.filter(stack_name=stack_name)
       return if candidates.empty?
 
-      StackMaster.stdout.puts "Stack name #{stack_name} exists in regions: #{candidates.map(:&region).join(', ')}"
+      StackMaster.stdout.puts "Stack name #{stack_name} exists in regions: #{candidates.map(&:region).join(', ')}"
     end
 
     def execute_if_allowed_account(allowed_accounts, &block)

--- a/lib/stack_master/cli.rb
+++ b/lib/stack_master/cli.rb
@@ -254,6 +254,7 @@ module StackMaster
         stack_definitions = config.filter(region, stack_name)
         if stack_definitions.empty?
           StackMaster.stdout.puts "Could not find stack definition #{stack_name} in region #{region}"
+          show_other_region_candidates(stack_name)
           success = false
         end
         stack_definitions = stack_definitions.select do |stack_definition|
@@ -268,6 +269,13 @@ module StackMaster
         end
       end
       @kernel.exit false unless success
+    end
+
+    def show_other_region_candidates(stack_name)
+      candidates = config.filter(stack_name=stack_name)
+      return if candidates.empty?
+
+      StackMaster.stdout.puts "Stack name #{stack_name} exists in regions: #{candidates.map(:&region).join(', ')}"
     end
 
     def execute_if_allowed_account(allowed_accounts, &block)


### PR DESCRIPTION
When trying to apply a stack in a region where it's not defined we could do
better than just print the error.
List regions where the stack by that name is defined.