### PR TITLE
Excplicit error on empty stack defaults

### DIFF
--- a/lib/stack_master/config.rb
+++ b/lib/stack_master/config.rb
@@ -50,6 +50,8 @@ module StackMaster
       end
       @region_defaults = normalise_region_defaults(config.fetch('region_defaults', {}))
       @stacks = []
+
+      raise ConfigParseError.new("Stack defaults can't be undefined") if @stack_defaults.nil?
       load_template_compilers(config)
       load_config
     end

--- a/spec/fixtures/stack_master_empty_default.yml
+++ b/spec/fixtures/stack_master_empty_default.yml
@@ -1,0 +1,5 @@
+stack_defaults:
+stacks:
+  us-east-1:
+    myapp_vpc:
+      template: myapp_vpc.json

--- a/spec/stack_master/config_spec.rb
+++ b/spec/stack_master/config_spec.rb
@@ -42,6 +42,13 @@ RSpec.describe StackMaster::Config do
       end
     end
 
+    it "gives explicit error on empty defaults" do
+      Dir.chdir('./spec/fixtures/') do
+        expect { StackMaster::Config.load!('stack_master_empty_default.yml') }
+          .to raise_error StackMaster::Config::ConfigParseError
+      end
+    end
+
     it "searches up the tree for stack master yaml" do
       begin
         orig_dir = Dir.pwd


### PR DESCRIPTION
Prevent an exception when then stack_defaults are empty.