### PR TITLE
Trigger CI on pull request

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 ---
 name: tests
-on: push
+on: [ push, pull_request ]
 jobs:
   test:
     name: Test (Ruby ${{ matrix.ruby }}, ${{ matrix.os }})


### PR DESCRIPTION
I suspect this is required for PRs coming from forks, as `push` event may not trigger in this case.