### PR TITLE
Exit with status code 1 if any command fails

### DIFF
--- a/lib/stack_master/cli.rb
+++ b/lib/stack_master/cli.rb
@@ -274,9 +274,9 @@ module StackMaster
         stack_definitions.each do |stack_definition|
           StackMaster.cloud_formation_driver.set_region(stack_definition.region)
           StackMaster.stdout.puts "Executing #{command.command_name} on #{stack_definition.stack_name} in #{stack_definition.region}"
-          success = success && execute_if_allowed_account(stack_definition.allowed_accounts) do
+          success = execute_if_allowed_account(stack_definition.allowed_accounts) do
             command.perform(config, stack_definition, options).success?
-          end
+          end && success
         end
       end
       @kernel.exit false unless success

--- a/lib/stack_master/cli.rb
+++ b/lib/stack_master/cli.rb
@@ -274,10 +274,9 @@ module StackMaster
         stack_definitions.each do |stack_definition|
           StackMaster.cloud_formation_driver.set_region(stack_definition.region)
           StackMaster.stdout.puts "Executing #{command.command_name} on #{stack_definition.stack_name} in #{stack_definition.region}"
-          success = execute_if_allowed_account(stack_definition.allowed_accounts) do
+          success = success && execute_if_allowed_account(stack_definition.allowed_accounts) do
             command.perform(config, stack_definition, options).success?
           end
-          break if !success
         end
       end
       @kernel.exit false unless success

--- a/lib/stack_master/cli.rb
+++ b/lib/stack_master/cli.rb
@@ -277,6 +277,7 @@ module StackMaster
           success = execute_if_allowed_account(stack_definition.allowed_accounts) do
             command.perform(config, stack_definition, options).success?
           end
+          break if !success
         end
       end
       @kernel.exit false unless success


### PR DESCRIPTION
Today, when a command is executed across multiple stacks the status of each stack isn't checked. This means if one returns an error, the command continues processing across the other stacks.

This PR updates `execute_stacks_command ` exit at the first error. 

This allows CI processes to run `validate` (or other commands) across a range of stacks and be confident that an errors result in a failed build.