### PR TITLE
Support non-camel-case stack outputs

### DIFF
--- a/lib/stack_master/parameter_resolvers/stack_output.rb
+++ b/lib/stack_master/parameter_resolvers/stack_output.rb
@@ -18,7 +18,7 @@ module StackMaster
         region, stack_name, output_name = parse!(value)
         stack = find_stack(stack_name, region)
         if stack
-          output = stack.outputs.find { |stack_output| stack_output.output_key == output_name.camelize }
+          output = stack.outputs.find { |stack_output| stack_output.output_key == output_name.camelize || stack_output.output_key == output_name }
           if output
             output.output_value
           else

--- a/spec/stack_master/parameter_resolvers/stack_output_spec.rb
+++ b/spec/stack_master/parameter_resolvers/stack_output_spec.rb
@@ -67,6 +67,15 @@ RSpec.describe StackMaster::ParameterResolvers::StackOutput do
         resolver.resolve("ap-southeast-2:#{value}")
       end
 
+      context 'when the output key has a non-camel name' do
+        let(:value) { 'my-stack/my_Output' }
+        let(:outputs) { [{output_key: 'my_Output', output_value: 'myresolvedvalue'}] }
+
+        it 'resolves the value' do
+          expect(resolved_value).to eq 'myresolvedvalue'
+        end
+      end
+
       context "when different credentials are used" do
         let(:outputs_in_account_2) { [ {output_key: 'MyOutput', output_value: 'resolvedvalueinaccount2'} ] }
         let(:stacks_in_account_2) { [{ stack_name: 'other-stack', creation_time: Time.now, stack_status: 'CREATE_COMPLETE', outputs: outputs_in_account_2}] }


### PR DESCRIPTION
This adds support for non-camel-case stack output keys.  In my specific case I had to handle a key like `fooBarBaz` set by another application.