### PR TITLE
Add support for YAML ERB compilation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ The format is based on [Keep a Changelog], and this project adheres to
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
+## [Unreleased]
+
+- Added YAML/ERB support, allowing a YAML CloudFormation template to be pre-processed
+  via ERB, with compile-time parameters. ([#350])
+
+[#350]: https://github.com/envato/stack_master/pull/350
+
 ## [2.11.0] - 2020-10-02
 
 ### Added

--- a/lib/stack_master.rb
+++ b/lib/stack_master.rb
@@ -52,6 +52,7 @@ module StackMaster
   require 'stack_master/template_compilers/sparkle_formation'
   require 'stack_master/template_compilers/json'
   require 'stack_master/template_compilers/yaml'
+  require 'stack_master/template_compilers/yaml_erb'
   require 'stack_master/template_compilers/cfndsl'
 
   module Commands

--- a/lib/stack_master/config.rb
+++ b/lib/stack_master/config.rb
@@ -92,6 +92,7 @@ module StackMaster
         json: :json,
         yml:  :yaml,
         yaml: :yaml,
+        erb:  :yaml_erb,
       }
     end
 

--- a/lib/stack_master/template_compilers/yaml_erb.rb
+++ b/lib/stack_master/template_compilers/yaml_erb.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module StackMaster::TemplateCompilers
+  class YamlErb
+    def self.require_dependencies
+      require 'erubis'
+      require 'yaml'
+    end
+
+    def self.compile(template_dir, template, compile_time_parameters, _compiler_options = {})
+      template_file_path = File.join(template_dir, template)
+      template = Erubis::Eruby.new(File.read(template_file_path))
+      template.filename = template_file_path
+
+      template.result(params: compile_time_parameters)
+    end
+
+    StackMaster::TemplateCompiler.register(:yaml_erb, self)
+  end
+end

--- a/spec/fixtures/templates/erb/compile_time_parameters_loop.yml.erb
+++ b/spec/fixtures/templates/erb/compile_time_parameters_loop.yml.erb
@@ -1,0 +1,20 @@
+---
+<% cidr_az_pairs = params['SubnetCidrs'].map { |pair| pair.split(":") }%>
+Description: "A test case for generating subnet resources in a loop"
+Parameters:
+  VpcCidr:
+    type: String
+
+Resources:
+  Vpc:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: !Ref VpcCidr
+  <% cidr_az_pairs.each_with_index do |pair, index| %>
+  SubnetPrivate<%= index %>:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref Vpc
+      CidrBlock: <%= pair[0] %>
+      AvailabilityZone: <%= pair[1] %>
+  <% end %>

--- a/spec/stack_master/config_spec.rb
+++ b/spec/stack_master/config_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe StackMaster::Config do
                                                      json: :json,
                                                      yml: :yaml,
                                                      yaml: :yaml,
-
+                                                     erb: :yaml_erb,
                                                    })
   end
 

--- a/spec/stack_master/template_compilers/yaml_erb_spec.rb
+++ b/spec/stack_master/template_compilers/yaml_erb_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+RSpec.describe StackMaster::TemplateCompilers::YamlErb do
+  before(:all) { described_class.require_dependencies }
+
+  describe '.compile' do
+    let(:compile_time_parameters) { { 'SubnetCidrs' => ['10.0.0.0/28:ap-southeast-2', '10.0.2.0/28:ap-southeast-1'] } }
+
+    def compile
+      described_class.compile(stack_definition.template_dir, stack_definition.template, compile_time_parameters)
+    end
+
+    context 'a YAML template using a loop over compile time parameters' do
+      let(:stack_definition) { StackMaster::StackDefinition.new(template_dir: 'spec/fixtures/templates/erb',
+                                                                template: 'compile_time_parameters_loop.yml.erb') }
+
+      it 'renders the expected output' do
+        expect(compile).to eq <<~EOEXPECTED
+          ---
+          Description: "A test case for generating subnet resources in a loop"
+          Parameters:
+            VpcCidr:
+              type: String
+
+          Resources:
+            Vpc:
+              Type: AWS::EC2::VPC
+              Properties:
+                CidrBlock: !Ref VpcCidr
+            SubnetPrivate0:
+              Type: AWS::EC2::Subnet
+              Properties:
+                VpcId: !Ref Vpc
+                CidrBlock: 10.0.0.0/28
+                AvailabilityZone: ap-southeast-2
+            SubnetPrivate1:
+              Type: AWS::EC2::Subnet
+              Properties:
+                VpcId: !Ref Vpc
+                CidrBlock: 10.0.2.0/28
+                AvailabilityZone: ap-southeast-1
+          EOEXPECTED
+      end
+    end
+  end
+end


### PR DESCRIPTION
Proposed as an alternative for the use-case in https://github.com/envato/stack_master/pull/345

With this change, any `.erb` templates are interpreted as ERB-preprocessed CloudFormation YAML templates, which can use compile time parameters. Handy for dynamically set resource names (which was the issue that inspired #345), and for defining resources in loops (without switching to SparkleFormation).