### PR TITLE
Fixes for Ruby 3.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-20.04 ]
-        ruby: [ '2.4', '2.5', '2.6', '2.7', '3.0', '3.1' ]
+        ruby: [ '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2' ]
         include:
           - os: macos-latest
             ruby: '2.7'

--- a/lib/stack_master/commands/init.rb
+++ b/lib/stack_master/commands/init.rb
@@ -29,7 +29,7 @@ module StackMaster
 
         if !@options.overwrite
           [@stack_master_filename, @stack_json_filename, @parameters_filename, @region_parameters_filename].each do |filename|
-            if File.exists?(filename)
+            if File.exist?(filename)
               StackMaster.stderr.puts("Aborting: #{filename} already exists. Use --overwrite to force overwriting file.")
               return false
             end

--- a/lib/stack_master/config.rb
+++ b/lib/stack_master/config.rb
@@ -28,7 +28,7 @@ module StackMaster
 
       dir = Dir.pwd
       parent_dir = File.expand_path("..", Dir.pwd)
-      while parent_dir != dir && !File.exists?(File.join(dir, config_file))
+      while parent_dir != dir && !File.exist?(File.join(dir, config_file))
         dir = parent_dir
         parent_dir = File.expand_path("..", dir)
       end

--- a/lib/stack_master/parameter_loader.rb
+++ b/lib/stack_master/parameter_loader.rb
@@ -21,7 +21,7 @@ module StackMaster
     private
 
     def self.load_parameters(file_name)
-      file_exists = File.exists?(file_name)
+      file_exists = File.exist?(file_name)
       StackMaster.debug file_exists ? "  #{file_name} found" : "  #{file_name} not found"
       file_exists ? load_file(file_name) : {}
     end

--- a/spec/stack_master/aws_driver/s3_spec.rb
+++ b/spec/stack_master/aws_driver/s3_spec.rb
@@ -9,10 +9,6 @@ RSpec.describe StackMaster::AwsDriver::S3 do
   end
 
   describe '#upload_files' do
-    before do
-      allow(File).to receive(:read).and_return('file content')
-    end
-
     context 'when set_region is called' do
       it 'defaults to that region' do
         s3_driver.set_region('default')

--- a/spec/stack_master/parameter_loader_spec.rb
+++ b/spec/stack_master/parameter_loader_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe StackMaster::ParameterLoader do
   end
 
   def file_mock(file_name, exists: false, read: nil)
-    allow(File).to receive(:exists?).with(file_name).and_return(exists)
+    allow(File).to receive(:exist?).with(file_name).and_return(exists)
     allow(File).to receive(:read).with(file_name).and_return(read) if read
   end
 

--- a/spec/stack_master/parameter_resolvers/one_password_spec.rb
+++ b/spec/stack_master/parameter_resolvers/one_password_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe StackMaster::ParameterResolvers::OnePassword do
       it 'we return an error' do
         allow_any_instance_of(described_class).to receive(:`).with("op --version").and_return(true)
         allow_any_instance_of(described_class).to receive(:`).with("op get item --vault='Shared' 'password title' 2>&1").and_return('{key: value }')
-        expect { resolver.resolve(the_password) }.to raise_error(StackMaster::ParameterResolvers::OnePassword::OnePasswordInvalidResponse, /Failed to parse JSON returned, {key: value }: \d+: unexpected token at '{key: value }'/)
+        expect { resolver.resolve(the_password) }.to raise_error(StackMaster::ParameterResolvers::OnePassword::OnePasswordInvalidResponse, /Failed to parse JSON returned, {key: value }:.* unexpected token at '{key: value }'/)
       end
     end
   end

--- a/spec/stack_master/parameter_resolvers/stack_output_spec.rb
+++ b/spec/stack_master/parameter_resolvers/stack_output_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe StackMaster::ParameterResolvers::StackOutput do
     let(:outputs) { [] }
 
     before do
+      allow(StackMaster.cloud_formation_driver).to receive(:region).and_return(region)
       allow(Aws::CloudFormation::Client).to receive(:new).and_return(cf)
       cf.stub_responses(:describe_stacks, { stacks: stacks })
     end


### PR DESCRIPTION
### Context

Ruby 3.2 has [been released](https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/)! Let's get Stack Master working on this.

### Change

- Resolve Ruby deprecation: replace `File.exists?` with `File.exist?`. This is the only change to files included in the gem.
- Add Ruby 3.2 to the RSpec CI matrix and get the test suite working with this version of Ruby.