### PR TITLE
Improve allowed account handling

### DIFF
--- a/features/apply_with_allowed_accounts.feature
+++ b/features/apply_with_allowed_accounts.feature
@@ -5,14 +5,14 @@ Feature: Apply command with allowed accounts
       """
       stack_defaults:
         allowed_accounts:
-          - '11111111'
+          - '111111111111'
       stacks:
         us_east_1:
           myapp_vpc:
             template: myapp.rb
           myapp_db:
             template: myapp.rb
-            allowed_accounts: '22222222'
+            allowed_accounts: '222222222222'
           myapp_web:
             template: myapp.rb
             allowed_accounts: []
@@ -33,7 +33,7 @@ Feature: Apply command with allowed accounts
     Given I stub the following stack events:
       | stack_id | event_id | stack_name | logical_resource_id | resource_status | resource_type              | timestamp           |
       | 1        | 1        | myapp-vpc  | myapp-vpc           | CREATE_COMPLETE | AWS::CloudFormation::Stack | 2020-10-29 00:00:00 |
-    When I use the account "11111111"
+    When I use the account "111111111111"
     And I run `stack_master apply us-east-1 myapp-vpc`
     Then the output should match /2020-10-29 00:00:00 (\+|\-)[0-9]{4} myapp-vpc AWS::CloudFormation::Stack CREATE_COMPLETE/
     And the exit status should be 0
@@ -42,17 +42,17 @@ Feature: Apply command with allowed accounts
     Given I stub the following stack events:
       | stack_id | event_id | stack_name | logical_resource_id | resource_status | resource_type              | timestamp           |
       | 1        | 1        | myapp-db   | myapp-db            | CREATE_COMPLETE | AWS::CloudFormation::Stack | 2020-10-29 00:00:00 |
-    When I use the account "11111111"
+    When I use the account "111111111111"
     And I run `stack_master apply us-east-1 myapp-db`
     Then the output should contain all of these lines:
-      | Account '11111111' is not an allowed account. Allowed accounts are ["22222222"].|
+      | Account '111111111111' is not an allowed account. Allowed accounts are ["222222222222"].|
     And the exit status should be 1
 
   Scenario: Run apply with stack overriding allowed accounts to allow all accounts
     Given I stub the following stack events:
       | stack_id | event_id | stack_name | logical_resource_id | resource_status | resource_type              | timestamp           |
       | 1        | 1        | myapp-web  | myapp-web           | CREATE_COMPLETE | AWS::CloudFormation::Stack | 2020-10-29 00:00:00 |
-    When I use the account "33333333"
+    When I use the account "333333333333"
     And I run `stack_master apply us-east-1 myapp-web`
     Then the output should match /2020-10-29 00:00:00 (\+|\-)[0-9]{4} myapp-web AWS::CloudFormation::Stack CREATE_COMPLETE/
     And the exit status should be 0
@@ -61,7 +61,7 @@ Feature: Apply command with allowed accounts
     Given I stub the following stack events:
       | stack_id | event_id | stack_name  | logical_resource_id | resource_status | resource_type              | timestamp           |
       | 1        | 1        | myapp-cache | myapp-cache         | CREATE_COMPLETE | AWS::CloudFormation::Stack | 2020-10-29 00:00:00 |
-    When I use the account "44444444" with alias "my-account-alias"
+    When I use the account "444444444444" with alias "my-account-alias"
     And I run `stack_master apply us-east-1 myapp-cache`
     Then the output should match /2020-10-29 00:00:00 (\+|\-)[0-9]{4} myapp-cache AWS::CloudFormation::Stack CREATE_COMPLETE/
     And the exit status should be 0
@@ -70,8 +70,8 @@ Feature: Apply command with allowed accounts
     Given I stub the following stack events:
       | stack_id | event_id | stack_name  | logical_resource_id | resource_status | resource_type              | timestamp           |
       | 1        | 1        | myapp-cache | myapp-cache         | CREATE_COMPLETE | AWS::CloudFormation::Stack | 2020-10-29 00:00:00 |
-    When I use the account "11111111" with alias "an-account-alias"
+    When I use the account "111111111111" with alias "an-account-alias"
     And I run `stack_master apply us-east-1 myapp-cache`
     Then the output should contain all of these lines:
-      | Account '11111111' (an-account-alias) is not an allowed account. Allowed accounts are ["my-account-alias"].|
+      | Account '111111111111' (an-account-alias) is not an allowed account. Allowed accounts are ["my-account-alias"].|
     And the exit status should be 1

--- a/lib/stack_master/identity.rb
+++ b/lib/stack_master/identity.rb
@@ -1,5 +1,6 @@
 module StackMaster
   class Identity
+    AllowedAccountAliasesError = Class.new(StandardError)
     MissingIamPermissionsError = Class.new(StandardError)
 
     def running_in_account?(accounts)
@@ -7,6 +8,8 @@ module StackMaster
         accounts.empty? ||
         contains_account_id?(accounts) ||
         contains_account_alias?(accounts)
+    rescue MissingIamPermissionsError
+      raise AllowedAccountAliasesError, "Unable to validate whether the current AWS account is allowed"
     end
 
     def account

--- a/spec/stack_master/identity_spec.rb
+++ b/spec/stack_master/identity_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe StackMaster::Identity do
   end
 
   describe '#running_in_account?' do
-    let(:account) { '1234567890' }
+    let(:account) { '123456789012' }
     let(:running_in_allowed_account) { identity.running_in_account?(allowed_accounts) }
 
     before do
@@ -42,10 +42,25 @@ RSpec.describe StackMaster::Identity do
     end
 
     context 'with no allowed account' do
-      let(:allowed_accounts) { ['9876543210'] }
+      let(:allowed_accounts) { ['210987654321'] }
 
       it 'returns false' do
         expect(running_in_allowed_account).to eq(false)
+      end
+
+      context "without list account aliases permissions" do
+        before do
+          allow(iam).to receive(:list_account_aliases).and_raise(
+            Aws::IAM::Errors.error_class('AccessDenied').new(
+              an_instance_of(Seahorse::Client::RequestContext),
+              'User: arn:aws:sts::123456789:assumed-role/my-role/123456789012 is not authorized to perform: iam:ListAccountAliases on resource: *'
+            )
+          )
+        end
+
+        it 'returns false' do
+          expect(running_in_allowed_account).to eq(false)
+        end
       end
     end
 
@@ -76,10 +91,27 @@ RSpec.describe StackMaster::Identity do
       end
 
       context 'with a combination of account id and alias' do
-        let(:allowed_accounts) { %w(1928374 allowed-account another-account) }
+        let(:allowed_accounts) { %w(192837471659 allowed-account another-account) }
 
         it 'returns true' do
           expect(running_in_allowed_account).to eq(true)
+        end
+      end
+
+      context "without list account aliases permissions" do
+        let(:allowed_accounts) { ['an-account-alias'] }
+
+        before do
+          allow(iam).to receive(:list_account_aliases).and_raise(
+            Aws::IAM::Errors.error_class('AccessDenied').new(
+              an_instance_of(Seahorse::Client::RequestContext),
+              'User: arn:aws:sts::123456789:assumed-role/my-role/123456789012 is not authorized to perform: iam:ListAccountAliases on resource: *'
+            )
+          )
+        end
+
+        it 'raises the correct error' do
+          expect { running_in_allowed_account }.to raise_error(StackMaster::Identity::AllowedAccountAliasesError)
         end
       end
     end


### PR DESCRIPTION
Per #362, there's some opportunity for improvement around allowed account logic. This PR introduces two changes:

1. Return a more contextual error message when  `Identity#account_aliases` raises an IAM permissions error in `Identity#running_in_account?` — previously, users had to examine the stack trace to work out which part of the application logic triggered the error.

    Note that the previous error message (identifying the missing IAM permission) is no longer shown, but can be seen with `--trace`, as the `MissingIamPermissionsError` is recorded as the `Error#cause` of the `AllowedAccountAliasesError`.
2. Avoid checking the current account's aliases against the `allowed_accounts` list if all values are 12-digit numbers (i.e. AWS account IDs) — considering the way AWS account aliases are used, it should not be possible to use a 12-digit number as an account alias

Some tests had to be updated when making this change, as they used AWS account IDs of an incorrect length.