### PR TITLE
Empty strings are valid

### DIFF
--- a/lib/stack_master/sparkle_formation/compile_time/empty_validator.rb
+++ b/lib/stack_master/sparkle_formation/compile_time/empty_validator.rb
@@ -19,7 +19,7 @@ module StackMaster
 
         def has_invalid_values?
           values = build_values(@definition, @parameter)
-          values.include?(nil) || values.include?('')
+          values.include?(nil)
         end
 
         def create_error

--- a/spec/stack_master/sparkle_formation/compile_time/empty_validator_spec.rb
+++ b/spec/stack_master/sparkle_formation/compile_time/empty_validator_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe StackMaster::SparkleFormation::CompileTime::EmptyValidator do
     context 'string validation with multiples' do
       let(:definition) { {type: :string, multiple: true} }
       validate_valid_parameter('a,b')
-      validate_invalid_parameter('a,,b', 'a,,b')
+      validate_valid_parameter('a,,b')
     end
 
     context 'string validation with multiples and defaults' do


### PR DESCRIPTION
I'm trying to write a dynamic that takes a compile time parameter and if it's set adds a statement to a policy.

But this code doesn't let me, apparently empty strings are not valid. I don't think that's true, empty strings are perfectly ok! Especially as we can't set nil values either.