### PR TITLE
CI: test on Ruby 3.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,12 +8,12 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-20.04 ]
-        ruby: [ '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2' ]
+        ruby: [ '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3' ]
         include:
           - os: macos-latest
             ruby: '2.7'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Ruby ${{ matrix.ruby }}
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,13 +4,13 @@ on: [ push, pull_request ]
 jobs:
   test:
     name: Test (Ruby ${{ matrix.ruby }}, ${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}-latest
     strategy:
       matrix:
-        os: [ ubuntu-20.04 ]
+        os: [ ubuntu ]
         ruby: [ '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3' ]
         include:
-          - os: macos-latest
+          - os: macos
             ruby: '2.7'
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,12 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Test on Ruby 3.3 in the CI build ([#376]).
+
 [Unreleased]: https://github.com/envato/stack_master/compare/v2.13.4...HEAD
+[#376]: https://github.com/envato/stack_master/pull/376
 
 ## [2.13.4] - 2023-08-02
 


### PR DESCRIPTION
Ensure this project is compatible with the latest Ruby release: [3.3](https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/)!