### PR TITLE
Make the compile time parameter error clearer

### DIFF
--- a/lib/stack_master/sparkle_formation/compile_time/empty_validator.rb
+++ b/lib/stack_master/sparkle_formation/compile_time/empty_validator.rb
@@ -23,7 +23,7 @@ module StackMaster
         end
 
         def create_error
-          "#{@name} cannot contain empty parameters:#{@parameter.inspect}"
+          "#{@name} is not present inside the 'compile_time_parameters' entry, or has an empty value; found: #{@parameter.inspect}"
         end
 
       end

--- a/spec/stack_master/sparkle_formation/compile_time/empty_validator_spec.rb
+++ b/spec/stack_master/sparkle_formation/compile_time/empty_validator_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe StackMaster::SparkleFormation::CompileTime::EmptyValidator do
 
   describe '#validate' do
     let(:name) { 'name' }
-    let(:error_message) { -> (error, _definition) { "#{name} cannot contain empty parameters:#{error.inspect}" } }
+    let(:error_message) { -> (error, _definition) { "#{name} is not present inside the 'compile_time_parameters' entry, or has an empty value; found: #{error.inspect}" } }
 
     context 'string validation' do
       let(:definition) { {type: :string} }


### PR DESCRIPTION
Print out the expectation that the parameter should be under a specific key.