### PR TITLE
Configure Dependabot to check for dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+- package-ecosystem: bundler
+  directory: "/"
+  schedule:
+    interval: weekly
+    day: monday
+    time: "08:00"
+    timezone: Australia/Melbourne


### PR DESCRIPTION
With so many gems pinned in the gemspec, I think it's a good idea to have Dependabot check regularly for updates.

https://github.com/envato/stack_master/blob/10e97eac29e4b51590e26772e72e697857af307d/stack_master.gemspec#L38-L59