### PR TITLE
Report a more explicit error on indentation issues

### DIFF
--- a/lib/stack_master/config.rb
+++ b/lib/stack_master/config.rb
@@ -112,6 +112,8 @@ module StackMaster
       stacks.each do |region, stacks_for_region|
         region = Utils.underscore_to_hyphen(region)
         stacks_for_region.each do |stack_name, attributes|
+          raise ConfigParseError.new("Entry for stack #{stack_name} has no attributes") if attributes.nil?
+
           stack_name = Utils.underscore_to_hyphen(stack_name)
           stack_attributes = build_stack_defaults(region).deeper_merge!(attributes).merge(
             'region' => region,

--- a/spec/fixtures/stack_master_wrong_indent.yml
+++ b/spec/fixtures/stack_master_wrong_indent.yml
@@ -1,0 +1,4 @@
+stacks:
+  us-east-1:
+    myapp_vpc:
+    template: myapp_vpc.json

--- a/spec/stack_master/config_spec.rb
+++ b/spec/stack_master/config_spec.rb
@@ -35,6 +35,16 @@ RSpec.describe StackMaster::Config do
       end
     end
 
+    it "gives explicit error on badly indented entries" do
+      begin
+        orig_dir = Dir.pwd
+        Dir.chdir './spec/fixtures/'
+        expect { StackMaster::Config.load!('stack_master_wrong_indent.yml') }.to raise_error StackMaster::Config::ConfigParseError
+      ensure
+        Dir.chdir orig_dir
+      end
+    end
+
     it "searches up the tree for stack master yaml" do
       begin
         orig_dir = Dir.pwd

--- a/spec/stack_master/config_spec.rb
+++ b/spec/stack_master/config_spec.rb
@@ -36,12 +36,9 @@ RSpec.describe StackMaster::Config do
     end
 
     it "gives explicit error on badly indented entries" do
-      begin
-        orig_dir = Dir.pwd
-        Dir.chdir './spec/fixtures/'
-        expect { StackMaster::Config.load!('stack_master_wrong_indent.yml') }.to raise_error StackMaster::Config::ConfigParseError
-      ensure
-        Dir.chdir orig_dir
+      Dir.chdir('./spec/fixtures/') do
+        expect { StackMaster::Config.load!('stack_master_wrong_indent.yml') }
+          .to raise_error StackMaster::Config::ConfigParseError
       end
     end
 


### PR DESCRIPTION
When a template parameter is accidentially unindented, the stack attributes become empty. This resulted in:

```
lib/stack_master/config.rb:123:in `block (2 levels) in load_stacks':
undefined method `[]' for nil:NilClass (NoMethodError)

          stack_attributes['allowed_accounts'] = attributes['allowed_accounts'] if attributes['allowed_accounts']
```

Now it will report a ConfigParseError with a more specific message.