### PR TITLE
Show a short backtrace on error

### DIFF
--- a/lib/stack_master/command.rb
+++ b/lib/stack_master/command.rb
@@ -42,6 +42,7 @@ module StackMaster
     def error_message(e)
       msg = "#{e.class} #{e.message}"
       msg << "\n Caused by: #{e.cause.class} #{e.cause.message}" if e.cause
+      msg << "\n at #{e.cause.backtrace[0..3].join("\n    ")}\n ..." if e.cause && !options.trace
       if options.trace
         msg << "\n#{backtrace(e)}"
       else


### PR DESCRIPTION
Currently the errors are not very clear. For example:
```
StackMaster::TemplateCompiler::TemplateCompilationFailed Failed to
compile elasticsearch_snapshot_bucket.rb
 Caused by: ArgumentError wrong number of arguments (given 2, expected
1)
```
which doesn't provide the location for the issue in the template.

Instead of the all-or-nothing, if `--trace` is not provided, show the first 4 lines of the original exception:

```
 Caused by: ArgumentError wrong number of arguments (given 2, expected
1)
 at
/Users/viraptor/.asdf/installs/ruby/3.3.1/lib/ruby/gems/3.3.0/gems/sparkle_formation-3.0.40/lib/sparkle_formation/sparkle_attribute/aws.rb:93:in
`_cf_ref'
    ../templates/elasticsearch_snapshot_bucket.rb:62:in `block (3
levels) in compile'
    /Users/viraptor/.asdf/installs/ruby/3.3.1/lib/ruby/gems/3.3.0/gems/attribute_struct-0.4.4/lib/attribute_struct/attribute_struct.rb:245:in
`instance_exec'
    /Users/viraptor/.asdf/installs/ruby/3.3.1/lib/ruby/gems/3.3.0/gems/attribute_struct-0.4.4/lib/attribute_struct/attribute_struct.rb:245:in
`method_missing'
 ...
 Use --trace to view backtrace
```