### PR TITLE
Support cross-region SSM parameter resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,9 @@ you will likely want to set the parameter to NoEcho in your template.
 ```yaml
 db_password:
   parameter_store: ssm_parameter_name
+saas_api_key:
+  # Parameter in a different region in the same account
+  parameter_store: us-east-1:ssm_parameter_name
 ```
 
 ### 1Password Lookup

--- a/lib/stack_master/parameter_resolvers/parameter_store.rb
+++ b/lib/stack_master/parameter_resolvers/parameter_store.rb
@@ -7,19 +7,32 @@ module StackMaster
       def initialize(config, stack_definition)
         @config = config
         @stack_definition = stack_definition
+        @output_regex = %r{(?:(?<region>[^:]+):)?(?<key_name>.+)}
       end
 
       def resolve(value)
+        region, key_name = parse!(value)
         begin
-          ssm = Aws::SSM::Client.new(region: @stack_definition.region)
+          ssm = Aws::SSM::Client.new(region: region)
           resp = ssm.get_parameter(
-            name: value,
+            name: key_name,
             with_decryption: true
           )
         rescue Aws::SSM::Errors::ParameterNotFound
-          raise ParameterNotFound, "Unable to find #{value} in Parameter Store"
+          raise ParameterNotFound, "Unable to find #{key_name} in Parameter Store in #{region}"
         end
         resp.parameter.value
+      end
+
+      def parse!(value)
+        if !value.is_a?(String) || !(match = @output_regex.match(value))
+          raise ArgumentError, 'Parameter store names must be in the form of [region:]<parameter_name>'
+        end
+
+        [
+          match[:region] || @stack_definition.region,
+          match[:key_name]
+        ]
       end
     end
   end

--- a/spec/stack_master/parameter_resolvers/parameter_store_spec.rb
+++ b/spec/stack_master/parameter_resolvers/parameter_store_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe StackMaster::ParameterResolvers::ParameterStore do
           }
         }
       end
-  
+
       it 'should return the parameter value' do
         expect(resolver.resolve(parameter_name)).to eq parameter_value
       end
@@ -36,14 +36,14 @@ RSpec.describe StackMaster::ParameterResolvers::ParameterStore do
       before do
         Aws.config[:ssm] = {
           stub_responses: {
-            get_parameter: 
+            get_parameter:
               Aws::SSM::Errors::ParameterNotFound.new(unknown_parameter_name, "Parameter #{unknown_parameter_name} not found")
           }
         }
       end
       it 'should raise and error' do
         expect { resolver.resolve(unknown_parameter_name) }
-            .to raise_error(StackMaster::ParameterResolvers::ParameterStore::ParameterNotFound, "Unable to find #{unknown_parameter_name} in Parameter Store")
+            .to raise_error(StackMaster::ParameterResolvers::ParameterStore::ParameterNotFound, "Unable to find #{unknown_parameter_name} in Parameter Store in us-east-1")
       end
     end
   end


### PR DESCRIPTION
Had a case where I was about to copy a bunch of SSM keys to another region and then realised that there was a better way.

Struggled with trying to write tests for this: the existing tests, in their use of mocking the AWS api, will return the same response regardless of which region or SSM key is queried. So this is technically "covered" - but not explicitly tested.