### PR TITLE
Update `Commander::Runner` instance variable name

### DIFF
--- a/lib/stack_master/cli.rb
+++ b/lib/stack_master/cli.rb
@@ -7,7 +7,7 @@ module StackMaster
 
     def initialize(argv, stdin=STDIN, stdout=STDOUT, stderr=STDERR, kernel=Kernel)
       @argv, @stdin, @stdout, @stderr, @kernel = argv, stdin, stdout, stderr, kernel
-      Commander::Runner.instance_variable_set('@singleton', Commander::Runner.new(argv))
+      Commander::Runner.instance_variable_set('@instance', Commander::Runner.new(argv))
       StackMaster.stdout = @stdout
       StackMaster.stderr = @stderr
       TablePrint::Config.io = StackMaster.stdout

--- a/stack_master.gemspec
+++ b/stack_master.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "timecop"
   spec.add_dependency "os"
   spec.add_dependency "ruby-progressbar"
-  spec.add_dependency "commander", ">= 4.5.2", "< 5"
+  spec.add_dependency "commander", ">= 4.6.0", "< 5"
   spec.add_dependency "aws-sdk-acm", "~> 1"
   spec.add_dependency "aws-sdk-cloudformation", "~> 1"
   spec.add_dependency "aws-sdk-ec2", "~> 1"


### PR DESCRIPTION
### Context

The `master` build is broken 😞 
https://github.com/envato/stack_master/actions/runs/797958955

Investigation finds StackMaster is incompatible with the recently released commander v4.6.0.

### Change

Update the `Commander::Runner` instance variable name from `@singleton` to `@instance`. This was renamed amongst Rubocop fixes in
https://github.com/commander-rb/commander/commit/203dae340d92f1d116a2c6cb55acf310fc077b3a#diff-4160b6ff33fa3b76bd5f6ee18080a9fb6f7178f90090ed8c24ec104d4f585845L44

### Considerations

It's unfortunate we need to rely on the private internals of this gem.