### PR TITLE
Fix Cucumber test suite

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -4,6 +4,7 @@ require 'stack_master/testing'
 require 'aruba/processes/in_process'
 require 'pry'
 require 'cucumber/rspec/doubles'
+require 'timecop'
 
 Aruba.configure do |config|
   config.command_launcher = :in_process
@@ -14,6 +15,11 @@ Before do
   StackMaster.cloud_formation_driver.reset
   StackMaster.s3_driver.reset
   StackMaster.reset_flags
+  Timecop.travel(Time.local(2020, 10, 19))
+end
+
+After do
+  Timecop.return
 end
 
 lib = File.join(File.dirname(__FILE__), "../../spec/fixtures/sparkle_pack_integration/my_sparkle_pack/lib")


### PR DESCRIPTION
### Context

In our Cucumber test suite, we've stubbed AWS Cloudformation to return events stamped with a date of `2020-10-29`.

https://github.com/envato/stack_master/blob/fe78bfa5cf15608b6836da19a8123350c6611aea/features/apply.feature#L71-L74

Now that this date is in the past, StackMaster is filtering these events out causing it to wait forever to receive an event.

### Change

To resolve this let's use the Timecop gem to travel back in time to before 2020-10-29. This will prevent StackMaster from filtering out our simulated AWS Cloudformation events and get the test suite passing again.