### PR TITLE
Use sorted_set gem instead of relying on it existing in ruby's `set` library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,16 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ## [Unreleased]
 
-[Unreleased]: https://github.com/envato/stack_master/compare/v2.13.3...HEAD
+[Unreleased]: https://github.com/envato/stack_master/compare/v2.13.4...HEAD
+
+## [2.13.4] - 2023-07-31
+
+### Fixed
+
+- Resolve error caused by `SortedSet` class being removed from the `set` library ([#374]).
+
+[2.13.3]: https://github.com/envato/stack_master/compare/v2.13.3...v2.13.4
+[#374]: https://github.com/envato/stack_master/pull/374
 
 ## [2.13.3] - 2023-02-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ### Fixed
 
-- Resolve error caused by `SortedSet` class being removed from the `set` library ([#374]).
+- Resolve SparkleFormation template error caused by `SortedSet` class being removed from the `set` library in Ruby 3 ([#374]).
 
 [2.13.3]: https://github.com/envato/stack_master/compare/v2.13.3...v2.13.4
 [#374]: https://github.com/envato/stack_master/pull/374

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 [Unreleased]: https://github.com/envato/stack_master/compare/v2.13.4...HEAD
 
-## [2.13.4] - 2023-07-31
+## [2.13.4] - 2023-08-02
 
 ### Fixed
 

--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,3 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in stack_master.gemspec
 gemspec
-
-if RUBY_VERSION >= '3.0.0'
-  # SparkleFormation has an issue with Ruby 3 and the SortedSet class.
-  # Remove after merged: https://github.com/sparkleformation/sparkle_formation/pull/271
-  gem 'faux_sorted_set', require: false
-end

--- a/lib/stack_master/version.rb
+++ b/lib/stack_master/version.rb
@@ -1,3 +1,3 @@
 module StackMaster
-  VERSION = "2.13.3"
+  VERSION = "2.13.4"
 end

--- a/stack_master.gemspec
+++ b/stack_master.gemspec
@@ -44,6 +44,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "aws-sdk-ssm", "~> 1"
   spec.add_dependency "aws-sdk-ecr", "~> 1"
   spec.add_dependency "aws-sdk-iam", "~> 1"
+  spec.add_dependency "sorted_set" # remove once new version of sparkle_formation released (> v3.0.40). See https://github.com/sparkleformation/sparkle_formation/pull/271.
   spec.add_dependency "diffy"
   spec.add_dependency "erubis"
   spec.add_dependency "rainbow"


### PR DESCRIPTION
Resolves the following error:

```
StackMaster::TemplateCompiler::TemplateCompilationFailed Failed to compile a_stack_template.rb
 Caused by: RuntimeError The `SortedSet` class has been extracted from the `set` library. You must use the `sorted_set` gem or other alternatives.
```

In ruby 3.1, the SortedSet class was removed from the `set` library.

The sparkle_formation gem has resolved this issue, but has yet to release a new version of the gem.

This commit works around the issue by ensuring the SortedSet class in the `sorted_set` gem is used by the sparkle_formation gem.